### PR TITLE
Add support for Internal OpenAI-compatible API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,15 @@ WEBLLM_DEFAULT_F32_MODEL_ID="Qwen2.5-0.5B-Instruct-q4f32_1-MLC"
 
 # The default model ID for Wllama.
 WLLAMA_DEFAULT_MODEL_ID="qwen-2.5-0.5b"
+
+# The base URL for the internal OpenAI compatible API. Example: `INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL="https://api.openai.com/v1"`. Leave blank to disable internal OpenAI compatible API.
+INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL=""
+
+# The access key for the internal OpenAI compatible API.
+INTERNAL_OPENAI_COMPATIBLE_API_KEY=""
+
+# The model for the internal OpenAI compatible API.
+INTERNAL_OPENAI_COMPATIBLE_API_MODEL=""
+
+# The name of the internal OpenAI compatible API, displayed in the UI.
+INTERNAL_OPENAI_COMPATIBLE_API_NAME="Internal API"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ Then, open http://localhost:7860 in your browser and start searching!
     <li>Manual installation of SearXNG is not trivial, so we use the docker image they provide, which has everything set up.</li>
     <li>SearXNG only provides a Docker Image based on Alpine Linux.</li>
     <li>The user of the image needs to be customized in a specific way to run on HuggingFace Spaces, where MiniSearch's demo runs.</li>
-    <li>HuggingFace only accepts a single docker image. It doesn’t run docker compose or multiple images, unfortunately.</li>
+    <li>HuggingFace only accepts a single docker image. It doesn't run docker compose or multiple images, unfortunately.</li>
   </ul>
+</details>
+
+<details>
+  <summary>What is the Internal OpenAI-compatible API option, and how do I use it?</summary>
+  <p>MiniSearch supports an Internal OpenAI-compatible API option for text generation. This feature allows you to leverage the API while maintaining the privacy and control benefits when serving MiniSearch for others. To use this feature:</p>
+  <ol>
+    <li>Set up your OpenAI-compatible API endpoint.</li>
+    <li>Configure the following environment variables in your <code>.env</code> file:
+      <ul>
+        <li><code>INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL</code>: The base URL for your API</li>
+        <li><code>INTERNAL_OPENAI_COMPATIBLE_API_KEY</code>: Your API access key</li>
+        <li><code>INTERNAL_OPENAI_COMPATIBLE_API_MODEL</code>: The model to use</li>
+        <li><code>INTERNAL_OPENAI_COMPATIBLE_API_NAME</code>: The name to display in the UI</li>
+      </ul>
+    </li>
+    <li>Restart MiniSearch.</li>
+    <li>In the MiniSearch menu, select the new option (named as per your <code>INTERNAL_OPENAI_COMPATIBLE_API_NAME</code> setting) from the inference type dropdown.</li>
+  </ol>
 </details>

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -24,7 +24,7 @@ export const defaultSettings = {
 
 Search results:
 {{searchResults}}`,
-  inferenceType: "browser",
+  inferenceType: VITE_INTERNAL_API_ENABLED ? "internal" : "browser",
   openAiApiBaseUrl: "",
   openAiApiKey: "",
   openAiApiModel: "",
@@ -38,6 +38,9 @@ addLogEntry(
 export type Settings = typeof defaultSettings;
 
 export const inferenceTypes = [
+  ...(VITE_INTERNAL_API_ENABLED
+    ? [{ value: "internal", label: VITE_INTERNAL_API_NAME }]
+    : []),
   { value: "browser", label: "Browser-Based" },
   { value: "openai", label: "OpenAI-Compatible API" },
 ];

--- a/client/types.d.ts
+++ b/client/types.d.ts
@@ -7,3 +7,5 @@ declare const VITE_ACCESS_KEYS_ENABLED: boolean;
 declare const VITE_WEBLLM_DEFAULT_F16_MODEL_ID: string;
 declare const VITE_WEBLLM_DEFAULT_F32_MODEL_ID: string;
 declare const VITE_WLLAMA_DEFAULT_MODEL_ID: string;
+declare const VITE_INTERNAL_API_ENABLED: boolean;
+declare const VITE_INTERNAL_API_NAME: string;

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -1,0 +1,144 @@
+import { Connect, PreviewServer, ViteDevServer } from "vite";
+import OpenAI from "openai";
+import { Stream } from "openai/streaming.mjs";
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import { argon2Verify } from "hash-wasm";
+import { getSearchToken } from "./searchToken";
+import { isVerifiedToken, addVerifiedToken } from "./verifiedTokens";
+
+const rateLimiter = new RateLimiterMemory({
+  points: 2,
+  duration: 10,
+});
+
+export function internalApiEndpointServerHook<
+  T extends ViteDevServer | PreviewServer,
+>(server: T) {
+  server.middlewares.use(async (request, response, next) => {
+    if (!request.url.startsWith("/inference")) return next();
+
+    const authHeader = request.headers.authorization;
+    const tokenPrefix = "Bearer ";
+    const token =
+      authHeader && authHeader.startsWith(tokenPrefix)
+        ? authHeader.slice(tokenPrefix.length)
+        : null;
+
+    if (!token) {
+      response.statusCode = 401;
+      response.end("Missing or invalid Authorization header.");
+      return;
+    }
+
+    if (!isVerifiedToken(token)) {
+      let isValidToken = false;
+
+      try {
+        isValidToken = await argon2Verify({
+          password: getSearchToken(),
+          hash: token,
+        });
+      } catch (error) {
+        void error;
+      }
+
+      if (isValidToken) {
+        addVerifiedToken(token);
+      } else {
+        response.statusCode = 401;
+        response.end("Unauthorized.");
+        return;
+      }
+    }
+
+    try {
+      await rateLimiter.consume(token);
+    } catch {
+      response.statusCode = 429;
+      response.end("Too many requests.");
+      return;
+    }
+
+    const openai = new OpenAI({
+      baseURL: process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL,
+      apiKey: process.env.INTERNAL_OPENAI_COMPATIBLE_API_KEY,
+    });
+
+    try {
+      const requestBody = await getRequestBody(request);
+      const completion = await openai.chat.completions.create({
+        ...requestBody,
+        model: process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL,
+        stream: true,
+      });
+      response.setHeader("Content-Type", "text/event-stream");
+      response.setHeader("Cache-Control", "no-cache");
+      response.setHeader("Connection", "keep-alive");
+      const stream = OpenAIStream(completion);
+      stream.pipeTo(
+        new WritableStream({
+          write(chunk) {
+            response.write(chunk);
+          },
+          close() {
+            response.end();
+          },
+        }),
+      );
+    } catch (error) {
+      console.error("Error in internal API endpoint:", error);
+      response.statusCode = 500;
+      response.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  });
+}
+
+async function getRequestBody(
+  request: Connect.IncomingMessage,
+): Promise<OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+function OpenAIStream(
+  completion: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>,
+) {
+  return new ReadableStream({
+    async start(controller) {
+      for await (const chunk of completion) {
+        const content = chunk.choices[0]?.delta?.content || "";
+        if (content) {
+          const payload = {
+            id: chunk.id,
+            object: "chat.completion.chunk",
+            created: chunk.created,
+            model: chunk.model,
+            choices: [
+              {
+                index: 0,
+                delta: { content },
+                finish_reason: chunk.choices[0].finish_reason,
+              },
+            ],
+          };
+          controller.enqueue(
+            new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`),
+          );
+        }
+      }
+      controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ import { getSearchToken, regenerateSearchToken } from "./server/searchToken";
 import { visualizer } from "rollup-plugin-visualizer";
 import getGitCommitHash from "helper-git-hash";
 import { validateAccessKeyServerHook } from "./server/validateAccessKeyServerHook";
+import { internalApiEndpointServerHook } from "./server/internalApiEndpointServerHook";
 import dotenv from "dotenv";
 
 dotenv.config({ path: [".env", ".env.example"] });
@@ -34,6 +35,12 @@ export default defineConfig(({ command }) => {
       ),
       VITE_WLLAMA_DEFAULT_MODEL_ID: JSON.stringify(
         process.env.WLLAMA_DEFAULT_MODEL_ID,
+      ),
+      VITE_INTERNAL_API_ENABLED: JSON.stringify(
+        Boolean(process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL),
+      ),
+      VITE_INTERNAL_API_NAME: JSON.stringify(
+        process.env.INTERNAL_OPENAI_COMPATIBLE_API_NAME,
       ),
     },
     server: {
@@ -82,6 +89,11 @@ export default defineConfig(({ command }) => {
         name: "configure-server-validate-access-key",
         configureServer: validateAccessKeyServerHook,
         configurePreviewServer: validateAccessKeyServerHook,
+      },
+      {
+        name: "configure-server-internal-api-endpoint",
+        configureServer: internalApiEndpointServerHook,
+        configurePreviewServer: internalApiEndpointServerHook,
       },
       visualizer({
         filename: "vite-build-stats.html",


### PR DESCRIPTION
This pull request addresses Issue #582 by implementing support for an internal OpenAI-compatible API. This feature allows MiniSearch administrators to configure their own API endpoint, which users can then utilize through the MiniSearch interface.

- Resolves #582

## Changes

1. Added new environment variables in `.env.example`:
   - `INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL`
   - `INTERNAL_OPENAI_COMPATIBLE_API_KEY`
   - `INTERNAL_OPENAI_COMPATIBLE_API_MODEL`
   - `INTERNAL_OPENAI_COMPATIBLE_API_NAME`

2. Updated `README.md` with a new FAQ entry explaining the Internal OpenAI-compatible API option and how to use it.

3. Modified `client/modules/settings.ts` to include the new internal API option in the inference types list.

4. Implemented `generateTextWithInternalApi()` function in `client/modules/textGeneration.ts` to handle text generation using the internal API.

5. Updated `vite.config.ts` to expose necessary environment variables to the client-side code.

6. Added new type declarations in `client/types.d.ts` for the internal API-related variables.

## How it works

- Administrators can configure their OpenAI-compatible API (including services like OpenRouter.ai) by setting the appropriate environment variables.
- When enabled, a new option appears in the MiniSearch UI for users to select the internal API for text generation.
- The internal API is used with the same interface as the OpenAI API, ensuring compatibility and ease of integration.

## Testing

To test this feature:

1. Set up the environment variables in your `.env` file.
2. Restart MiniSearch.
3. In the UI, select the new internal API option from the inference type dropdown.
4. Perform a search to verify that text generation works correctly with the configured API.

This implementation provides flexibility for MiniSearch administrators to use their preferred API while maintaining the privacy and control benefits of self-hosting.