### PR TITLE
Allow asking follow-up questions

### DIFF
--- a/client/components/AiResponse/AiResponseContent.tsx
+++ b/client/components/AiResponse/AiResponseContent.tsx
@@ -9,7 +9,6 @@ import {
   ScrollArea,
   Text,
   Tooltip,
-  TypographyStylesProvider,
 } from "@mantine/core";
 import {
   IconArrowsMaximize,
@@ -19,11 +18,10 @@ import {
   IconInfoCircle,
 } from "@tabler/icons-react";
 import { PublishFunction } from "create-pubsub";
-import { ReactNode, useMemo, useState } from "react";
-import Markdown from "react-markdown";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import syntaxHighlighterStyle from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
+import { lazy, ReactNode, Suspense, useMemo, useState } from "react";
 import { match } from "ts-pattern";
+
+const FormattedMarkdown = lazy(() => import("./FormattedMarkdown"));
 
 export default function AiResponseContent({
   textGenerationState,
@@ -124,32 +122,9 @@ export default function AiResponseContent({
       </Card.Section>
       <Card.Section withBorder>
         <ConditionalScrollArea>
-          <TypographyStylesProvider p="md">
-            <Markdown
-              components={{
-                code(props) {
-                  const { children, className, node, ref, ...rest } = props;
-                  void node;
-                  const languageMatch = /language-(\w+)/.exec(className || "");
-                  return languageMatch ? (
-                    <SyntaxHighlighter
-                      {...rest}
-                      ref={ref as never}
-                      children={children?.toString().replace(/\n$/, "") ?? ""}
-                      language={languageMatch[1]}
-                      style={syntaxHighlighterStyle}
-                    />
-                  ) : (
-                    <code {...rest} className={className}>
-                      {children}
-                    </code>
-                  );
-                },
-              }}
-            >
-              {response}
-            </Markdown>
-          </TypographyStylesProvider>
+          <Suspense>
+            <FormattedMarkdown>{response}</FormattedMarkdown>
+          </Suspense>
         </ConditionalScrollArea>
         {match(textGenerationState)
           .with("failed", () => (

--- a/client/components/AiResponse/AiResponseSection.tsx
+++ b/client/components/AiResponse/AiResponseSection.tsx
@@ -5,14 +5,17 @@ import {
   modelLoadingProgressPubSub,
   responsePubSub,
   settingsPubSub,
+  queryPubSub,
   textGenerationStatePubSub,
 } from "../../modules/pubSub";
+import ChatInterface from "./ChatInterface";
 
 const AiResponseContent = lazy(() => import("./AiResponseContent"));
 const PreparingContent = lazy(() => import("./PreparingContent"));
 const LoadingModelContent = lazy(() => import("./LoadingModelContent"));
 
 export default function AiResponseSection() {
+  const [query] = usePubSub(queryPubSub);
   const [response] = usePubSub(responsePubSub);
   const [textGenerationState, setTextGenerationState] = usePubSub(
     textGenerationStatePubSub,
@@ -28,13 +31,21 @@ export default function AiResponseSection() {
             .with(
               Pattern.union("generating", "interrupted", "completed", "failed"),
               (textGenerationState) => (
-                <Suspense>
-                  <AiResponseContent
-                    textGenerationState={textGenerationState}
-                    response={response}
-                    setTextGenerationState={setTextGenerationState}
-                  />
-                </Suspense>
+                <>
+                  <Suspense>
+                    <AiResponseContent
+                      textGenerationState={textGenerationState}
+                      response={response}
+                      setTextGenerationState={setTextGenerationState}
+                    />
+                  </Suspense>
+                  {textGenerationState === "completed" && (
+                    <ChatInterface
+                      initialQuery={query}
+                      initialResponse={response}
+                    />
+                  )}
+                </>
               ),
             )
             .with("loadingModel", () => (
@@ -61,6 +72,7 @@ export default function AiResponseSection() {
       setTextGenerationState,
       modelLoadingProgress,
       response,
+      query,
     ],
   );
 }

--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -1,0 +1,179 @@
+import {
+  useState,
+  useEffect,
+  lazy,
+  Suspense,
+  useRef,
+  KeyboardEvent,
+} from "react";
+import {
+  Card,
+  Text,
+  Textarea,
+  Button,
+  Stack,
+  Group,
+  Paper,
+} from "@mantine/core";
+import { IconSend } from "@tabler/icons-react";
+import {
+  ChatMessage,
+  generateChatResponse,
+} from "../../modules/textGeneration";
+import { addLogEntry } from "../../modules/logEntries";
+import { usePubSub } from "create-pubsub/react";
+import { settingsPubSub } from "../../modules/pubSub";
+import { match } from "ts-pattern";
+
+const FormattedMarkdown = lazy(() => import("./FormattedMarkdown"));
+
+export default function ChatInterface({
+  initialQuery,
+  initialResponse,
+}: {
+  initialQuery: string;
+  initialResponse: string;
+}) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [streamedResponse, setStreamedResponse] = useState("");
+  const latestResponseRef = useRef("");
+  const [settings] = usePubSub(settingsPubSub);
+
+  useEffect(() => {
+    setMessages([
+      { role: "user", content: initialQuery },
+      { role: "assistant", content: initialResponse },
+    ]);
+  }, [initialQuery, initialResponse]);
+
+  const handleSend = async () => {
+    if (input.trim() === "" || isGenerating) return;
+
+    const newMessages = [...messages, { role: "user", content: input }];
+    setMessages(newMessages);
+    setInput("");
+    setIsGenerating(true);
+    setStreamedResponse("");
+    latestResponseRef.current = "";
+
+    try {
+      addLogEntry("User sent a follow-up question");
+      await generateChatResponse(input, newMessages, (partialResponse) => {
+        setStreamedResponse(partialResponse);
+        latestResponseRef.current = partialResponse;
+      });
+      setMessages((prevMessages) => [
+        ...prevMessages,
+        { role: "assistant", content: latestResponseRef.current },
+      ]);
+      addLogEntry("AI responded to follow-up question");
+    } catch (error) {
+      addLogEntry(`Error generating chat response: ${error}`);
+      setMessages((prevMessages) => [
+        ...prevMessages,
+        {
+          role: "assistant",
+          content: "Sorry, I encountered an error while generating a response.",
+        },
+      ]);
+    } finally {
+      setIsGenerating(false);
+      setStreamedResponse("");
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    match([event, settings.enterToSubmit])
+      .with([{ code: "Enter", shiftKey: false }, true], () => {
+        event.preventDefault();
+        handleSend();
+      })
+      .with([{ code: "Enter", shiftKey: true }, false], () => {
+        event.preventDefault();
+        handleSend();
+      })
+      .otherwise(() => undefined);
+  };
+
+  return (
+    <Card withBorder shadow="sm" radius="md">
+      <Card.Section withBorder inheritPadding py="xs">
+        <Text fw={500}>Follow-up questions</Text>
+      </Card.Section>
+      <Stack gap="md" pt="md">
+        {messages.slice(2).length > 0 && (
+          <Stack gap="md" mah="300px" style={{ overflowY: "auto" }}>
+            {messages.slice(2).map((message, index) => (
+              <Paper
+                key={index}
+                shadow="xs"
+                radius="xl"
+                p="sm"
+                maw="80%"
+                style={{
+                  alignSelf:
+                    message.role === "user" ? "flex-end" : "flex-start",
+                }}
+              >
+                <Suspense fallback={<Text>Loading...</Text>}>
+                  <FormattedMarkdown>
+                    {`**${message.role === "user" ? "You" : "AI"}**: ${message.content}`}
+                  </FormattedMarkdown>
+                </Suspense>
+              </Paper>
+            ))}
+            {isGenerating && streamedResponse.length > 0 && (
+              <Paper
+                shadow="xs"
+                radius="xl"
+                p="sm"
+                maw="80%"
+                style={{
+                  alignSelf: "flex-start",
+                }}
+              >
+                <Suspense fallback={<Text>Loading...</Text>}>
+                  <FormattedMarkdown>
+                    {`**AI**: ${streamedResponse}`}
+                  </FormattedMarkdown>
+                </Suspense>
+              </Paper>
+            )}
+          </Stack>
+        )}
+        <Group align="flex-end" style={{ position: "relative" }}>
+          <Textarea
+            placeholder="Ask a follow-up question..."
+            value={input}
+            onChange={(event) => setInput(event.currentTarget.value)}
+            onKeyDown={handleKeyDown}
+            autosize
+            minRows={1}
+            maxRows={4}
+            style={{ flexGrow: 1, paddingRight: "50px" }}
+            disabled={isGenerating}
+          />
+          <Button
+            size="sm"
+            variant="default"
+            onClick={handleSend}
+            loading={isGenerating}
+            style={{
+              height: "100%",
+              position: "absolute",
+              right: 0,
+              top: 0,
+              bottom: 0,
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0,
+            }}
+          >
+            <IconSend size={16} />
+          </Button>
+        </Group>
+      </Stack>
+    </Card>
+  );
+}

--- a/client/components/AiResponse/FormattedMarkdown.tsx
+++ b/client/components/AiResponse/FormattedMarkdown.tsx
@@ -1,0 +1,37 @@
+import { TypographyStylesProvider } from "@mantine/core";
+import Markdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import syntaxHighlighterStyle from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
+
+const FormattedMarkdown = ({ children }: { children: string }) => {
+  return (
+    <TypographyStylesProvider p="md">
+      <Markdown
+        components={{
+          code(props) {
+            const { children, className, node, ref, ...rest } = props;
+            void node;
+            const languageMatch = /language-(\w+)/.exec(className || "");
+            return languageMatch ? (
+              <SyntaxHighlighter
+                {...rest}
+                ref={ref as never}
+                children={children?.toString().replace(/\n$/, "") ?? ""}
+                language={languageMatch[1]}
+                style={syntaxHighlighterStyle}
+              />
+            ) : (
+              <code {...rest} className={className}>
+                {children}
+              </code>
+            );
+          },
+        }}
+      >
+        {children}
+      </Markdown>
+    </TypographyStylesProvider>
+  );
+};
+
+export default FormattedMarkdown;


### PR DESCRIPTION
- Resolves #627

> [!NOTE]
> This PR doesn't handle the context limit discussed [here](https://github.com/felladrin/MiniSearch/discussions/287#discussioncomment-10831511). We'll need to incorporate some logic to work around the context limit, which is quite restricted due to the memory reserved for WASM. The idea is to adopt the same strategies that the LLM UIs used in the past when the models had only 2K context: discard any previous text from the conversation and maintain a window of "<2K tokens + space for the response".