### PR TITLE
Read the default inference type from the  environment variable `DEFAULT_INFERENCE_TYPE`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ INTERNAL_OPENAI_COMPATIBLE_API_MODEL=""
 
 # The name of the internal OpenAI compatible API, displayed in the UI.
 INTERNAL_OPENAI_COMPATIBLE_API_NAME="Internal API"
+
+# The type of inference to use by default. Options: "browser" (browser-based), "openai" (OpenAI-compatible API), "internal" (internal API).
+DEFAULT_INFERENCE_TYPE="browser"

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -24,7 +24,7 @@ export const defaultSettings = {
 
 Search results:
 {{searchResults}}`,
-  inferenceType: VITE_INTERNAL_API_ENABLED ? "internal" : "browser",
+  inferenceType: VITE_DEFAULT_INFERENCE_TYPE,
   openAiApiBaseUrl: "",
   openAiApiKey: "",
   openAiApiModel: "",

--- a/client/types.d.ts
+++ b/client/types.d.ts
@@ -9,3 +9,4 @@ declare const VITE_WEBLLM_DEFAULT_F32_MODEL_ID: string;
 declare const VITE_WLLAMA_DEFAULT_MODEL_ID: string;
 declare const VITE_INTERNAL_API_ENABLED: boolean;
 declare const VITE_INTERNAL_API_NAME: string;
+declare const VITE_DEFAULT_INFERENCE_TYPE: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,9 @@ export default defineConfig(({ command }) => {
       VITE_INTERNAL_API_NAME: JSON.stringify(
         process.env.INTERNAL_OPENAI_COMPATIBLE_API_NAME,
       ),
+      VITE_DEFAULT_INFERENCE_TYPE: JSON.stringify(
+        process.env.DEFAULT_INFERENCE_TYPE,
+      ),
     },
     server: {
       host: process.env.HOST,


### PR DESCRIPTION
This variable can take values such as "browser", "openai", or "internal".

These changes aim to streamline the configuration process for inference types, making it easier for developers to switch between different inference methods without modifying the core logic of the application.

If this environment variable is not set, it will use "browser" (browser-based inference) by default.

- Resolves #650