### PR TITLE
chore: use dpdm-fast to make lint faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-basic-ssl": "^1.1.0",
         "@vitejs/plugin-react": "^4.0.3",
-        "dpdm-fast": "^1.0.4",
+        "dpdm-fast": "^1.0.6",
         "eslint": "^9.0.0",
         "glob": "^11.0.0",
         "globals": "^15.0.0",
@@ -1879,6 +1879,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pm2/agent": {
@@ -4536,23 +4546,21 @@
       }
     },
     "node_modules/dpdm-fast": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dpdm-fast/-/dpdm-fast-1.0.4.tgz",
-      "integrity": "sha512-Na7mniSggAJzu9t33aBo7ZumsplgJGpeHPWQeCWgAtPgH3PMNQK3bVACPF1Y+LMgjfY8NWEPNWx2pqItM12JDg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/dpdm-fast/-/dpdm-fast-1.0.6.tgz",
+      "integrity": "sha512-Q9iltxBHG/HWDxkqJF5Xo0RfEv+65vc+YUlk8uEtkr0lQJjfBKp2aQdXJKCYAIv5xFeoHLLCNfHlfQ/newrcbQ==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "fs-extra": "^11.2.0",
-        "glob": "^11.0.0",
-        "ora": "5.4.1",
-        "tslib": "^2.6.2",
-        "typescript": "^5.3.3",
+        "glob": "^10.3.10",
+        "ora": "^5.4.1",
+        "tslib": "^2.7.0",
+        "typescript": "^5.6.3",
         "yargs": "^17.7.2"
       },
       "bin": {
-        "dpdm": "target/release/dpdm"
+        "dpdm": "scripts/dpdm.js"
       }
     },
     "node_modules/dpdm-fast/node_modules/ansi-styles": {
@@ -4569,6 +4577,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/dpdm-fast/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/dpdm-fast/node_modules/chalk": {
@@ -4608,6 +4625,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dpdm-fast/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/dpdm-fast/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4616,6 +4653,58 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dpdm-fast/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/dpdm-fast/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/dpdm-fast/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dpdm-fast/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/dpdm-fast/node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-basic-ssl": "^1.1.0",
         "@vitejs/plugin-react": "^4.0.3",
-        "dpdm": "^3.14.0",
+        "dpdm-fast": "^1.0.4",
         "eslint": "^9.0.0",
         "glob": "^11.0.0",
         "globals": "^15.0.0",
@@ -1879,17 +1879,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@pm2/agent": {
@@ -4546,26 +4535,27 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dpdm": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/dpdm/-/dpdm-3.14.0.tgz",
-      "integrity": "sha512-YJzsFSyEtj88q5eTELg3UWU7TVZkG1dpbF4JDQ3t1b07xuzXmdoGeSz9TKOke1mUuOpWlk4q+pBh+aHzD6GBTg==",
+    "node_modules/dpdm-fast": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dpdm-fast/-/dpdm-fast-1.0.4.tgz",
+      "integrity": "sha512-Na7mniSggAJzu9t33aBo7ZumsplgJGpeHPWQeCWgAtPgH3PMNQK3bVACPF1Y+LMgjfY8NWEPNWx2pqItM12JDg==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
-        "fs-extra": "^11.1.1",
-        "glob": "^10.3.4",
-        "ora": "^5.4.1",
+        "fs-extra": "^11.2.0",
+        "glob": "^11.0.0",
+        "ora": "5.4.1",
         "tslib": "^2.6.2",
-        "typescript": "^5.2.2",
+        "typescript": "^5.3.3",
         "yargs": "^17.7.2"
       },
       "bin": {
-        "dpdm": "lib/bin/dpdm.js"
+        "dpdm": "target/release/dpdm"
       }
     },
-    "node_modules/dpdm/node_modules/ansi-styles": {
+    "node_modules/dpdm-fast/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -4581,17 +4571,7 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/dpdm/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/dpdm/node_modules/chalk": {
+    "node_modules/dpdm-fast/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -4608,7 +4588,7 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/dpdm/node_modules/color-convert": {
+    "node_modules/dpdm-fast/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -4621,35 +4601,14 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/dpdm/node_modules/color-name": {
+    "node_modules/dpdm-fast/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dpdm/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/dpdm/node_modules/has-flag": {
+    "node_modules/dpdm-fast/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -4659,63 +4618,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/dpdm/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/dpdm/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/dpdm/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/dpdm/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/dpdm/node_modules/supports-color": {
+    "node_modules/dpdm-fast/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "vite preview",
     "build": "vite build",
     "dev": "vite",
-    "lint": "prettier --check . && tsc && eslint --fix client && ts-prune && jscpd client server && dpdm --tree false --warning false vite.config.ts client",
+    "lint": "prettier --check . && tsc && eslint --fix client && ts-prune && jscpd client server && dpdm --no-tree --no-progress --no-warning vite.config.ts client",
     "format": "prettier --write .",
     "test": "glob -c 'tsx --test' '**/*.test.ts'"
   },
@@ -68,7 +68,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-basic-ssl": "^1.1.0",
     "@vitejs/plugin-react": "^4.0.3",
-    "dpdm": "^3.14.0",
+    "dpdm-fast": "^1.0.4",
     "eslint": "^9.0.0",
     "glob": "^11.0.0",
     "globals": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-basic-ssl": "^1.1.0",
     "@vitejs/plugin-react": "^4.0.3",
-    "dpdm-fast": "^1.0.4",
+    "dpdm-fast": "^1.0.6",
     "eslint": "^9.0.0",
     "glob": "^11.0.0",
     "globals": "^15.0.0",


### PR DESCRIPTION
## Description

I want to switch from `dpdm` to a faster `dpdm-fast`, as their CLI capabilities are completely identical. The latter has improved performance by 10-25 times after Rust reconstruction

## How to test
 `dpdm-fast` has been used in multiple projects in my company