### PR TITLE
Split text generation module into separate files for better maintainability and organization

### DIFF
--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -16,14 +16,12 @@ import {
   Paper,
 } from "@mantine/core";
 import { IconSend } from "@tabler/icons-react";
-import {
-  ChatMessage,
-  generateChatResponse,
-} from "../../modules/textGeneration";
+import { generateChatResponse } from "../../modules/textGeneration";
 import { addLogEntry } from "../../modules/logEntries";
 import { usePubSub } from "create-pubsub/react";
 import { settingsPubSub } from "../../modules/pubSub";
 import { match } from "ts-pattern";
+import { ChatMessage } from "gpt-tokenizer/GptEncoding";
 
 const FormattedMarkdown = lazy(() => import("./FormattedMarkdown"));
 
@@ -51,7 +49,10 @@ export default function ChatInterface({
   const handleSend = async () => {
     if (input.trim() === "" || isGenerating) return;
 
-    const newMessages = [...messages, { role: "user", content: input }];
+    const newMessages: ChatMessage[] = [
+      ...messages,
+      { role: "user", content: input },
+    ];
     setMessages(newMessages);
     setInput("");
     setIsGenerating(true);

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -1,32 +1,41 @@
-import { isWebGPUAvailable } from "./webGpu";
+import gptTokenizer from "gpt-tokenizer";
+import { ChatMessage } from "gpt-tokenizer/GptEncoding";
+import prettyMilliseconds from "pretty-ms";
+import { addLogEntry } from "./logEntries";
 import {
-  updateSearchResults,
-  updateResponse,
-  getSearchResults,
   getQuery,
-  updateSearchPromise,
-  getSearchPromise,
-  updateTextGenerationState,
-  updateSearchState,
-  updateModelLoadingProgress,
-  getTextGenerationState,
   getSettings,
+  getTextGenerationState,
   listenToSettingsChanges,
-  updateModelSizeInMegabytes,
+  updateResponse,
+  updateSearchPromise,
+  updateSearchResults,
+  updateSearchState,
+  updateTextGenerationState,
 } from "./pubSub";
 import { search } from "./search";
-import { addLogEntry } from "./logEntries";
 import { getSystemPrompt } from "./systemPrompt";
-import prettyMilliseconds from "pretty-ms";
-import { getOpenAiClient } from "./openai";
-import { getSearchTokenHash } from "./searchTokenHash";
 import {
-  ChatCompletionCreateParamsStreaming,
-  ChatCompletionMessageParam,
-} from "openai/resources/chat/completions.mjs";
-import gptTokenizer from "gpt-tokenizer";
-import { ChatOptions } from "@mlc-ai/web-llm";
-import { defaultSettings } from "./settings";
+  ChatGenerationError,
+  getFormattedSearchResults,
+} from "./textGenerationUtilities";
+import {
+  generateChatWithInternalApi,
+  generateTextWithInternalApi,
+} from "./textGenerationWithInternalApi";
+import {
+  generateChatWithOpenAi,
+  generateTextWithOpenAi,
+} from "./textGenerationWithOpenAi";
+import {
+  generateChatWithWebLlm,
+  generateTextWithWebLlm,
+} from "./textGenerationWithWebLlm";
+import {
+  generateChatWithWllama,
+  generateTextWithWllama,
+} from "./textGenerationWithWllama";
+import { isWebGPUAvailable } from "./webGpu";
 
 export async function searchAndRespond() {
   if (getQuery() === "") return;
@@ -48,7 +57,7 @@ export async function searchAndRespond() {
   try {
     const settings = getSettings();
     if (settings.inferenceType === "openai") {
-      await generateTextWithOpenAI();
+      await generateTextWithOpenAi();
     } else if (settings.inferenceType === "internal") {
       await generateTextWithInternalApi();
     } else {
@@ -83,308 +92,60 @@ export async function searchAndRespond() {
   );
 }
 
-async function generateTextWithOpenAI() {
+export async function generateChatResponse(
+  newMessages: ChatMessage[],
+  onUpdate: (partialResponse: string) => void,
+) {
   const settings = getSettings();
-  const openai = getOpenAiClient({
-    baseURL: settings.openAiApiBaseUrl,
-    apiKey: settings.openAiApiKey,
-  });
+  let response = "";
 
-  await canStartResponding();
-
-  updateTextGenerationState("preparingToGenerate");
-
-  const completion = await openai.chat.completions.create({
-    ...getDefaultChatCompletionCreateParamsStreaming(),
-    model: settings.openAiApiModel,
-    messages: [
+  try {
+    const allMessages: ChatMessage[] = [
       {
         role: "user",
         content: getSystemPrompt(getFormattedSearchResults(true)),
       },
       { role: "assistant", content: "Ok!" },
-      { role: "user", content: getQuery() },
-    ],
-  });
+      ...newMessages,
+    ];
 
-  let streamedMessage = "";
+    const lastMessagesReversed: ChatMessage[] = [];
 
-  for await (const chunk of completion) {
-    const deltaContent = chunk.choices[0].delta.content;
+    let totalTokens = 0;
 
-    if (deltaContent) streamedMessage += deltaContent;
+    for (const message of allMessages.reverse()) {
+      const newTotalTokens =
+        totalTokens + gptTokenizer.encode(message.content).length;
 
-    if (getTextGenerationState() === "interrupted") {
-      completion.controller.abort();
-    } else if (getTextGenerationState() !== "generating") {
-      updateTextGenerationState("generating");
+      if (newTotalTokens > 1280) break;
+
+      totalTokens = newTotalTokens;
+      lastMessagesReversed.push(message);
     }
 
-    updateResponseRateLimited(streamedMessage);
-  }
+    const lastMessages = lastMessagesReversed.reverse();
 
-  updateResponse(streamedMessage);
-}
-
-async function generateTextWithInternalApi() {
-  await canStartResponding();
-
-  updateTextGenerationState("preparingToGenerate");
-
-  const inferenceUrl = new URL("/inference", self.location.origin);
-
-  const tokenPrefix = "Bearer ";
-
-  const token = await getSearchTokenHash();
-
-  const response = await fetch(inferenceUrl.toString(), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `${tokenPrefix}${token}`,
-    },
-    body: JSON.stringify({
-      ...getDefaultChatCompletionCreateParamsStreaming(),
-      messages: [
-        {
-          role: "user",
-          content: getSystemPrompt(getFormattedSearchResults(true)),
-        },
-        { role: "assistant", content: "Ok!" },
-        { role: "user", content: getQuery() },
-      ],
-    } as ChatCompletionCreateParamsStreaming),
-  });
-
-  if (!response.ok || !response.body) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder("utf-8");
-  let streamedMessage = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    const chunk = decoder.decode(value);
-    const lines = chunk.split("\n");
-    const parsedLines = lines
-      .map((line) => line.replace(/^data: /, "").trim())
-      .filter((line) => line !== "" && line !== "[DONE]")
-      .map((line) => JSON.parse(line));
-
-    for (const parsedLine of parsedLines) {
-      const deltaContent = parsedLine.choices[0].delta.content;
-      if (deltaContent) streamedMessage += deltaContent;
-
-      if (getTextGenerationState() === "interrupted") {
-        reader.cancel();
-      } else if (getTextGenerationState() !== "generating") {
-        updateTextGenerationState("generating");
+    if (settings.inferenceType === "openai") {
+      response = await generateChatWithOpenAi(lastMessages, onUpdate);
+    } else if (settings.inferenceType === "internal") {
+      response = await generateChatWithInternalApi(lastMessages, onUpdate);
+    } else {
+      if (isWebGPUAvailable && settings.enableWebGpu) {
+        response = await generateChatWithWebLlm(lastMessages, onUpdate);
+      } else {
+        response = await generateChatWithWllama(lastMessages, onUpdate);
       }
-
-      updateResponseRateLimited(streamedMessage);
     }
-  }
-
-  updateResponse(streamedMessage);
-}
-
-async function generateTextWithWebLlm() {
-  const {
-    CreateWebWorkerMLCEngine,
-    CreateMLCEngine,
-    hasModelInCache,
-    prebuiltAppConfig,
-  } = await import("@mlc-ai/web-llm");
-
-  type InitProgressCallback = import("@mlc-ai/web-llm").InitProgressCallback;
-  type MLCEngineConfig = import("@mlc-ai/web-llm").MLCEngineConfig;
-  type ChatOptions = import("@mlc-ai/web-llm").ChatOptions;
-
-  const selectedModelId = getSettings().webLlmModelId;
-
-  updateModelSizeInMegabytes(
-    prebuiltAppConfig.model_list.find((m) => m.model_id === selectedModelId)
-      ?.vram_required_MB || 0,
-  );
-
-  addLogEntry(`Selected WebLLM model: ${selectedModelId}`);
-
-  const isModelCached = await hasModelInCache(selectedModelId);
-
-  let initProgressCallback: InitProgressCallback | undefined;
-
-  if (isModelCached) {
-    updateTextGenerationState("preparingToGenerate");
-  } else {
-    initProgressCallback = (report) => {
-      updateModelLoadingProgress(Math.round(report.progress * 100));
-    };
-  }
-
-  const engineConfig: MLCEngineConfig = {
-    initProgressCallback,
-    logLevel: "SILENT",
-  };
-
-  const chatOptions: ChatOptions = {
-    repetition_penalty: defaultSettings.inferenceRepeatPenalty,
-  };
-
-  const engine = Worker
-    ? await CreateWebWorkerMLCEngine(
-        new Worker(new URL("./webLlmWorker.ts", import.meta.url), {
-          type: "module",
-        }),
-        selectedModelId,
-        engineConfig,
-        chatOptions,
-      )
-    : await CreateMLCEngine(selectedModelId, engineConfig, chatOptions);
-
-  if (getSettings().enableAiResponse) {
-    await canStartResponding();
-
-    updateTextGenerationState("preparingToGenerate");
-
-    const completion = await engine.chat.completions.create({
-      ...getDefaultChatCompletionCreateParamsStreaming(),
-      messages: [
-        {
-          role: "user",
-          content: getSystemPrompt(getFormattedSearchResults(true)),
-        },
-        { role: "assistant", content: "Ok!" },
-        { role: "user", content: getQuery() },
-      ],
-    });
-
-    let streamedMessage = "";
-
-    for await (const chunk of completion) {
-      const deltaContent = chunk.choices[0].delta.content;
-
-      if (deltaContent) streamedMessage += deltaContent;
-
-      if (getTextGenerationState() === "interrupted") {
-        await engine.interruptGenerate();
-      } else if (getTextGenerationState() !== "generating") {
-        updateTextGenerationState("generating");
-      }
-
-      updateResponseRateLimited(streamedMessage);
+  } catch (error) {
+    if (error instanceof ChatGenerationError) {
+      addLogEntry(`Chat generation interrupted: ${error.message}`);
+    } else {
+      addLogEntry(`Error generating chat response: ${error}`);
     }
-
-    updateResponse(streamedMessage);
+    throw error;
   }
 
-  addLogEntry(
-    `WebLLM finished generating the response. Stats: ${await engine.runtimeStatsText()}`,
-  );
-
-  engine.unload();
-}
-
-async function generateTextWithWllama() {
-  const { initializeWllama, wllamaModels } = await import("./wllama");
-
-  let loadingPercentage = 0;
-
-  const model = wllamaModels[getSettings().wllamaModelId];
-
-  updateModelSizeInMegabytes(model.fileSizeInMegabytes);
-
-  const wllama = await initializeWllama(model.url, {
-    wllama: {
-      suppressNativeLog: true,
-    },
-    model: {
-      n_threads: getSettings().cpuThreads,
-      n_ctx: model.contextSize,
-      cache_type_k: model.cacheType,
-      embeddings: false,
-      allowOffline: true,
-      progressCallback: ({ loaded, total }) => {
-        const progressPercentage = Math.round((loaded / total) * 100);
-
-        if (loadingPercentage !== progressPercentage) {
-          loadingPercentage = progressPercentage;
-          updateModelLoadingProgress(progressPercentage);
-        }
-      },
-    },
-  });
-
-  if (getSettings().enableAiResponse) {
-    await canStartResponding();
-
-    updateTextGenerationState("preparingToGenerate");
-
-    const prompt = await model.buildPrompt(
-      wllama,
-      getQuery(),
-      getFormattedSearchResults(model.shouldIncludeUrlsOnPrompt),
-    );
-
-    let streamedMessage = "";
-
-    await wllama.createCompletion(prompt, {
-      stopTokens: model.stopTokens,
-      sampling: model.sampling,
-      onNewToken: (_token, _piece, currentText, { abortSignal }) => {
-        if (getTextGenerationState() === "interrupted") {
-          abortSignal();
-        } else if (getTextGenerationState() !== "generating") {
-          updateTextGenerationState("generating");
-        }
-
-        if (model.stopStrings) {
-          for (const stopString of model.stopStrings) {
-            if (
-              currentText.slice(-(stopString.length * 2)).includes(stopString)
-            ) {
-              abortSignal();
-              currentText = currentText.slice(0, -stopString.length);
-              break;
-            }
-          }
-        }
-
-        streamedMessage = currentText;
-
-        updateResponseRateLimited(streamedMessage);
-      },
-    });
-
-    updateResponse(streamedMessage);
-  }
-
-  await wllama.exit();
-}
-
-function getFormattedSearchResults(shouldIncludeUrl: boolean) {
-  const searchResults = getSearchResults().textResults.slice(
-    0,
-    getSettings().searchResultsToConsider,
-  );
-
-  if (searchResults.length === 0) return "None.";
-
-  if (shouldIncludeUrl) {
-    return searchResults
-      .map(
-        ([title, snippet, url], index) =>
-          `${index + 1}. [${title}](${url}) | ${snippet}`,
-      )
-      .join("\n");
-  }
-
-  return searchResults
-    .map(([title, snippet]) => `- ${title} | ${snippet}`)
-    .join("\n");
+  return response;
 }
 
 async function getKeywords(text: string, limit?: number) {
@@ -416,316 +177,6 @@ async function startSearch(query: string) {
   return searchResults;
 }
 
-async function canStartResponding() {
-  if (getSettings().searchResultsToConsider > 0) {
-    updateTextGenerationState("awaitingSearchResults");
-    await getSearchPromise();
-  }
-}
-
-function updateResponseRateLimited(text: string) {
-  const currentTime = Date.now();
-
-  if (
-    currentTime - updateResponseRateLimited.lastUpdateTime >=
-    updateResponseRateLimited.updateInterval
-  ) {
-    updateResponse(text);
-    updateResponseRateLimited.lastUpdateTime = currentTime;
-  }
-}
-updateResponseRateLimited.lastUpdateTime = 0;
-updateResponseRateLimited.updateInterval = 1000 / 12;
-
-class ChatGenerationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ChatGenerationError";
-  }
-}
-
-async function generateChatWithOpenAI(
-  messages: ChatMessage[],
-  onUpdate: (partialResponse: string) => void,
-) {
-  const settings = getSettings();
-  const openai = getOpenAiClient({
-    baseURL: settings.openAiApiBaseUrl,
-    apiKey: settings.openAiApiKey,
-  });
-  const completion = await openai.chat.completions.create({
-    ...getDefaultChatCompletionCreateParamsStreaming(),
-    model: settings.openAiApiModel,
-    messages: messages as ChatCompletionMessageParam[],
-  });
-
-  let streamedMessage = "";
-
-  for await (const chunk of completion) {
-    const deltaContent = chunk.choices[0].delta.content;
-
-    if (deltaContent) {
-      streamedMessage += deltaContent;
-      onUpdate(streamedMessage);
-    }
-
-    if (getTextGenerationState() === "interrupted") {
-      completion.controller.abort();
-      throw new ChatGenerationError("Chat generation interrupted");
-    }
-  }
-
-  return streamedMessage;
-}
-
-async function generateChatWithInternalApi(
-  messages: ChatMessage[],
-  onUpdate: (partialResponse: string) => void,
-) {
-  const inferenceUrl = new URL("/inference", self.location.origin);
-  const tokenPrefix = "Bearer ";
-  const token = await getSearchTokenHash();
-
-  const response = await fetch(inferenceUrl.toString(), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `${tokenPrefix}${token}`,
-    },
-    body: JSON.stringify({
-      ...getDefaultChatCompletionCreateParamsStreaming(),
-      messages,
-    } as ChatCompletionCreateParamsStreaming),
-  });
-
-  if (!response.ok || !response.body) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder("utf-8");
-  let streamedMessage = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    const chunk = decoder.decode(value);
-    const lines = chunk.split("\n");
-    const parsedLines = lines
-      .map((line) => line.replace(/^data: /, "").trim())
-      .filter((line) => line !== "" && line !== "[DONE]")
-      .map((line) => JSON.parse(line));
-
-    for (const parsedLine of parsedLines) {
-      const deltaContent = parsedLine.choices[0].delta.content;
-      if (deltaContent) {
-        streamedMessage += deltaContent;
-        onUpdate(streamedMessage);
-      }
-
-      if (getTextGenerationState() === "interrupted") {
-        reader.cancel();
-        throw new ChatGenerationError("Chat generation interrupted");
-      }
-    }
-  }
-
-  return streamedMessage;
-}
-
-async function generateChatWithWebLlm(
-  messages: ChatMessage[],
-  onUpdate: (partialResponse: string) => void,
-) {
-  const { CreateWebWorkerMLCEngine, CreateMLCEngine, prebuiltAppConfig } =
-    await import("@mlc-ai/web-llm");
-
-  type MLCEngineConfig = import("@mlc-ai/web-llm").MLCEngineConfig;
-  type ChatCompletionMessageParam =
-    import("@mlc-ai/web-llm").ChatCompletionMessageParam;
-
-  const selectedModelId = getSettings().webLlmModelId;
-
-  updateModelSizeInMegabytes(
-    prebuiltAppConfig.model_list.find((m) => m.model_id === selectedModelId)
-      ?.vram_required_MB || 0,
-  );
-
-  addLogEntry(`Selected WebLLM model for chat: ${selectedModelId}`);
-
-  const engineConfig: MLCEngineConfig = {
-    logLevel: "SILENT",
-  };
-
-  const chatOptions: ChatOptions = {
-    repetition_penalty: defaultSettings.inferenceRepeatPenalty,
-  };
-
-  const engine = Worker
-    ? await CreateWebWorkerMLCEngine(
-        new Worker(new URL("./webLlmWorker.ts", import.meta.url), {
-          type: "module",
-        }),
-        selectedModelId,
-        engineConfig,
-        chatOptions,
-      )
-    : await CreateMLCEngine(selectedModelId, engineConfig, chatOptions);
-
-  const completion = await engine.chat.completions.create({
-    ...getDefaultChatCompletionCreateParamsStreaming(),
-    messages: messages as ChatCompletionMessageParam[],
-  });
-
-  let streamedMessage = "";
-
-  for await (const chunk of completion) {
-    const deltaContent = chunk.choices[0].delta.content;
-
-    if (deltaContent) {
-      streamedMessage += deltaContent;
-      onUpdate(streamedMessage);
-    }
-
-    if (getTextGenerationState() === "interrupted") {
-      await engine.interruptGenerate();
-      throw new ChatGenerationError("Chat generation interrupted");
-    }
-  }
-
-  addLogEntry(
-    `WebLLM finished generating the chat response. Stats: ${await engine.runtimeStatsText()}`,
-  );
-
-  engine.unload();
-
-  return streamedMessage;
-}
-
-async function generateChatWithWllama(
-  messages: ChatMessage[],
-  onUpdate: (partialResponse: string) => void,
-) {
-  const { initializeWllama, wllamaModels } = await import("./wllama");
-
-  const model = wllamaModels[getSettings().wllamaModelId];
-
-  updateModelSizeInMegabytes(model.fileSizeInMegabytes);
-
-  const wllama = await initializeWllama(model.url, {
-    wllama: {
-      suppressNativeLog: true,
-    },
-    model: {
-      n_threads: getSettings().cpuThreads,
-      n_ctx: model.contextSize,
-      cache_type_k: model.cacheType,
-      embeddings: false,
-      allowOffline: true,
-    },
-  });
-
-  const prompt = await model.buildPrompt(
-    wllama,
-    messages[messages.length - 1].content,
-    getFormattedSearchResults(model.shouldIncludeUrlsOnPrompt),
-  );
-
-  let streamedMessage = "";
-
-  await wllama.createCompletion(prompt, {
-    stopTokens: model.stopTokens,
-    sampling: model.sampling,
-    onNewToken: (_token, _piece, currentText, { abortSignal }) => {
-      if (getTextGenerationState() === "interrupted") {
-        abortSignal();
-        throw new ChatGenerationError("Chat generation interrupted");
-      }
-
-      if (model.stopStrings) {
-        for (const stopString of model.stopStrings) {
-          if (
-            currentText.slice(-(stopString.length * 2)).includes(stopString)
-          ) {
-            abortSignal();
-            currentText = currentText.slice(0, -stopString.length);
-            break;
-          }
-        }
-      }
-
-      streamedMessage = currentText;
-      onUpdate(streamedMessage);
-    },
-  });
-
-  await wllama.exit();
-
-  return streamedMessage;
-}
-
-export async function generateChatResponse(
-  newMessages: ChatMessage[],
-  onUpdate: (partialResponse: string) => void,
-) {
-  const settings = getSettings();
-  let response = "";
-
-  try {
-    const allMessages = [
-      {
-        role: "user",
-        content: getSystemPrompt(getFormattedSearchResults(true)),
-      },
-      { role: "assistant", content: "Ok!" },
-      ...newMessages,
-    ];
-
-    const lastMessagesReversed: ChatMessage[] = [];
-
-    let totalTokens = 0;
-
-    for (const message of allMessages.reverse()) {
-      const newTotalTokens =
-        totalTokens + gptTokenizer.encode(message.content).length;
-
-      if (newTotalTokens > 1280) break;
-
-      totalTokens = newTotalTokens;
-      lastMessagesReversed.push(message);
-    }
-
-    const lastMessages = lastMessagesReversed.reverse();
-
-    if (settings.inferenceType === "openai") {
-      response = await generateChatWithOpenAI(lastMessages, onUpdate);
-    } else if (settings.inferenceType === "internal") {
-      response = await generateChatWithInternalApi(lastMessages, onUpdate);
-    } else {
-      if (isWebGPUAvailable && settings.enableWebGpu) {
-        response = await generateChatWithWebLlm(lastMessages, onUpdate);
-      } else {
-        response = await generateChatWithWllama(lastMessages, onUpdate);
-      }
-    }
-  } catch (error) {
-    if (error instanceof ChatGenerationError) {
-      addLogEntry(`Chat generation interrupted: ${error.message}`);
-    } else {
-      addLogEntry(`Error generating chat response: ${error}`);
-    }
-    throw error;
-  }
-
-  return response;
-}
-
-export interface ChatMessage {
-  role: "user" | "assistant" | string;
-  content: string;
-}
-
 function canDownloadModels(): Promise<void> {
   return new Promise((resolve) => {
     if (getSettings().allowAiModelDownload) {
@@ -739,15 +190,4 @@ function canDownloadModels(): Promise<void> {
       });
     }
   });
-}
-
-function getDefaultChatCompletionCreateParamsStreaming() {
-  return {
-    stream: true,
-    max_tokens: 2048,
-    temperature: defaultSettings.inferenceTemperature,
-    top_p: defaultSettings.inferenceTopP,
-    frequency_penalty: defaultSettings.inferenceFrequencyPenalty,
-    presence_penalty: defaultSettings.inferencePresencePenalty,
-  } as const;
 }

--- a/client/modules/textGenerationUtilities.ts
+++ b/client/modules/textGenerationUtilities.ts
@@ -1,0 +1,123 @@
+import { ChatCompletionChunk } from "openai/resources/chat/completions.mjs";
+import { ChatCompletionChunk as WebLlmChatCompletionChunk } from "@mlc-ai/web-llm";
+import {
+  getQuery,
+  getSearchPromise,
+  getSearchResults,
+  getSettings,
+  getTextGenerationState,
+  updateResponse,
+  updateTextGenerationState,
+} from "./pubSub";
+import { defaultSettings } from "./settings";
+import { getSystemPrompt } from "./systemPrompt";
+import { Stream } from "openai/streaming.mjs";
+import { ChatMessage } from "gpt-tokenizer/GptEncoding";
+
+export class ChatGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChatGenerationError";
+  }
+}
+
+export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
+  const searchResults = getSearchResults().textResults.slice(
+    0,
+    getSettings().searchResultsToConsider,
+  );
+
+  if (searchResults.length === 0) return "None.";
+
+  if (shouldIncludeUrl) {
+    return searchResults
+      .map(
+        ([title, snippet, url], index) =>
+          `${index + 1}. [${title}](${url}) | ${snippet}`,
+      )
+      .join("\n");
+  }
+
+  return searchResults
+    .map(([title, snippet]) => `- ${title} | ${snippet}`)
+    .join("\n");
+}
+
+export async function canStartResponding() {
+  if (getSettings().searchResultsToConsider > 0) {
+    updateTextGenerationState("awaitingSearchResults");
+    await getSearchPromise();
+  }
+}
+
+export function updateResponseRateLimited(text: string) {
+  const currentTime = Date.now();
+
+  if (
+    currentTime - updateResponseRateLimited.lastUpdateTime >=
+    updateResponseRateLimited.updateInterval
+  ) {
+    updateResponse(text);
+    updateResponseRateLimited.lastUpdateTime = currentTime;
+  }
+}
+updateResponseRateLimited.lastUpdateTime = 0;
+updateResponseRateLimited.updateInterval = 1000 / 12;
+
+export function getDefaultChatCompletionCreateParamsStreaming() {
+  return {
+    stream: true,
+    max_tokens: 2048,
+    temperature: defaultSettings.inferenceTemperature,
+    top_p: defaultSettings.inferenceTopP,
+    frequency_penalty: defaultSettings.inferenceFrequencyPenalty,
+    presence_penalty: defaultSettings.inferencePresencePenalty,
+  } as const;
+}
+
+export async function handleStreamingResponse(
+  completion:
+    | Stream<ChatCompletionChunk>
+    | AsyncIterable<WebLlmChatCompletionChunk>,
+  onChunk: (streamedMessage: string) => void,
+  options?: {
+    abortController?: { abort: () => void };
+    shouldUpdateGeneratingState?: boolean;
+  },
+) {
+  let streamedMessage = "";
+
+  for await (const chunk of completion) {
+    const deltaContent = chunk.choices[0].delta.content;
+
+    if (deltaContent) {
+      streamedMessage += deltaContent;
+      onChunk(streamedMessage);
+    }
+
+    if (getTextGenerationState() === "interrupted") {
+      if (options?.abortController) {
+        options.abortController.abort();
+      }
+      throw new ChatGenerationError("Chat generation interrupted");
+    } else if (
+      options?.shouldUpdateGeneratingState &&
+      getTextGenerationState() !== "generating"
+    ) {
+      updateTextGenerationState("generating");
+    }
+  }
+
+  return streamedMessage;
+}
+
+export function getDefaultChatMessages(searchResults: string): ChatMessage[] {
+  return [
+    {
+      role: "user",
+      content: getSystemPrompt(searchResults),
+    },
+    { role: "assistant", content: "Ok!" },
+    { role: "user", content: getQuery() },
+  ];
+}

--- a/client/modules/textGenerationWithInternalApi.ts
+++ b/client/modules/textGenerationWithInternalApi.ts
@@ -1,0 +1,105 @@
+import type { ChatMessage } from "gpt-tokenizer/GptEncoding";
+import type { ChatCompletionCreateParamsStreaming } from "openai/resources/chat/completions.mjs";
+import {
+  getQuery,
+  getTextGenerationState,
+  updateResponse,
+  updateTextGenerationState,
+} from "./pubSub";
+import { getSearchTokenHash } from "./searchTokenHash";
+import { getSystemPrompt } from "./systemPrompt";
+import {
+  canStartResponding,
+  ChatGenerationError,
+  getDefaultChatCompletionCreateParamsStreaming,
+  getFormattedSearchResults,
+  updateResponseRateLimited,
+} from "./textGenerationUtilities";
+
+export async function generateTextWithInternalApi() {
+  await canStartResponding();
+  updateTextGenerationState("preparingToGenerate");
+
+  const messages: ChatMessage[] = [
+    {
+      role: "user",
+      content: getSystemPrompt(getFormattedSearchResults(true)),
+    },
+    { role: "assistant", content: "Ok!" },
+    { role: "user", content: getQuery() },
+  ];
+
+  const streamedMessage = await processStreamResponse(messages, (message) => {
+    if (getTextGenerationState() === "interrupted") {
+      throw new ChatGenerationError("Generation interrupted");
+    } else if (getTextGenerationState() !== "generating") {
+      updateTextGenerationState("generating");
+    }
+    updateResponseRateLimited(message);
+  });
+
+  updateResponse(streamedMessage);
+}
+
+export async function generateChatWithInternalApi(
+  messages: ChatMessage[],
+  onUpdate: (partialResponse: string) => void,
+) {
+  return processStreamResponse(messages, (message) => {
+    onUpdate(message);
+    if (getTextGenerationState() === "interrupted") {
+      throw new ChatGenerationError("Chat generation interrupted");
+    }
+  });
+}
+
+async function processStreamResponse(
+  messages: ChatMessage[],
+  onChunk: (message: string) => void,
+): Promise<string> {
+  const inferenceUrl = new URL("/inference", self.location.origin);
+  const tokenPrefix = "Bearer ";
+  const token = await getSearchTokenHash();
+
+  const response = await fetch(inferenceUrl.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `${tokenPrefix}${token}`,
+    },
+    body: JSON.stringify({
+      ...getDefaultChatCompletionCreateParamsStreaming(),
+      messages,
+    } as ChatCompletionCreateParamsStreaming),
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let streamedMessage = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const chunk = decoder.decode(value);
+    const lines = chunk.split("\n");
+    const parsedLines = lines
+      .map((line) => line.replace(/^data: /, "").trim())
+      .filter((line) => line !== "" && line !== "[DONE]")
+      .map((line) => JSON.parse(line));
+
+    for (const parsedLine of parsedLines) {
+      const deltaContent = parsedLine.choices[0].delta.content;
+      if (deltaContent) {
+        streamedMessage += deltaContent;
+        onChunk(streamedMessage);
+      }
+    }
+  }
+
+  return streamedMessage;
+}

--- a/client/modules/textGenerationWithOpenAi.ts
+++ b/client/modules/textGenerationWithOpenAi.ts
@@ -1,0 +1,57 @@
+import { ChatMessage } from "gpt-tokenizer/GptEncoding";
+import { ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
+import { getOpenAiClient } from "./openai";
+import { getSettings, updateTextGenerationState } from "./pubSub";
+import {
+  canStartResponding,
+  getDefaultChatCompletionCreateParamsStreaming,
+  getDefaultChatMessages,
+  getFormattedSearchResults,
+  handleStreamingResponse,
+  updateResponseRateLimited,
+} from "./textGenerationUtilities";
+
+export async function generateTextWithOpenAi() {
+  const settings = getSettings();
+  const openai = getOpenAiClient({
+    baseURL: settings.openAiApiBaseUrl,
+    apiKey: settings.openAiApiKey,
+  });
+
+  await canStartResponding();
+  updateTextGenerationState("preparingToGenerate");
+
+  const completion = await openai.chat.completions.create({
+    ...getDefaultChatCompletionCreateParamsStreaming(),
+    model: settings.openAiApiModel,
+    messages: getDefaultChatMessages(
+      getFormattedSearchResults(true),
+    ) as ChatCompletionMessageParam[],
+  });
+
+  await handleStreamingResponse(completion, updateResponseRateLimited, {
+    abortController: completion.controller,
+    shouldUpdateGeneratingState: true,
+  });
+}
+
+export async function generateChatWithOpenAi(
+  messages: ChatMessage[],
+  onUpdate: (partialResponse: string) => void,
+) {
+  const settings = getSettings();
+  const openai = getOpenAiClient({
+    baseURL: settings.openAiApiBaseUrl,
+    apiKey: settings.openAiApiKey,
+  });
+
+  const completion = await openai.chat.completions.create({
+    ...getDefaultChatCompletionCreateParamsStreaming(),
+    model: settings.openAiApiModel,
+    messages: messages as ChatCompletionMessageParam[],
+  });
+
+  return handleStreamingResponse(completion, onUpdate, {
+    abortController: completion.controller,
+  });
+}

--- a/client/modules/textGenerationWithWebLlm.ts
+++ b/client/modules/textGenerationWithWebLlm.ts
@@ -1,0 +1,117 @@
+import {
+  ChatCompletionMessageParam,
+  ChatOptions,
+  InitProgressCallback,
+  MLCEngineConfig,
+} from "@mlc-ai/web-llm";
+import { ChatMessage } from "gpt-tokenizer/GptEncoding";
+import { addLogEntry } from "./logEntries";
+import {
+  getSettings,
+  updateModelLoadingProgress,
+  updateModelSizeInMegabytes,
+  updateTextGenerationState,
+} from "./pubSub";
+import { defaultSettings } from "./settings";
+import {
+  canStartResponding,
+  getDefaultChatCompletionCreateParamsStreaming,
+  getDefaultChatMessages,
+  getFormattedSearchResults,
+  handleStreamingResponse,
+  updateResponseRateLimited,
+} from "./textGenerationUtilities";
+
+export async function generateTextWithWebLlm() {
+  const engine = await initializeWebLlmEngine();
+
+  if (getSettings().enableAiResponse) {
+    await canStartResponding();
+    updateTextGenerationState("preparingToGenerate");
+
+    const completion = await engine.chat.completions.create({
+      ...getDefaultChatCompletionCreateParamsStreaming(),
+      messages: getDefaultChatMessages(
+        getFormattedSearchResults(true),
+      ) as ChatCompletionMessageParam[],
+    });
+
+    await handleStreamingResponse(completion, updateResponseRateLimited, {
+      shouldUpdateGeneratingState: true,
+    });
+  }
+
+  addLogEntry(
+    `WebLLM finished generating the response. Stats: ${await engine.runtimeStatsText()}`,
+  );
+
+  engine.unload();
+}
+
+export async function generateChatWithWebLlm(
+  messages: ChatMessage[],
+  onUpdate: (partialResponse: string) => void,
+) {
+  const engine = await initializeWebLlmEngine();
+
+  const completion = await engine.chat.completions.create({
+    ...getDefaultChatCompletionCreateParamsStreaming(),
+    messages: messages as ChatCompletionMessageParam[],
+  });
+
+  const response = await handleStreamingResponse(completion, onUpdate);
+
+  addLogEntry(
+    `WebLLM finished generating the chat response. Stats: ${await engine.runtimeStatsText()}`,
+  );
+
+  engine.unload();
+  return response;
+}
+
+async function initializeWebLlmEngine() {
+  const {
+    CreateWebWorkerMLCEngine,
+    CreateMLCEngine,
+    hasModelInCache,
+    prebuiltAppConfig,
+  } = await import("@mlc-ai/web-llm");
+
+  const selectedModelId = getSettings().webLlmModelId;
+
+  updateModelSizeInMegabytes(
+    prebuiltAppConfig.model_list.find((m) => m.model_id === selectedModelId)
+      ?.vram_required_MB || 0,
+  );
+
+  addLogEntry(`Selected WebLLM model: ${selectedModelId}`);
+
+  const isModelCached = await hasModelInCache(selectedModelId);
+  let initProgressCallback: InitProgressCallback | undefined;
+
+  if (!isModelCached) {
+    initProgressCallback = (report) => {
+      updateModelLoadingProgress(Math.round(report.progress * 100));
+    };
+  }
+
+  const engineConfig: MLCEngineConfig = {
+    initProgressCallback,
+    logLevel: "SILENT",
+  };
+
+  const chatOptions: ChatOptions = {
+    repetition_penalty: defaultSettings.inferenceRepeatPenalty,
+  };
+
+  return Worker
+    ? await CreateWebWorkerMLCEngine(
+        new Worker(new URL("./webLlmWorker.ts", import.meta.url), {
+          type: "module",
+        }),
+        selectedModelId,
+        engineConfig,
+        chatOptions,
+      )
+    : await CreateMLCEngine(selectedModelId, engineConfig, chatOptions);
+}

--- a/client/modules/textGenerationWithWllama.ts
+++ b/client/modules/textGenerationWithWllama.ts
@@ -1,0 +1,148 @@
+import {
+  getQuery,
+  getSettings,
+  getTextGenerationState,
+  updateModelLoadingProgress,
+  updateModelSizeInMegabytes,
+  updateResponse,
+  updateTextGenerationState,
+} from "./pubSub";
+import {
+  canStartResponding,
+  ChatGenerationError,
+  getFormattedSearchResults,
+  updateResponseRateLimited,
+} from "./textGenerationUtilities";
+
+export async function generateTextWithWllama() {
+  if (!getSettings().enableAiResponse) return;
+
+  const response = await generateWithWllama(
+    getQuery(),
+    updateResponseRateLimited,
+    true,
+  );
+
+  updateResponse(response);
+}
+
+export async function generateChatWithWllama(
+  messages: import("gpt-tokenizer/GptEncoding").ChatMessage[],
+  onUpdate: (partialResponse: string) => void,
+) {
+  return generateWithWllama(
+    messages[messages.length - 1].content,
+    onUpdate,
+    false,
+  );
+}
+
+async function initializeWllamaInstance(
+  progressCallback?: ({
+    loaded,
+    total,
+  }: {
+    loaded: number;
+    total: number;
+  }) => void,
+) {
+  const { initializeWllama, wllamaModels } = await import("./wllama");
+  const model = wllamaModels[getSettings().wllamaModelId];
+
+  updateModelSizeInMegabytes(model.fileSizeInMegabytes);
+
+  const wllama = await initializeWllama(model.url, {
+    wllama: {
+      suppressNativeLog: true,
+    },
+    model: {
+      n_threads: getSettings().cpuThreads,
+      n_ctx: model.contextSize,
+      cache_type_k: model.cacheType,
+      embeddings: false,
+      allowOffline: true,
+      progressCallback,
+    },
+  });
+
+  return { wllama, model };
+}
+
+async function generateWithWllama(
+  input: string,
+  onUpdate: (partialResponse: string) => void,
+  shouldCheckCanRespond = false,
+) {
+  let loadingPercentage = 0;
+
+  const { wllama, model } = await initializeWllamaInstance(
+    shouldCheckCanRespond
+      ? ({ loaded, total }) => {
+          const progressPercentage = Math.round((loaded / total) * 100);
+          if (loadingPercentage !== progressPercentage) {
+            loadingPercentage = progressPercentage;
+            updateModelLoadingProgress(progressPercentage);
+          }
+        }
+      : undefined,
+  );
+
+  if (shouldCheckCanRespond) {
+    await canStartResponding();
+    updateTextGenerationState("preparingToGenerate");
+  }
+
+  const prompt = await model.buildPrompt(
+    wllama,
+    input,
+    getFormattedSearchResults(model.shouldIncludeUrlsOnPrompt),
+  );
+
+  let streamedMessage = "";
+
+  await wllama.createCompletion(prompt, {
+    stopTokens: model.stopTokens,
+    sampling: model.sampling,
+    onNewToken: (_token, _piece, currentText, { abortSignal }) => {
+      if (shouldCheckCanRespond && getTextGenerationState() === "interrupted") {
+        abortSignal();
+        throw new ChatGenerationError("Chat generation interrupted");
+      } else if (
+        shouldCheckCanRespond &&
+        getTextGenerationState() !== "generating"
+      ) {
+        updateTextGenerationState("generating");
+      }
+
+      streamedMessage = handleWllamaCompletion(
+        model,
+        currentText,
+        abortSignal,
+        onUpdate,
+      );
+    },
+  });
+
+  await wllama.exit();
+  return streamedMessage;
+}
+
+function handleWllamaCompletion(
+  model: import("./wllama").WllamaModel,
+  currentText: string,
+  abortSignal: () => void,
+  onUpdate: (text: string) => void,
+) {
+  if (model.stopStrings) {
+    for (const stopString of model.stopStrings) {
+      if (currentText.slice(-(stopString.length * 2)).includes(stopString)) {
+        abortSignal();
+        currentText = currentText.slice(0, -stopString.length);
+        break;
+      }
+    }
+  }
+
+  onUpdate(currentText);
+  return currentText;
+}


### PR DESCRIPTION
1. Major refactoring of the text generation module by splitting it into separate files:
   - `textGenerationWithOpenAi.ts`
   - `textGenerationWithInternalApi.ts`
   - `textGenerationWithWebLlm.ts`
   - `textGenerationWithWllama.ts`
   - `textGenerationUtilities.ts`

2. ChatMessage type is now imported from `gpt-tokenizer/GptEncoding` instead of being defined locally

3. Code organization improvements:
   - Common utilities and types moved to separate files
   - Each text generation method (OpenAI, Internal API, WebLLM, WLLAMA) now has its dedicated file
   - Removed duplicated code