### PR TITLE
Add AI Horde model selection dropdown

### DIFF
--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -31,6 +31,7 @@ Search results:
   openAiApiKey: "",
   openAiApiModel: "",
   hordeApiKey: "0000000000",
+  hordeModel: "",
   enterToSubmit: true,
   enableAiResponseScrolling: true,
   allowAiModelDownload: false,

--- a/client/modules/textGenerationWithHorde.ts
+++ b/client/modules/textGenerationWithHorde.ts
@@ -26,6 +26,16 @@ interface HordeStatusResponse {
   faulted?: boolean;
 }
 
+interface HordeModelInfo {
+  performance: number;
+  queued: number;
+  jobs: number;
+  eta: number;
+  type: string;
+  name: string;
+  count: number;
+}
+
 const aiHordeApiBaseUrl = "https://aihorde.net/api/v2";
 const aiHordeDefaultApiKey = "0000000000";
 const aiHordeApiKey = getSettings().hordeApiKey || aiHordeDefaultApiKey;
@@ -61,6 +71,7 @@ async function startGeneration(messages: ChatMessage[]) {
       validated_backends: false,
       slow_workers: false,
       extra_slow_workers: false,
+      models: settings.hordeModel ? [settings.hordeModel] : undefined,
     }),
   });
 
@@ -133,6 +144,25 @@ async function handleGenerationStatus(
     }
     throw new Error(`Error while checking generation status: ${error}`);
   }
+}
+
+export async function fetchHordeModels(): Promise<HordeModelInfo[]> {
+  const response = await fetch(
+    `${aiHordeApiBaseUrl}/status/models?type=text&model_state=all`,
+    {
+      method: "GET",
+      headers: {
+        "client-agent": clientAgent,
+        accept: "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch AI Horde models");
+  }
+
+  return response.json();
 }
 
 export async function generateTextWithHorde() {


### PR DESCRIPTION
This PR adds the ability for users to select specific AI Horde models when using the AI Horde inference type.

<img width="345" alt="image" src="https://github.com/user-attachments/assets/107339c8-ed00-4ebc-a1c1-5ea207dc89be" />

Changes:
- Added model selection dropdown in AI settings form
- Implemented API integration to fetch available AI Horde models
- Added model selection state management
- Models list is searchable and allows clearing selection
- When no model is selected, AI Horde automatically selects an available model

Technical Details:
- Added [HordeModelInfo](cci:2://file:///Users/victor/Repositories/MiniSearch/client/modules/textGenerationWithHorde.ts:28:0-36:1) interface for type safety
- Added `hordeModel` setting to store user selection
- Implemented [fetchHordeModels](cci:1://file:///Users/victor/Repositories/MiniSearch/client/modules/textGenerationWithHorde.ts:148:0-165:1) function to retrieve available models
- Modified generation payload to include selected model when specified
- Added proper error handling for model fetching

The dropdown is optional and displays "Auto-selected" when no specific model is chosen, maintaining the existing behavior while adding more control for users who need it.