### PR TITLE
Fix image results eventually appearing duplicated

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -51,7 +51,7 @@ export default function ImageResultsList({
   return (
     <>
       <Carousel slideSize="0" slideGap="xs" align="start" dragFree loop>
-        {imageResults.map(([title, , thumbnailUrl, url], index) => (
+        {imageResults.map(([title, url, thumbnailUrl], index) => (
           <Transition
             key={url}
             mounted={state.canStartTransition}

--- a/server/fetchSearXNG.ts
+++ b/server/fetchSearXNG.ts
@@ -22,12 +22,19 @@ export async function fetchSearXNG(
 ) {
   try {
     if (searchType === "text") {
-      const resultsResponse = await searxng.search(query, {
+      const { results } = await searxng.search(query, {
         categories: ["general"],
       });
 
+      const urls = new Set<string>();
+      const deduplicatedResults = results.filter((result) => {
+        if (urls.has(result.url)) return false;
+        urls.add(result.url);
+        return true;
+      });
+
       const textualResults = await Promise.all(
-        resultsResponse.results.slice(0, limit).map(processTextualResult),
+        deduplicatedResults.slice(0, limit).map(processTextualResult),
       );
 
       return textualResults.filter(
@@ -35,12 +42,19 @@ export async function fetchSearXNG(
       );
     }
 
-    const resultsResponse = await searxng.search(query, {
+    const { results } = await searxng.search(query, {
       categories: ["images", "videos"],
     });
 
+    const urls = new Set<string>();
+    const deduplicatedResults = results.filter((result) => {
+      if (urls.has(result.url)) return false;
+      urls.add(result.url);
+      return true;
+    });
+
     const graphicalResults = await Promise.all(
-      resultsResponse.results.slice(0, limit).map(processGraphicalResult),
+      deduplicatedResults.slice(0, limit).map(processGraphicalResult),
     );
 
     return graphicalResults.filter(


### PR DESCRIPTION
Fixes an issue caused when two or more image results had the same title. This would cause the matching of the images after re-rank to go wrong, and end up showing twice or more the same image in the results.