### PR TITLE
Fix issue preventing typing in the input field from the "Follow-up questions" area

### DIFF
--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -11,6 +11,7 @@ import { IconSend } from "@tabler/icons-react";
 import { usePubSub } from "create-pubsub/react";
 import type { ChatMessage } from "gpt-tokenizer/GptEncoding";
 import {
+  type ChangeEvent,
   type KeyboardEvent,
   Suspense,
   lazy,
@@ -100,6 +101,11 @@ export default function ChatInterface({
     }
   };
 
+  const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const input = event.target.value;
+    setState((prev) => ({ ...prev, input }));
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     handleEnterKeyDown(event, settings, handleSend);
   };
@@ -170,12 +176,7 @@ export default function ChatInterface({
           <Textarea
             placeholder="Anything else you would like to know?"
             value={state.input}
-            onChange={(event) =>
-              setState((prev) => ({
-                ...prev,
-                input: event.currentTarget.value,
-              }))
-            }
+            onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             autosize
             minRows={1}


### PR DESCRIPTION
- Fixes #947

The problem was the `event.currentTarget` used inside the closure of `setState((prev) => {...})`.

When used inside the closure, the value of `event.currentTarget` became `null`, as the target was not the current anymore (in this carried over event). But the `event.target` remained set. So saving the `event.currentTarget` in an constant before passing it to the closure solves the issue. But as the `event.target` was always set with the expected value, it was safer to use it instead.

Below is a description of the change and how to test it.