### PR TITLE
Add browser notification when AI response is ready

### DIFF
--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/modules/history";
 import { handleEnterKeyDown } from "@/modules/keyboard";
 import { addLogEntry } from "@/modules/logEntries";
+import { showAiCompleteNotification } from "@/modules/notifications";
 import {
   chatGenerationStatePubSub,
   chatInputPubSub,
@@ -239,6 +240,9 @@ export default function ChatInterface({
       addLogEntry("AI response re-generated");
 
       if (lastUser?.role === "user") {
+        if (settings.enableNotificationOnAiComplete) {
+          showAiCompleteNotification(lastUser.content);
+        }
         await regenerateFollowUpQuestion(lastUser.content, finalResponse);
       }
     } catch (error) {
@@ -250,6 +254,7 @@ export default function ChatInterface({
     generationState,
     messages,
     regenerateFollowUpQuestion,
+    settings,
     setFollowUpQuestion,
     setGenerationState,
     updateStreamedResponse,
@@ -368,6 +373,10 @@ export default function ChatInterface({
         ]);
 
         addLogEntry("AI response completed");
+
+        if (settings.enableNotificationOnAiComplete) {
+          showAiCompleteNotification(currentInput);
+        }
 
         await saveChatMessageForQuery(currentQuery, "user", currentInput);
         await saveChatMessageForQuery(currentQuery, "assistant", finalResponse);

--- a/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
@@ -71,7 +71,7 @@ export default function AISettingsForm() {
               onChange: handleNotificationToggle,
             })}
             labelPosition="left"
-            description="Show a browser notification when AI summary generation is complete. Useful for longer queries that take time to process."
+            description="Show a browser notification when the AI response is ready. Useful for longer queries that take time to process."
           />
 
           <Stack gap="xs" mb="md">

--- a/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
@@ -4,6 +4,7 @@ import { usePubSub } from "create-pubsub/react";
 import { useMemo } from "react";
 import { settingsPubSub } from "@/modules/pubSub";
 import { inferenceTypes } from "@/modules/settings";
+import { requestNotificationPermission } from "@/modules/notifications";
 import { BrowserSettings } from "./components/BrowserSettings";
 import { HordeSettings } from "./components/HordeSettings";
 import { OpenAISettings } from "./components/OpenAISettings";
@@ -32,6 +33,18 @@ export default function AISettingsForm() {
     [],
   );
 
+  const handleNotificationToggle = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (event.target.checked) {
+      const permission = await requestNotificationPermission();
+      if (permission !== "granted") {
+        return;
+      }
+    }
+    form.setFieldValue("enableNotificationOnAiComplete", event.target.checked);
+  };
+
   return (
     <Stack gap="md">
       <Switch
@@ -43,6 +56,16 @@ export default function AISettingsForm() {
 
       {form.values.enableAiResponse && (
         <>
+          <Switch
+            label="Notification on AI Complete"
+            {...form.getInputProps("enableNotificationOnAiComplete", {
+              type: "checkbox",
+              onChange: handleNotificationToggle,
+            })}
+            labelPosition="left"
+            description="Show a browser notification when AI summary generation is complete. Useful for longer queries that take time to process."
+          />
+
           <Stack gap="xs" mb="md">
             <Text size="sm">Search results to consider</Text>
             <Text size="xs" c="dimmed">

--- a/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
@@ -1,10 +1,11 @@
 import { Select, Slider, Stack, Switch, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
 import { usePubSub } from "create-pubsub/react";
 import { useMemo } from "react";
+import { requestNotificationPermission } from "@/modules/notifications";
 import { settingsPubSub } from "@/modules/pubSub";
 import { inferenceTypes } from "@/modules/settings";
-import { requestNotificationPermission } from "@/modules/notifications";
 import { BrowserSettings } from "./components/BrowserSettings";
 import { HordeSettings } from "./components/HordeSettings";
 import { OpenAISettings } from "./components/OpenAISettings";
@@ -39,6 +40,13 @@ export default function AISettingsForm() {
     if (event.target.checked) {
       const permission = await requestNotificationPermission();
       if (permission !== "granted") {
+        notifications.show({
+          title: "Couldn't enable notifications",
+          message:
+            "Your browser didn't grant permission. Check your notification settings for this site and try again.",
+          color: "red",
+          position: "top-right",
+        });
         return;
       }
     }

--- a/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
@@ -57,7 +57,7 @@ export default function AISettingsForm() {
       {form.values.enableAiResponse && (
         <>
           <Switch
-            label="Notification on AI Complete"
+            label="Notify me when AI response is ready"
             {...form.getInputProps("enableNotificationOnAiComplete", {
               type: "checkbox",
               onChange: handleNotificationToggle,

--- a/client/modules/notifications.test.ts
+++ b/client/modules/notifications.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  requestNotificationPermission,
+  showAiCompleteNotification,
+} from "./notifications";
+
+const addLogEntryMock = vi.fn();
+
+vi.mock("./logEntries", () => ({
+  addLogEntry: (...args: unknown[]) => addLogEntryMock(...args),
+}));
+
+class MockNotification {
+  static permission: NotificationPermission = "default";
+  static requestPermission = vi.fn<() => Promise<NotificationPermission>>();
+  static lastInstance: MockNotification | undefined;
+  title: string;
+  options?: NotificationOptions;
+
+  constructor(title: string, options?: NotificationOptions) {
+    this.title = title;
+    this.options = options;
+    MockNotification.lastInstance = this;
+  }
+}
+
+describe("notifications module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    MockNotification.permission = "default";
+    MockNotification.lastInstance = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("requestNotificationPermission", () => {
+    it("returns denied when the Notification API is unsupported", async () => {
+      const result = await requestNotificationPermission();
+
+      expect(result).toBe("denied");
+    });
+
+    it("returns granted without prompting when already granted", async () => {
+      MockNotification.permission = "granted";
+      vi.stubGlobal("Notification", MockNotification);
+
+      const result = await requestNotificationPermission();
+
+      expect(result).toBe("granted");
+      expect(MockNotification.requestPermission).not.toHaveBeenCalled();
+    });
+
+    it("returns denied without prompting when already denied", async () => {
+      MockNotification.permission = "denied";
+      vi.stubGlobal("Notification", MockNotification);
+
+      const result = await requestNotificationPermission();
+
+      expect(result).toBe("denied");
+      expect(MockNotification.requestPermission).not.toHaveBeenCalled();
+    });
+
+    it("prompts the user when permission has not been decided yet", async () => {
+      MockNotification.permission = "default";
+      MockNotification.requestPermission.mockResolvedValue("granted");
+      vi.stubGlobal("Notification", MockNotification);
+
+      const result = await requestNotificationPermission();
+
+      expect(result).toBe("granted");
+      expect(MockNotification.requestPermission).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("showAiCompleteNotification", () => {
+    it("does nothing when the Notification API is unsupported", () => {
+      expect(() => showAiCompleteNotification("test query")).not.toThrow();
+    });
+
+    it("does nothing when permission is not granted", () => {
+      MockNotification.permission = "default";
+      vi.stubGlobal("Notification", MockNotification);
+
+      showAiCompleteNotification("test query");
+
+      expect(MockNotification.lastInstance).toBeUndefined();
+    });
+
+    it("does nothing when the page already has focus", () => {
+      MockNotification.permission = "granted";
+      vi.stubGlobal("Notification", MockNotification);
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+      showAiCompleteNotification("test query");
+
+      expect(MockNotification.lastInstance).toBeUndefined();
+    });
+
+    it("shows a notification with the query in the body when granted and unfocused", () => {
+      MockNotification.permission = "granted";
+      vi.stubGlobal("Notification", MockNotification);
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+      showAiCompleteNotification("capital of France");
+
+      expect(MockNotification.lastInstance?.title).toBe(
+        "MiniSearch: AI response is ready",
+      );
+      expect(MockNotification.lastInstance?.options?.body).toContain(
+        "capital of France",
+      );
+      expect(MockNotification.lastInstance?.options?.icon).toBe("/favicon.png");
+    });
+
+    it("truncates very long queries in the notification body", () => {
+      MockNotification.permission = "granted";
+      vi.stubGlobal("Notification", MockNotification);
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      const longQuery = "a".repeat(200);
+
+      showAiCompleteNotification(longQuery);
+
+      const body = MockNotification.lastInstance?.options?.body ?? "";
+      expect(body.length).toBeLessThan(longQuery.length);
+    });
+
+    it("logs instead of throwing when the browser rejects the constructor", () => {
+      class ThrowingNotification extends MockNotification {
+        constructor(title: string, options?: NotificationOptions) {
+          super(title, options);
+          throw new TypeError("Illegal constructor");
+        }
+      }
+      ThrowingNotification.permission = "granted";
+      vi.stubGlobal("Notification", ThrowingNotification);
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+      expect(() => showAiCompleteNotification("test query")).not.toThrow();
+      expect(addLogEntryMock).toHaveBeenCalledWith(
+        expect.stringContaining("Illegal constructor"),
+      );
+    });
+  });
+});

--- a/client/modules/notifications.test.ts
+++ b/client/modules/notifications.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  REQUEST_PERMISSION_TIMEOUT_MS,
   requestNotificationPermission,
   showAiCompleteNotification,
 } from "./notifications";
@@ -73,6 +74,24 @@ describe("notifications module", () => {
 
       expect(result).toBe("granted");
       expect(MockNotification.requestPermission).toHaveBeenCalledOnce();
+    });
+
+    it("falls back to default if the browser never responds to the request", async () => {
+      vi.useFakeTimers();
+      try {
+        MockNotification.permission = "default";
+        MockNotification.requestPermission.mockReturnValue(
+          new Promise(() => {}),
+        );
+        vi.stubGlobal("Notification", MockNotification);
+
+        const resultPromise = requestNotificationPermission();
+        await vi.advanceTimersByTimeAsync(REQUEST_PERMISSION_TIMEOUT_MS);
+
+        expect(await resultPromise).toBe("default");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/client/modules/notifications.test.ts
+++ b/client/modules/notifications.test.ts
@@ -100,23 +100,21 @@ describe("notifications module", () => {
       expect(MockNotification.lastInstance).toBeUndefined();
     });
 
-    it("shows a notification with the query in the body when granted and unfocused", () => {
+    it("shows a notification with the query as the title when granted and unfocused", () => {
       MockNotification.permission = "granted";
       vi.stubGlobal("Notification", MockNotification);
       vi.spyOn(document, "hasFocus").mockReturnValue(false);
 
       showAiCompleteNotification("capital of France");
 
-      expect(MockNotification.lastInstance?.title).toBe(
-        "MiniSearch: AI response is ready",
-      );
-      expect(MockNotification.lastInstance?.options?.body).toContain(
-        "capital of France",
+      expect(MockNotification.lastInstance?.title).toBe("capital of France");
+      expect(MockNotification.lastInstance?.options?.body).toBe(
+        "AI response is ready on MiniSearch.",
       );
       expect(MockNotification.lastInstance?.options?.icon).toBe("/favicon.png");
     });
 
-    it("truncates very long queries in the notification body", () => {
+    it("truncates very long queries in the notification title", () => {
       MockNotification.permission = "granted";
       vi.stubGlobal("Notification", MockNotification);
       vi.spyOn(document, "hasFocus").mockReturnValue(false);
@@ -124,8 +122,8 @@ describe("notifications module", () => {
 
       showAiCompleteNotification(longQuery);
 
-      const body = MockNotification.lastInstance?.options?.body ?? "";
-      expect(body.length).toBeLessThan(longQuery.length);
+      const title = MockNotification.lastInstance?.title ?? "";
+      expect(title.length).toBeLessThan(longQuery.length);
     });
 
     it("logs instead of throwing when the browser rejects the constructor", () => {

--- a/client/modules/notifications.ts
+++ b/client/modules/notifications.ts
@@ -2,8 +2,13 @@ import { addLogEntry } from "./logEntries";
 
 const MAX_NOTIFICATION_QUERY_LENGTH = 100;
 
+export const REQUEST_PERMISSION_TIMEOUT_MS = 8000;
+
 /**
- * Requests permission to show browser notifications
+ * Requests permission to show browser notifications. Some browsers can
+ * silently never resolve this request (e.g. Brave has been observed doing
+ * this on localhost), so it falls back to "default" after a timeout instead
+ * of leaving the caller waiting forever
  * @returns Promise resolving to the notification permission state
  */
 export async function requestNotificationPermission(): Promise<NotificationPermission> {
@@ -15,11 +20,21 @@ export async function requestNotificationPermission(): Promise<NotificationPermi
     return "granted";
   }
 
-  if (Notification.permission !== "denied") {
-    return await Notification.requestPermission();
+  if (Notification.permission === "denied") {
+    return "denied";
   }
 
-  return "denied";
+  return new Promise((resolve) => {
+    const timeoutId = setTimeout(
+      () => resolve("default"),
+      REQUEST_PERMISSION_TIMEOUT_MS,
+    );
+
+    Notification.requestPermission().then((permission) => {
+      clearTimeout(timeoutId);
+      resolve(permission);
+    });
+  });
 }
 
 /**

--- a/client/modules/notifications.ts
+++ b/client/modules/notifications.ts
@@ -1,6 +1,6 @@
-/**
- * Browser notification module for AI completion alerts
- */
+import { addLogEntry } from "./logEntries";
+
+const MAX_NOTIFICATION_QUERY_LENGTH = 100;
 
 /**
  * Requests permission to show browser notifications
@@ -23,7 +23,8 @@ export async function requestNotificationPermission(): Promise<NotificationPermi
 }
 
 /**
- * Shows a browser notification when AI generation is complete
+ * Shows a browser notification when AI generation is complete, unless the
+ * user already has this page focused
  * @param query - The search query that triggered the AI generation
  */
 export function showAiCompleteNotification(query: string) {
@@ -35,10 +36,25 @@ export function showAiCompleteNotification(query: string) {
     return;
   }
 
-  new Notification("MiniSearch: AI response is ready", {
-    body: `Your search for "${query}" has finished generating a summary.`,
-    icon: "/favicon.ico",
-    tag: "ai-complete",
-    requireInteraction: false,
-  });
+  if (document.hasFocus()) {
+    return;
+  }
+
+  const truncatedQuery =
+    query.length > MAX_NOTIFICATION_QUERY_LENGTH
+      ? `${query.slice(0, MAX_NOTIFICATION_QUERY_LENGTH)}…`
+      : query;
+
+  try {
+    new Notification("MiniSearch: AI response is ready", {
+      body: `Your search for "${truncatedQuery}" has finished generating a summary.`,
+      icon: "/favicon.png",
+      tag: "ai-complete",
+      requireInteraction: false,
+    });
+  } catch (error) {
+    addLogEntry(
+      `Failed to show AI-complete notification: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }

--- a/client/modules/notifications.ts
+++ b/client/modules/notifications.ts
@@ -35,7 +35,7 @@ export function showAiCompleteNotification(query: string) {
     return;
   }
 
-  new Notification("MiniSearch - AI Summary Complete", {
+  new Notification("MiniSearch: AI response is ready", {
     body: `Your search for "${query}" has finished generating a summary.`,
     icon: "/favicon.ico",
     tag: "ai-complete",

--- a/client/modules/notifications.ts
+++ b/client/modules/notifications.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser notification module for AI completion alerts
+ */
+
+/**
+ * Requests permission to show browser notifications
+ * @returns Promise resolving to the notification permission state
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!("Notification" in window)) {
+    return "denied";
+  }
+
+  if (Notification.permission === "granted") {
+    return "granted";
+  }
+
+  if (Notification.permission !== "denied") {
+    return await Notification.requestPermission();
+  }
+
+  return "denied";
+}
+
+/**
+ * Shows a browser notification when AI generation is complete
+ * @param query - The search query that triggered the AI generation
+ */
+export function showAiCompleteNotification(query: string) {
+  if (!("Notification" in window)) {
+    return;
+  }
+
+  if (Notification.permission !== "granted") {
+    return;
+  }
+
+  new Notification("MiniSearch - AI Summary Complete", {
+    body: `Your search for "${query}" has finished generating a summary.`,
+    icon: "/favicon.ico",
+    tag: "ai-complete",
+    requireInteraction: false,
+  });
+}

--- a/client/modules/notifications.ts
+++ b/client/modules/notifications.ts
@@ -46,8 +46,8 @@ export function showAiCompleteNotification(query: string) {
       : query;
 
   try {
-    new Notification("MiniSearch: AI response is ready", {
-      body: `Your search for "${truncatedQuery}" has finished generating a summary.`,
+    new Notification(truncatedQuery, {
+      body: "AI response is ready on MiniSearch.",
       icon: "/favicon.png",
       tag: "ai-complete",
       requireInteraction: false,

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -43,6 +43,7 @@ Search results:
   selectedVoiceId: "",
   reasoningStartMarker: "<think>",
   reasoningEndMarker: "</think>",
+  enableNotificationOnAiComplete: false,
 };
 
 addLogEntry(

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -1,11 +1,12 @@
 import gptTokenizer from "gpt-tokenizer";
 import prettyMilliseconds from "pretty-ms";
+import { addLogEntry } from "./logEntries";
 import {
   getCurrentSearchRunId,
   saveLlmResponseForQuery,
   updateSearchResults,
 } from "./history";
-import { addLogEntry } from "./logEntries";
+import { showAiCompleteNotification } from "./notifications";
 import {
   getConversationSummary,
   getQuery,
@@ -233,6 +234,10 @@ export async function searchAndRespond() {
     }
 
     updateTextGenerationState("completed");
+
+    if (settings.enableNotificationOnAiComplete) {
+      showAiCompleteNotification(getQuery());
+    }
   } catch (error) {
     if (getTextGenerationState() !== "interrupted") {
       addLogEntry(`Error generating text: ${error}`);

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -1,11 +1,11 @@
 import gptTokenizer from "gpt-tokenizer";
 import prettyMilliseconds from "pretty-ms";
-import { addLogEntry } from "./logEntries";
 import {
   getCurrentSearchRunId,
   saveLlmResponseForQuery,
   updateSearchResults,
 } from "./history";
+import { addLogEntry } from "./logEntries";
 import { showAiCompleteNotification } from "./notifications";
 import {
   getConversationSummary,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ Settings are stored in browser localStorage and can be changed via the Settings 
 | `systemPrompt` | string | (template) | Custom system prompt template for AI |
 | `enterToSubmit` | boolean | `true` | Press Enter to submit query (vs Shift+Enter for new line) |
 | `enableAiResponseScrolling` | boolean | `true` | Auto-scroll AI response as it generates |
+| `enableNotificationOnAiComplete` | boolean | `false` | Show a browser notification when AI response generation finishes |
 
 ### Inference Settings
 


### PR DESCRIPTION
## Summary
Implements the feature requested in #2097 to show browser notifications when AI summary generation completes.

## Changes
- Added enableNotificationOnAiComplete setting to toggle notifications
- Created new notifications.ts module with permission request and notification display functions
- Integrated notification trigger in searchAndRespond() when AI generation completes
- Added UI toggle in AI Settings with automatic permission request on enable

## User Experience
- Users can enable 'Notify me when AI response is ready' in AI Settings
<img width="417" height="285" alt="image" src="https://github.com/user-attachments/assets/cbbceb14-90d6-4083-ad9e-532be7b43b98" />

- Browser requests notification permission when first enabled
- When a long-running AI query completes, a notification appears
<img width="351" height="80" alt="image" src="https://github.com/user-attachments/assets/27ccd696-31db-4909-829c-ba702360754f" />

- Users can navigate away during processing and return when notified

## Testing
- Build passes successfully
- Notification only shows when setting is enabled and permission is granted
- Works with all inference types (browser, OpenAI, AI Horde, Internal API)