### PR TITLE
Remove searchResultsToConsider setting and hardcode to 6

### DIFF
--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -21,7 +21,6 @@ import {
   chatGenerationStatePubSub,
   chatInputPubSub,
   followUpQuestionPubSub,
-  getSettings,
   imageSearchResultsPubSub,
   queryPubSub,
   settingsPubSub,
@@ -297,9 +296,7 @@ export default function ChatInterface({
               ([, , url]) => !existingUrls.has(url),
             );
 
-            updateLlmTextSearchResults(
-              freshResults.slice(0, getSettings().searchResultsToConsider),
-            );
+            updateLlmTextSearchResults(freshResults.slice(0, 6));
 
             if (uniqueFreshResults.length > 0) {
               const updatedResults = [

--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -33,6 +33,7 @@ import {
 import { generateRelatedSearchQuery } from "@/modules/relatedSearchQuery";
 import { searchImages, searchText } from "@/modules/search";
 import { generateChatResponse } from "@/modules/textGeneration";
+import { searchResultsToConsider } from "@/modules/textGenerationUtilities";
 import type { ChatMessage } from "@/modules/types";
 import ChatHeader from "./ChatHeader";
 import ChatInputArea from "./ChatInputArea";
@@ -296,7 +297,9 @@ export default function ChatInterface({
               ([, , url]) => !existingUrls.has(url),
             );
 
-            updateLlmTextSearchResults(freshResults.slice(0, 6));
+            updateLlmTextSearchResults(
+              freshResults.slice(0, searchResultsToConsider),
+            );
 
             if (uniqueFreshResults.length > 0) {
               const updatedResults = [

--- a/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
@@ -1,8 +1,7 @@
-import { Select, Slider, Stack, Switch, Text, TextInput } from "@mantine/core";
+import { Select, Stack, Switch, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import { usePubSub } from "create-pubsub/react";
-import { useMemo } from "react";
 import { requestNotificationPermission } from "@/modules/notifications";
 import { settingsPubSub } from "@/modules/pubSub";
 import { inferenceTypes } from "@/modules/settings";
@@ -24,15 +23,6 @@ export default function AISettingsForm() {
     initialValues: settings,
     onValuesChange: setSettings,
   });
-
-  const searchResultsToConsiderSliderMarks = useMemo(
-    () =>
-      Array.from({ length: 7 }, (_, index) => ({
-        value: index,
-        label: index.toString(),
-      })),
-    [],
-  );
 
   const handleNotificationToggle = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -74,21 +64,6 @@ export default function AISettingsForm() {
             labelPosition="left"
             description="Show a browser notification when the AI response is ready. Useful for longer queries that take time to process."
           />
-
-          <Stack gap="xs" mb="md">
-            <Text size="sm">Search results to consider</Text>
-            <Text size="xs" c="dimmed">
-              Determines the number of search results to consider when
-              generating AI responses. A higher value may enhance accuracy, but
-              it will also increase response time.
-            </Text>
-            <Slider
-              {...form.getInputProps("searchResultsToConsider")}
-              min={0}
-              max={6}
-              marks={searchResultsToConsiderSliderMarks}
-            />
-          </Stack>
 
           <Select
             {...form.getInputProps("inferenceType")}

--- a/client/modules/settings.test.ts
+++ b/client/modules/settings.test.ts
@@ -6,7 +6,6 @@ describe("Settings Module", () => {
     expect(defaultSettings.showEnableAiResponsePrompt).toBe(true);
     expect(defaultSettings.enableAiResponse).toBe(false);
     expect(defaultSettings.enableImageSearch).toBe(true);
-    expect(defaultSettings.searchResultsToConsider).toBe(3);
     expect(defaultSettings.searchResultsLimit).toBe(15);
     expect(defaultSettings.inferenceType).toBeDefined();
   });

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -9,7 +9,6 @@ export const defaultSettings = {
   enableImageSearch: true,
   wllamaModelId: VITE_WLLAMA_DEFAULT_MODEL_ID,
   cpuThreads: Math.max(1, (navigator.hardwareConcurrency ?? 1) - 2),
-  searchResultsToConsider: 3,
   searchResultsLimit: 15,
   systemPrompt: `Answer using the search results below as your primary source, supplemented by your own knowledge when needed. Write your response in the same language as the query.
 

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -403,9 +403,7 @@ async function startTextSearch(query: string) {
       results.textResults.length === 0 ? "failed" : "completed",
     );
     updateTextSearchResults(textResults);
-    updateLlmTextSearchResults(
-      textResults.slice(0, getSettings().searchResultsToConsider),
-    );
+    updateLlmTextSearchResults(textResults.slice(0, 6));
 
     updateSearchResults(getCurrentSearchRunId(), {
       type: "text",

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -31,6 +31,7 @@ import {
   ChatGenerationError,
   defaultContextSize,
   getFormattedSearchResults,
+  searchResultsToConsider,
 } from "./textGenerationUtilities";
 import type {
   ChatMessage,
@@ -403,7 +404,7 @@ async function startTextSearch(query: string) {
       results.textResults.length === 0 ? "failed" : "completed",
     );
     updateTextSearchResults(textResults);
-    updateLlmTextSearchResults(textResults.slice(0, 6));
+    updateLlmTextSearchResults(textResults.slice(0, searchResultsToConsider));
 
     updateSearchResults(getCurrentSearchRunId(), {
       type: "text",

--- a/client/modules/textGenerationUtilities.ts
+++ b/client/modules/textGenerationUtilities.ts
@@ -14,6 +14,11 @@ import type { ChatMessage } from "./types";
 export const defaultContextSize = 4096;
 
 /**
+ * Number of top text search results included in the AI context
+ */
+export const searchResultsToConsider = 6;
+
+/**
  * Custom error class for chat generation failures
  */
 export class ChatGenerationError extends Error {

--- a/client/modules/textGenerationUtilities.ts
+++ b/client/modules/textGenerationUtilities.ts
@@ -48,10 +48,8 @@ export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
  * Waits for search results if they are required before starting response generation
  */
 export async function canStartResponding() {
-  if (getSettings().searchResultsToConsider > 0) {
-    updateTextGenerationState("awaitingSearchResults");
-    await getSearchPromise();
-  }
+  updateTextGenerationState("awaitingSearchResults");
+  await getSearchPromise();
 }
 
 /**

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -336,12 +336,10 @@ Wllama models are sharded (split into chunks):
 
 ### For Maximum Quality
 - Use OpenAI GPT-4 or Internal API with large model
-- Set `searchResultsToConsider: 5-10`
 - Adjust temperature: 0.5-0.7 for factual, 0.8-1.0 for creative
 
 ### For Cost Efficiency
 - Use AI Horde (free) or Browser inference - Wllama (one-time download)
-- Set `searchResultsToConsider: 3` (default)
 - Limit `inferenceMaxTokens: 2048`
 
 ### For Teams/Enterprise

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -201,6 +201,8 @@ Stream response via selected inference type
 Update PubSub channels (response, textGenerationState)
 ```
 
+The AI context includes the top 6 text search results (a fixed value, `searchResultsToConsider` in `client/modules/textGenerationUtilities.ts`), not a user-configurable setting.
+
 ### Chat Generation
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,6 @@ Settings are stored in browser localStorage and can be changed via the Settings 
 | `showEnableAiResponsePrompt` | boolean | `true` | Show prompt to enable AI response on first use |
 | `enableImageSearch` | boolean | `true` | Include image results in searches |
 | `enableTextSearch` | boolean | `true` | Include text results in searches |
-| `searchResultsToConsider` | number | `3` | Number of top search results to include in AI context |
 | `searchResultsLimit` | number | `15` | Maximum search results to fetch |
 | `systemPrompt` | string | (template) | Custom system prompt template for AI |
 | `enterToSubmit` | boolean | `true` | Press Enter to submit query (vs Shift+Enter for new line) |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -133,7 +133,7 @@ MiniSearch uses a PubSub-based architecture where state flows through independen
 - `idle` - No active generation
 - `awaitingModelDownloadAllowance` - Waiting for user consent to download a browser model
 - `loadingModel` - Downloading or initializing the browser (Wllama) model
-- `awaitingSearchResults` - Waiting for search to complete before generating (only when `searchResultsToConsider > 0`)
+- `awaitingSearchResults` - Waiting for search to complete before generating
 - `preparingToGenerate` - Building the prompt/request just before calling the inference backend (OpenAI-compatible, Internal API, and AI Horde paths)
 - `generating` - Streaming response tokens
 - `interrupted` - Generation was cancelled by the user


### PR DESCRIPTION
## Summary

Remove the `searchResultsToConsider` slider from AI settings and hardcode the value to 6.

## Changes

- **Removed** `searchResultsToConsider` from `defaultSettings` in `client/modules/settings.ts`
- **Removed** the slider UI from `AISettingsForm.tsx` (including the `useMemo` for marks and unused imports)
- **Updated** `canStartResponding()` in `textGenerationUtilities.ts` to always wait for search results (removed the `> 0` guard)
- **Hardcoded** `6` in `textGeneration.ts` and `ChatInterface.tsx` where `searchResultsToConsider` was used for slicing results
- **Updated** tests in `settings.test.ts`
- **Updated** documentation: `configuration.md`, `ai-integration.md`, `overview.md`

## Rationale

The default value of 3 was too few for good LLM responses. Hardcoding to 6 gives the model more context without requiring user configuration. The slider was a false choice — most users left it at 3, which produced suboptimal results.