### PR TITLE
Harden CI workflows and Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -27,7 +29,7 @@ jobs:
         run: npm run lint
 
       - name: Check formatting
-        run: npm run format
+        run: npm run format:check
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/deploy-to-hugging-face.yml
+++ b/.github/workflows/deploy-to-hugging-face.yml
@@ -7,9 +7,11 @@ jobs:
   sync-to-hf:
     name: Sync to Hugging Face Spaces
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: JacobLinCool/huggingface-sync@v1
+      - uses: JacobLinCool/huggingface-sync@3e022764ae2defd53d9fed4633f522c0f0f3d116 # v1.3.1
         with:
           github: ${{ secrets.GITHUB_TOKEN }}
           user: ${{ vars.HF_SPACE_OWNER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts AS llama-builder
 
 ARG LLAMA_CPP_RELEASE_TAG="b6604"
+ARG SEARXNG_RELEASE_TAG="6da6eee265daeb4a62ab638d6921522bf405de69"
 
 RUN apt-get update && apt-get install -y \
   build-essential \
@@ -19,6 +20,8 @@ RUN cd /tmp && \
   find build -type f \( -name "libllama.so" -o -name "libmtmd.so" -o -name "libggml.so" -o -name "libggml-base.so" -o -name "libggml-cpu.so" \) -exec cp {} /usr/local/lib/llama/ \;
 
 FROM node:lts
+
+ARG SEARXNG_RELEASE_TAG
 
 ENV PORT=7860
 EXPOSE $PORT
@@ -45,6 +48,9 @@ RUN python3 -m venv searxng-venv && \
   /usr/local/searxng/searxng-venv/bin/pip install wheel setuptools pyyaml lxml
 
 RUN git clone https://github.com/searxng/searxng.git /usr/local/searxng/searxng-src && \
+  cd /usr/local/searxng/searxng-src && \
+  git checkout $SEARXNG_RELEASE_TAG && \
+  cd - && \
   chown -R ${USERNAME}:${USERNAME} /usr/local/searxng/searxng-src
 
 ARG SEARXNG_SETTINGS_PATH="/etc/searxng/settings.yml"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "vite",
     "lint": "biome check && tsc && knip && jscpd client server --ignore-pattern \"**/dist/**\" && node scripts/architectural-linter.cjs && node scripts/doc-gardening.cjs && node scripts/documentation-validator.cjs",
     "format": "biome check --write",
+    "format:check": "biome check",
     "prepare": "husky",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
Fixes #2129. Addresses the hardening items: workflow permissions,
CI format gate, and Docker build reproducibility.

## Changes
- **Workflow permissions**: `ci.yml` and `deploy-to-hugging-face.yml`
  now set explicit `permissions: contents: read` at the job level,
  matching the pattern already used in `publish-docker-image.yml`.
- **Format gate**: added a `format:check` script (`biome check`,
  no `--write`) and pointed CI's "Check formatting" step at it,
  since the previous `npm run format` auto-fixes and can pass even
  when there's unformatted code.
- **SearXNG pin**: SearXNG has no release tags (rolling release from
  `master`), so I pinned to a commit SHA instead, following the same
  `ARG`-based pattern already used for llama.cpp.
- **huggingface-sync pin**: SHA-pinned to v1.3.1 (the latest tagged
  release) instead of the `v1` branch, with a comment for readability.

## Not addressed in this PR
`skip-test-lint-ping` label — I searched the repo and couldn't find
any reference to it in workflows, configs, or code, so this looks
safe to delete. Since that's a repo-settings change rather than a
file change, I didn't include it here — let me know if you'd like me
to do anything further on that.