### PR TITLE
GNX-2124: Type-check the server/ folder in the lint gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "vite preview",
     "build": "vite build",
     "dev": "vite",
-    "lint": "biome check && tsc && knip && jscpd client server --ignore-pattern \"**/dist/**\" && node scripts/architectural-linter.cjs && node scripts/doc-gardening.cjs && node scripts/documentation-validator.cjs",
+    "lint": "biome check && tsc && tsc -p tsconfig.node.json --noEmit && knip && jscpd client server --ignore-pattern \"**/dist/**\" && node scripts/architectural-linter.cjs && node scripts/doc-gardening.cjs && node scripts/documentation-validator.cjs",
     "format": "biome check --write",
     "prepare": "husky",
     "test": "vitest run",

--- a/server/helper-git-hash.d.ts
+++ b/server/helper-git-hash.d.ts
@@ -1,0 +1,7 @@
+declare module "helper-git-hash" {
+  interface GitHashOptions {
+    short?: boolean;
+    cwd?: string;
+  }
+  export default function gitHash(options?: GitHashOptions): string;
+}

--- a/server/http-compression.d.ts
+++ b/server/http-compression.d.ts
@@ -1,0 +1,18 @@
+declare module "http-compression" {
+  import { IncomingMessage, ServerResponse } from "http";
+
+  interface Options {
+    gzip?: {
+      threshold?: number;
+      flush?: number;
+    };
+    brotli?: {
+      threshold?: number;
+      flush?: number;
+    };
+  }
+
+  export default function compression(
+    options?: Options,
+  ): (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,7 +5,8 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts", "server", "shared"]
 }


### PR DESCRIPTION
## Summary
Fixes #2124. The `server/` folder was never type-checked by `tsc` because `tsconfig.json` only includes `client`, `shared`, and `test`. The `tsconfig.node.json` that includes `server/` was never invoked with `-p`.

## Changes
- **tsconfig.node.json**: Added `strict: true` so server code gets the same null-checking the client already has
- **server/http-compression.d.ts**: New declaration file for `http-compression` (no `@types` package available)
- **server/helper-git-hash.d.ts**: New declaration file for `helper-git-hash` (no `@types` package available)
- **package.json**: Added `tsc -p tsconfig.node.json --noEmit` to the `lint` script so server type errors fail CI

## Verification
- `npm run lint` passes clean
- `tsc -p tsconfig.node.json --noEmit` reports zero errors
- Introducing a type error in `server/` now correctly fails CI