### PR TITLE
Clamp max_tokens on the /inference proxy (and wire up the unused getModelConfig)

### DIFF
--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -6,6 +6,7 @@ import {
   listOpenAiCompatibleModels,
   selectRandomModel,
 } from "../shared/openaiModels";
+import { getModelConfig } from "./config/modelConfig";
 import { handleTokenVerification } from "./handleTokenVerification";
 import {
   calculateBackoffTime,
@@ -245,9 +246,21 @@ export function internalApiEndpointServerHook<
           return;
         }
 
+        const config = getModelConfig();
         const maxAttempts = 5;
         let lastError: unknown = null;
         let hasStartedStreaming = false;
+
+        // Clamp sampling params to prevent abuse
+        const clampedMaxTokens = requestBody.max_tokens
+          ? Math.min(requestBody.max_tokens, config.defaultMaxTokens)
+          : undefined;
+        const clampedTemperature = requestBody.temperature
+          ? Math.max(0, Math.min(requestBody.temperature, 2))
+          : undefined;
+        const clampedTopP = requestBody.top_p
+          ? Math.max(0, Math.min(requestBody.top_p, 1))
+          : undefined;
 
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
           if (!model) break;
@@ -268,9 +281,9 @@ export function internalApiEndpointServerHook<
             const stream = streamText({
               model: openaiProvider.chatModel(model),
               messages: requestBody.messages,
-              temperature: requestBody.temperature,
-              topP: requestBody.top_p,
-              maxOutputTokens: requestBody.max_tokens,
+              temperature: clampedTemperature,
+              topP: clampedTopP,
+              maxOutputTokens: clampedMaxTokens,
               maxRetries: 0,
             });
 

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -251,7 +251,6 @@ export function internalApiEndpointServerHook<
         let lastError: unknown = null;
         let hasStartedStreaming = false;
 
-        // Clamp sampling params to prevent abuse
         const clampedMaxTokens = requestBody.max_tokens
           ? Math.min(requestBody.max_tokens, config.defaultMaxTokens)
           : undefined;

--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { rerank } from "./rerankerService";
 
-const mockRerank = vi.fn(() => []);
+const mockRerank = vi.fn<typeof rerank>();
 
 vi.mock("./rerankerService", () => ({
-  rerank: (...args: unknown[]) => mockRerank(...args),
+  rerank: mockRerank,
 }));
 
 beforeEach(() => {
@@ -12,7 +13,9 @@ beforeEach(() => {
 
 describe("rankSearchResults", () => {
   it("should return empty array when no results provided", async () => {
-    mockRerank.mockResolvedValue([]);
+    mockRerank.mockResolvedValue(
+      [] as { index: number; relevance_score: number }[],
+    );
     const { rankSearchResults } = await import("./rankSearchResults");
     const result = await rankSearchResults("test query", []);
     expect(result).toEqual([]);
@@ -23,7 +26,7 @@ describe("rankSearchResults", () => {
     mockRerank.mockResolvedValue([
       { index: 0, relevance_score: 0.9 },
       { index: 1, relevance_score: 0.5 },
-    ]);
+    ] as { index: number; relevance_score: number }[]);
     const { rankSearchResults } = await import("./rankSearchResults");
     await rankSearchResults("Test Query", [
       ["Title A", "Content A", "https://a.com"],
@@ -42,7 +45,7 @@ describe("rankSearchResults", () => {
     mockRerank.mockResolvedValue([
       { index: 0, relevance_score: 0.9 },
       { index: 1, relevance_score: 0.8 },
-    ]);
+    ] as { index: number; relevance_score: number }[]);
     const { rankSearchResults } = await import("./rankSearchResults");
     const result = await rankSearchResults("query", [
       ["A", "a", "https://a.com"],
@@ -56,7 +59,7 @@ describe("rankSearchResults", () => {
     mockRerank.mockResolvedValue([
       { index: 0, relevance_score: 0.95 },
       { index: 1, relevance_score: 0.8 },
-    ]);
+    ] as { index: number; relevance_score: number }[]);
     const { rankSearchResults } = await import("./rankSearchResults");
     const result = await rankSearchResults(
       "query",
@@ -70,7 +73,9 @@ describe("rankSearchResults", () => {
   });
 
   it("should return empty array when rerank returns no results", async () => {
-    mockRerank.mockResolvedValue([]);
+    mockRerank.mockResolvedValue(
+      [] as { index: number; relevance_score: number }[],
+    );
     const { rankSearchResults } = await import("./rankSearchResults");
     const result = await rankSearchResults("query", [
       ["A", "a", "https://a.com"],
@@ -79,7 +84,10 @@ describe("rankSearchResults", () => {
   });
 
   it("should truncate document strings to MAX_DOCUMENT_LENGTH", async () => {
-    mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }]);
+    mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }] as {
+      index: number;
+      relevance_score: number;
+    }[]);
     const { rankSearchResults } = await import("./rankSearchResults");
     const longTitle = "A".repeat(600);
     await rankSearchResults("query", [[longTitle, "short", "https://a.com"]]);
@@ -88,7 +96,10 @@ describe("rankSearchResults", () => {
   });
 
   it("should replace double quotes with single quotes in snippet", async () => {
-    mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }]);
+    mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }] as {
+      index: number;
+      relevance_score: number;
+    }[]);
     const { rankSearchResults } = await import("./rankSearchResults");
     await rankSearchResults("query", [
       ["Title", 'Content with "quotes"', "https://a.com"],


### PR DESCRIPTION
## Summary
Fixes #2125. The `/inference` proxy forwarded `max_tokens`, `temperature`, and `top_p` from the client directly to the model with no upper bound, allowing a client to request very large completions and run up the operator's bill. `getModelConfig()` was dead code — now it's wired up.

## Changes
- **server/internalApiEndpointServerHook.ts**: Import `getModelConfig()` and clamp sampling params before passing to `streamText`:
  - `max_tokens`: clamped to `min(requested, defaultMaxTokens)` (default 2048)
  - `temperature`: clamped to [0, 2]
  - `top_p`: clamped to [0, 1]

## Verification
- `npm run lint` passes clean
- `tsc -p tsconfig.node.json --noEmit` reports zero errors