### PR TITLE
Key rate limiter on client IP and add verifiedTokens cleanup

### DIFF
--- a/server/handleTokenVerification.ts
+++ b/server/handleTokenVerification.ts
@@ -1,13 +1,16 @@
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { verifyTokenAndRateLimit } from "./verifyTokenAndRateLimit";
 
 /** Handles token verification and sends appropriate error responses if needed. */
 export async function handleTokenVerification(
   token: string | null,
   response: ServerResponse,
+  request?: IncomingMessage,
 ): Promise<{ shouldContinue: boolean }> {
-  const { isAuthorized, statusCode, error } =
-    await verifyTokenAndRateLimit(token);
+  const { isAuthorized, statusCode, error } = await verifyTokenAndRateLimit(
+    token,
+    request,
+  );
 
   if (!isAuthorized && statusCode && error) {
     response.statusCode = statusCode;

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -163,7 +163,11 @@ export function internalApiEndpointServerHook<
           : "http://localhost";
       const url = new URL(request.url, baseUrl);
       const token = url.searchParams.get("token");
-      const { shouldContinue } = await handleTokenVerification(token, response);
+      const { shouldContinue } = await handleTokenVerification(
+        token,
+        response,
+        request,
+      );
       if (!shouldContinue) return;
 
       if (

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -91,7 +91,11 @@ export function searchEndpointServerHook<
       return;
     }
 
-    const { shouldContinue } = await handleTokenVerification(token, response);
+    const { shouldContinue } = await handleTokenVerification(
+      token,
+      response,
+      request,
+    );
 
     if (!shouldContinue) return;
 

--- a/server/verifiedTokens.ts
+++ b/server/verifiedTokens.ts
@@ -1,7 +1,35 @@
 /**
- * Set of verified tokens for session management
+ * Set of verified tokens for session management.
+ * Tokens are cleaned up every 60 seconds to prevent unbounded growth.
  */
 const verifiedTokens = new Set<string>();
+const CLEANUP_INTERVAL_MS = 60_000;
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Cleans up old entries from the verified tokens set.
+ * Since tokens are short-lived (used per-request), we simply
+ * clear the set periodically to prevent unbounded growth.
+ */
+function cleanupVerifiedTokens(): void {
+  verifiedTokens.clear();
+}
+
+/**
+ * Starts the periodic cleanup timer if not already running.
+ */
+function startCleanupTimer(): void {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(cleanupVerifiedTokens, CLEANUP_INTERVAL_MS);
+  // Prevent the timer from keeping the process alive
+  if (cleanupTimer.unref) {
+    cleanupTimer.unref();
+  }
+}
+
+// Start cleanup on module load
+startCleanupTimer();
 
 /**
  * Gets the number of verified tokens

--- a/server/verifiedTokens.ts
+++ b/server/verifiedTokens.ts
@@ -1,58 +1,31 @@
-/**
- * Set of verified tokens for session management.
- * Tokens are cleaned up every 60 seconds to prevent unbounded growth.
- */
+/** Set of verified tokens for session management. */
 const verifiedTokens = new Set<string>();
 const CLEANUP_INTERVAL_MS = 60_000;
 
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
-/**
- * Cleans up old entries from the verified tokens set.
- * Since tokens are short-lived (used per-request), we simply
- * clear the set periodically to prevent unbounded growth.
- */
 function cleanupVerifiedTokens(): void {
   verifiedTokens.clear();
 }
 
-/**
- * Starts the periodic cleanup timer if not already running.
- */
 function startCleanupTimer(): void {
   if (cleanupTimer) return;
   cleanupTimer = setInterval(cleanupVerifiedTokens, CLEANUP_INTERVAL_MS);
-  // Prevent the timer from keeping the process alive
   if (cleanupTimer.unref) {
     cleanupTimer.unref();
   }
 }
 
-// Start cleanup on module load
 startCleanupTimer();
 
-/**
- * Gets the number of verified tokens
- * @returns Number of verified tokens
- */
 export function getVerifiedTokensAmount() {
   return verifiedTokens.size;
 }
 
-/**
- * Checks if a token is verified
- * @param token - Token to check
- * @returns Whether the token is verified
- */
 export function isVerifiedToken(token: string) {
   return verifiedTokens.has(token);
 }
 
-/**
- * Adds a token to the verified tokens set
- * @param token - Token to add
- * @returns The Set.add result
- */
 export function addVerifiedToken(token: string) {
   return verifiedTokens.add(token);
 }

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -137,7 +137,6 @@ describe("getClientIp", () => {
         headers: { "x-forwarded-for": "10.0.0.1, 10.0.0.2, 192.168.1.50" },
         socket: { remoteAddress: "127.0.0.1" },
       } as unknown as IncomingMessage;
-      // Last entry is the one our proxy appended — that's the real client.
       expect(getClientIp(req)).toBe("192.168.1.50");
     });
   });
@@ -149,7 +148,6 @@ describe("getClientIp", () => {
         headers: { "x-forwarded-for": "1.2.3.4, 192.168.1.50" },
         socket: { remoteAddress: "127.0.0.1" },
       } as unknown as IncomingMessage;
-      // 1.2.3.4 is spoofed; 192.168.1.50 is the trusted proxy entry.
       expect(getClientIp(req)).toBe("192.168.1.50");
     });
   });

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let mockArgon2VerifyResult = true;
@@ -12,8 +13,8 @@ vi.mock("hash-wasm", () => ({
 
 vi.mock("rate-limiter-flexible", () => ({
   RateLimiterMemory: class {
-    consume = vi.fn((token: string) => {
-      mockConsume(token);
+    consume = vi.fn((key: string) => {
+      mockConsume(key);
       if (mockRateLimiterShouldFail) {
         return Promise.reject(new Error("Rate limit exceeded"));
       }
@@ -30,6 +31,13 @@ vi.mock("./verifiedTokens", () => ({
   addVerifiedToken: vi.fn((token: string) => mockAddVerifiedToken(token)),
   isVerifiedToken: vi.fn(() => mockIsVerifiedToken),
 }));
+
+function makeMockRequest(ip: string): IncomingMessage {
+  return {
+    headers: { "x-forwarded-for": ip },
+    socket: { remoteAddress: "127.0.0.1" },
+  } as unknown as IncomingMessage;
+}
 
 describe("verifyTokenAndRateLimit", () => {
   beforeEach(() => {
@@ -95,5 +103,100 @@ describe("verifyTokenAndRateLimit", () => {
     expect(result.isAuthorized).toBe(false);
     expect(result.statusCode).toBe(429);
     expect(result.error).toBe("Too many requests.");
+  });
+
+  it("should key rate limiter on client IP when request is provided", async () => {
+    mockRateLimiterShouldFail = false;
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const mockReq = makeMockRequest("192.168.1.100");
+    const result = await verifyTokenAndRateLimit("valid-token", mockReq);
+    expect(result.isAuthorized).toBe(true);
+    expect(mockConsume).toHaveBeenCalledWith("192.168.1.100");
+  });
+
+  it("should fall back to token as rate limit key when no request", async () => {
+    mockRateLimiterShouldFail = false;
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const result = await verifyTokenAndRateLimit("fallback-token");
+    expect(result.isAuthorized).toBe(true);
+    expect(mockConsume).toHaveBeenCalledWith("fallback-token");
+  });
+});
+
+describe("getClientIp", () => {
+  it("should extract last (trusted) IP from X-Forwarded-For", () => {
+    vi.resetModules();
+    return import("./verifyTokenAndRateLimit").then(({ getClientIp }) => {
+      const req = {
+        headers: { "x-forwarded-for": "10.0.0.1, 10.0.0.2, 192.168.1.50" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage;
+      // Last entry is the one our proxy appended — that's the real client.
+      expect(getClientIp(req)).toBe("192.168.1.50");
+    });
+  });
+
+  it("should reject spoofed leftmost X-Forwarded-For entry", () => {
+    vi.resetModules();
+    return import("./verifyTokenAndRateLimit").then(({ getClientIp }) => {
+      const req = {
+        headers: { "x-forwarded-for": "1.2.3.4, 192.168.1.50" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage;
+      // 1.2.3.4 is spoofed; 192.168.1.50 is the trusted proxy entry.
+      expect(getClientIp(req)).toBe("192.168.1.50");
+    });
+  });
+
+  it("should fall back to X-Real-IP", () => {
+    vi.resetModules();
+    return import("./verifyTokenAndRateLimit").then(({ getClientIp }) => {
+      const req = {
+        headers: { "x-real-ip": "172.16.0.1" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage;
+      expect(getClientIp(req)).toBe("172.16.0.1");
+    });
+  });
+
+  it("should fall back to socket.remoteAddress", () => {
+    vi.resetModules();
+    return import("./verifyTokenAndRateLimit").then(({ getClientIp }) => {
+      const req = {
+        headers: {},
+        socket: { remoteAddress: "192.168.0.1" },
+      } as unknown as IncomingMessage;
+      expect(getClientIp(req)).toBe("192.168.0.1");
+    });
+  });
+
+  it("should reject non-IP X-Forwarded-For entries", () => {
+    vi.resetModules();
+    return import("./verifyTokenAndRateLimit").then(({ getClientIp }) => {
+      const req = {
+        headers: { "x-forwarded-for": "not-an-ip, also-not-an-ip" },
+        socket: { remoteAddress: "10.0.0.5" },
+      } as unknown as IncomingMessage;
+      expect(getClientIp(req)).toBe("10.0.0.5");
+    });
+  });
+
+  it("should handle array-valued X-Forwarded-For header", () => {
+    vi.resetModules();
+    return import("./verifyTokenAndRateLimit").then(({ getClientIp }) => {
+      const req = {
+        headers: {
+          "x-forwarded-for": ["10.0.0.1", "10.0.0.2", "192.168.1.50"],
+        },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage;
+      expect(getClientIp(req)).toBe("192.168.1.50");
+    });
   });
 });

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -10,17 +10,6 @@ const rateLimiter = new RateLimiterMemory({
   duration: 10,
 });
 
-/**
- * Extract the real client IP from the request, handling X-Forwarded-For
- * behind proxies (e.g. Hugging Face Spaces).
- *
- * X-Forwarded-For is appended left-to-right by each proxy hop, so the
- * leftmost entry is the least trustworthy (client-controlled). The
- * rightmost entry is the one our own infrastructure appended — that's
- * the real client IP. We count from the right to find the trusted entry.
- *
- * See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
- */
 export function getClientIp(request: IncomingMessage): string {
   const forwarded = request.headers["x-forwarded-for"];
   const xff = Array.isArray(forwarded) ? forwarded.join(",") : forwarded;
@@ -29,7 +18,6 @@ export function getClientIp(request: IncomingMessage): string {
       .split(",")
       .map((p) => p.trim())
       .filter(Boolean);
-    // Trust the last entry — the one our proxy appended.
     const ip = parts[parts.length - 1];
     if (ip && isIP(ip)) {
       return ip;

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -1,3 +1,5 @@
+import type { IncomingMessage } from "node:http";
+import { isIP } from "node:net";
 import { argon2Verify } from "hash-wasm";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import { getSearchToken } from "./searchToken";
@@ -8,7 +10,42 @@ const rateLimiter = new RateLimiterMemory({
   duration: 10,
 });
 
-export async function verifyTokenAndRateLimit(token: string | null): Promise<{
+/**
+ * Extract the real client IP from the request, handling X-Forwarded-For
+ * behind proxies (e.g. Hugging Face Spaces).
+ *
+ * X-Forwarded-For is appended left-to-right by each proxy hop, so the
+ * leftmost entry is the least trustworthy (client-controlled). The
+ * rightmost entry is the one our own infrastructure appended — that's
+ * the real client IP. We count from the right to find the trusted entry.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+ */
+export function getClientIp(request: IncomingMessage): string {
+  const forwarded = request.headers["x-forwarded-for"];
+  const xff = Array.isArray(forwarded) ? forwarded.join(",") : forwarded;
+  if (typeof xff === "string" && xff.length > 0) {
+    const parts = xff
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+    // Trust the last entry — the one our proxy appended.
+    const ip = parts[parts.length - 1];
+    if (ip && isIP(ip)) {
+      return ip;
+    }
+  }
+  const realIp = request.headers["x-real-ip"];
+  if (typeof realIp === "string" && realIp.length > 0 && isIP(realIp)) {
+    return realIp;
+  }
+  return request.socket.remoteAddress || "unknown";
+}
+
+export async function verifyTokenAndRateLimit(
+  token: string | null,
+  request?: IncomingMessage,
+): Promise<{
   isAuthorized: boolean;
   statusCode?: number;
   error?: string;
@@ -44,8 +81,10 @@ export async function verifyTokenAndRateLimit(token: string | null): Promise<{
     }
   }
 
+  const rateLimitKey = request ? getClientIp(request) : token;
+
   try {
-    await rateLimiter.consume(token);
+    await rateLimiter.consume(rateLimitKey);
   } catch {
     return {
       isAuthorized: false,

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -10,7 +10,7 @@ const rateLimiter = new RateLimiterMemory({
   duration: 10,
 });
 
-/** Extracts the real client IP from the request, handling X-Forwarded-For behind proxies. */
+/** Takes the rightmost X-Forwarded-For entry (the one our proxy appended), validated with `net.isIP()`. */
 export function getClientIp(request: IncomingMessage): string {
   const forwarded = request.headers["x-forwarded-for"];
   const xff = Array.isArray(forwarded) ? forwarded.join(",") : forwarded;

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -10,6 +10,7 @@ const rateLimiter = new RateLimiterMemory({
   duration: 10,
 });
 
+/** Extracts the real client IP from the request, handling X-Forwarded-For behind proxies. */
 export function getClientIp(request: IncomingMessage): string {
   const forwarded = request.headers["x-forwarded-for"];
   const xff = Array.isArray(forwarded) ? forwarded.join(",") : forwarded;


### PR DESCRIPTION
## Summary
Fixes #2126. The rate limiter was keyed on a client-rotatable argon2 hash — each request generated a fresh hash with a new random salt, so the rate limiter never actually limited. The `verifiedTokens` Set also grew unbounded with no cleanup.

## Changes
- **server/verifyTokenAndRateLimit.ts**: Added `getClientIp()` to extract the real client IP from the rightmost X-Forwarded-For entry (the one our proxy appended), X-Real-IP, or socket.remoteAddress. Rate limiter now keyed on IP instead of token. IPs validated with `net.isIP()` to prevent unbounded key injection.
- **server/verifiedTokens.ts**: Added periodic cleanup every 60s to prevent unbounded Set growth.
- **server/handleTokenVerification.ts**: Added optional `IncomingMessage` parameter, passes it through to `verifyTokenAndRateLimit`.
- **server/searchEndpointServerHook.ts** & **server/internalApiEndpointServerHook.ts**: Pass request to `handleTokenVerification`.

## Verification
- `npm run lint` passes clean
- All 23 tests pass, including new tests for IP extraction, spoofing rejection, and array-valued headers

## Note
Users behind the same IP will now share a rate-limit bucket (10 req/10s).