### PR TITLE
GNX-2130: Add tests for server/rankSearchResults, searchToken, and validateAccessKeyServerHook

### DIFF
--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRerank = vi.fn(() => []);
+
+vi.mock("./rerankerService", () => ({
+  rerank: (...args: unknown[]) => mockRerank(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("rankSearchResults", () => {
+  it("should return empty array when no results provided", async () => {
+    mockRerank.mockResolvedValue([]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const result = await rankSearchResults("test query", []);
+    expect(result).toEqual([]);
+    expect(mockRerank).toHaveBeenCalledWith("test query", []);
+  });
+
+  it("should pass lowercased query and documents to rerank", async () => {
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 0.9 },
+      { index: 1, relevance_score: 0.5 },
+    ]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    await rankSearchResults("Test Query", [
+      ["Title A", "Content A", "https://a.com"],
+      ["Title B", "Content B", "https://b.com"],
+    ]);
+    expect(mockRerank).toHaveBeenCalledWith(
+      "test query",
+      expect.arrayContaining([
+        expect.stringContaining("title a"),
+        expect.stringContaining("title b"),
+      ]),
+    );
+  });
+
+  it("should sort results by score descending when preserveTopResults is false", async () => {
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 0.9 },
+      { index: 1, relevance_score: 0.8 },
+    ]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const result = await rankSearchResults("query", [
+      ["A", "a", "https://a.com"],
+      ["B", "b", "https://b.com"],
+    ]);
+    // Results are sorted by score descending (A has higher score)
+    expect(result[0][0]).toBe("A");
+  });
+
+  it("should preserve top result when preserveTopResults is true", async () => {
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 0.95 },
+      { index: 1, relevance_score: 0.8 },
+    ]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const result = await rankSearchResults(
+      "query",
+      [
+        ["Top", "top content", "https://top.com"],
+        ["Other", "other content", "https://other.com"],
+      ],
+      true,
+    );
+    expect(result[0][0]).toBe("Top");
+  });
+
+  it("should return empty array when rerank returns no results", async () => {
+    mockRerank.mockResolvedValue([]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const result = await rankSearchResults("query", [
+      ["A", "a", "https://a.com"],
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("should truncate document strings to MAX_DOCUMENT_LENGTH", async () => {
+    mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const longTitle = "A".repeat(600);
+    await rankSearchResults("query", [[longTitle, "short", "https://a.com"]]);
+    const docs = mockRerank.mock.calls[0][1] as string[];
+    expect(docs[0].length).toBeLessThanOrEqual(512);
+  });
+
+  it("should replace double quotes with single quotes in snippet", async () => {
+    mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    await rankSearchResults("query", [
+      ["Title", 'Content with "quotes"', "https://a.com"],
+    ]);
+    const docs = mockRerank.mock.calls[0][1] as string[];
+    // The snippet's double quotes are replaced with single quotes
+    expect(docs[0]).toContain("'quotes'");
+  });
+});

--- a/server/searchToken.test.ts
+++ b/server/searchToken.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+    writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  },
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+}));
+
+vi.mock("temp-dir", () => ({ default: "/tmp" }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExistsSync.mockReset();
+  mockReadFileSync.mockReset();
+  mockWriteFileSync.mockReset();
+});
+
+describe("searchToken", () => {
+  it("should read existing token file when it exists", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("existing-token-123");
+
+    const { getSearchToken } = await import("./searchToken");
+    const token = getSearchToken();
+
+    expect(token).toBe("existing-token-123");
+    expect(mockExistsSync).toHaveBeenCalled();
+    expect(mockReadFileSync).toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it("should generate a new token when file does not exist", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockReturnValue(undefined);
+
+    const { getSearchToken } = await import("./searchToken");
+
+    // First call — file doesn't exist, should regenerate
+    getSearchToken();
+    expect(mockWriteFileSync).toHaveBeenCalled();
+
+    // Now file exists
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("new-token-456");
+
+    const token2 = getSearchToken();
+    expect(token2).toBe("new-token-456");
+  });
+
+  it("regenerateSearchToken should write a new token", async () => {
+    mockWriteFileSync.mockReturnValue(undefined);
+
+    const { regenerateSearchToken } = await import("./searchToken");
+    regenerateSearchToken();
+
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    const writtenToken = mockWriteFileSync.mock.calls[0][1] as string;
+    // Token should be a random string (letters and digits, 2+ chars)
+    expect(writtenToken.length).toBeGreaterThan(2);
+    expect(writtenToken).toMatch(/^[a-z0-9]+$/);
+  });
+});

--- a/server/validateAccessKeyServerHook.test.ts
+++ b/server/validateAccessKeyServerHook.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockArgon2Verify = vi.fn();
+
+vi.mock("hash-wasm", () => ({
+  argon2Verify: (...args: unknown[]) => mockArgon2Verify(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeMockRequest(
+  url: string,
+  method: string,
+  body?: string,
+): {
+  url: string | undefined;
+  method: string;
+  headers: Record<string, string>;
+  on: ReturnType<typeof vi.fn>;
+  endCallbacks: Array<() => void>;
+} {
+  const endCallbacks: Array<() => void> = [];
+  const on = vi.fn((event: string, cb: (chunk: string) => void) => {
+    if (event === "data" && body) {
+      cb(body);
+    }
+    if (event === "end") {
+      endCallbacks.push(cb as () => void);
+    }
+  });
+  return { url, method, headers: {}, on, endCallbacks };
+}
+
+function makeMockResponse() {
+  const setHeader = vi.fn();
+  const end = vi.fn();
+  const statusCode = 200;
+  return { setHeader, end, statusCode };
+}
+
+describe("validateAccessKeyServerHook", () => {
+  it("should skip non-matching URLs", async () => {
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: { url: string; method: string },
+      res: unknown,
+      next: () => void,
+    ) => void;
+    const next = vi.fn();
+    handler({ url: "/other", method: "POST" }, {}, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should skip non-POST methods", async () => {
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: { url: string; method: string },
+      res: unknown,
+      next: () => void,
+    ) => void;
+    const next = vi.fn();
+    handler({ url: "/api/validate-access-key", method: "GET" }, {}, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should return valid: true for a matching access key", async () => {
+    process.env.ACCESS_KEYS = "test-key";
+    mockArgon2Verify.mockResolvedValue(true);
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: {
+        url: string;
+        method: string;
+        on: (event: string, cb: (chunk: string) => void) => void;
+      },
+      res: {
+        setHeader: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+      },
+      next: () => void,
+    ) => void;
+
+    const res = makeMockResponse();
+    const req = makeMockRequest(
+      "/api/validate-access-key",
+      "POST",
+      JSON.stringify({ accessKeyHash: "some-hash" }),
+    );
+
+    await new Promise<void>((resolve) => {
+      handler(req as never, res as never, () => {});
+      // Trigger the end callback that the handler registered
+      for (const cb of req.endCallbacks) {
+        cb();
+      }
+      // argon2Verify is async, so we need to wait for it.
+      setTimeout(resolve, 50);
+    });
+
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ valid: true }));
+  });
+
+  it("should return valid: false when no access keys match", async () => {
+    process.env.ACCESS_KEYS = "test-key";
+    mockArgon2Verify.mockResolvedValue(false);
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: {
+        url: string;
+        method: string;
+        on: (event: string, cb: (chunk: string) => void) => void;
+      },
+      res: {
+        setHeader: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+      },
+      next: () => void,
+    ) => void;
+
+    const res = makeMockResponse();
+    const req = makeMockRequest(
+      "/api/validate-access-key",
+      "POST",
+      JSON.stringify({ accessKeyHash: "wrong-hash" }),
+    );
+
+    await new Promise<void>((resolve) => {
+      handler(req as never, res as never, () => {});
+      for (const cb of req.endCallbacks) {
+        cb();
+      }
+      setTimeout(resolve, 50);
+    });
+
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ valid: false }));
+  });
+
+  it("should return 400 for invalid JSON body", async () => {
+    process.env.ACCESS_KEYS = "test-key";
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: {
+        url: string;
+        method: string;
+        on: (event: string, cb: (chunk: string) => void) => void;
+      },
+      res: {
+        setHeader: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+        statusCode: { value: number };
+      },
+      next: () => void,
+    ) => void;
+
+    const res = makeMockResponse();
+    const req = makeMockRequest("/api/validate-access-key", "POST", "not-json");
+
+    await new Promise<void>((resolve) => {
+      handler(req as never, res as never, () => {});
+      for (const cb of req.endCallbacks) {
+        cb();
+      }
+      setTimeout(resolve, 50);
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.end).toHaveBeenCalledWith(
+      JSON.stringify({ valid: false, error: "Invalid request" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Fixes part of #2130. Added tests for three server files that previously had no test coverage.

## Changes
- **server/rankSearchResults.test.ts**: Tests for rankSearchResults with mocked rerank — empty results, document truncation, quote escaping, sorting, and preserveTopResults behavior
- **server/searchToken.test.ts**: Tests for getSearchToken and regenerateSearchToken with mocked fs module
- **server/validateAccessKeyServerHook.test.ts**: Tests for the access key validation middleware — URL/method filtering, valid/invalid keys, and 400 for malformed JSON

## Verification
- `npm run lint` passes clean
- All 15 new tests pass