### PR TITLE
Harden reusable-check-docker workflow with explicit permissions

### DIFF
--- a/.github/workflows/reusable-check-docker.yml
+++ b/.github/workflows/reusable-check-docker.yml
@@ -4,6 +4,8 @@ jobs:
   check-docker-container:
     name: Check Docker Container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - run: docker compose -f docker-compose.production.yml up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:lts AS llama-builder
 
 ARG LLAMA_CPP_RELEASE_TAG="b6604"
-ARG SEARXNG_RELEASE_TAG="6da6eee265daeb4a62ab638d6921522bf405de69"
 
 RUN apt-get update && apt-get install -y \
   build-essential \
@@ -21,7 +20,7 @@ RUN cd /tmp && \
 
 FROM node:lts
 
-ARG SEARXNG_RELEASE_TAG
+ARG SEARXNG_COMMIT_SHA="6da6eee265daeb4a62ab638d6921522bf405de69"
 
 ENV PORT=7860
 EXPOSE $PORT
@@ -48,9 +47,7 @@ RUN python3 -m venv searxng-venv && \
   /usr/local/searxng/searxng-venv/bin/pip install wheel setuptools pyyaml lxml
 
 RUN git clone https://github.com/searxng/searxng.git /usr/local/searxng/searxng-src && \
-  cd /usr/local/searxng/searxng-src && \
-  git checkout $SEARXNG_RELEASE_TAG && \
-  cd - && \
+  git -C /usr/local/searxng/searxng-src checkout $SEARXNG_COMMIT_SHA && \
   chown -R ${USERNAME}:${USERNAME} /usr/local/searxng/searxng-src
 
 ARG SEARXNG_SETTINGS_PATH="/etc/searxng/settings.yml"


### PR DESCRIPTION
## Summary

Completes the repo-wide least-privilege hardening started in #2145 by adding `permissions: contents: read` to the reusable-check-docker.yml workflow.

Also cleans up the Dockerfile: renames `SEARXNG_RELEASE_TAG` to `SEARXNG_COMMIT_SHA` (it's a commit, not a release tag) and removes the duplicate `ARG` declaration from the llama-builder stage.

## Changes

| File | Change |
|---|---|
| `reusable-check-docker.yml` | Added `permissions: contents: read` to `check-docker-container` job |
| `Dockerfile` | Renamed `SEARXNG_RELEASE_TAG` → `SEARXNG_COMMIT_SHA`, moved declaration to second stage, removed duplicate from llama-builder stage |

## How to test

1. `docker compose -f docker-compose.production.yml up -d` — verify the build still succeeds with the renamed arg.