### PR TITLE
Slim the pull request template to essentials

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,44 +1,23 @@
 ## Description
-Brief description of what this PR changes.
+<!-- What does this PR change, and why? -->
 
 ## Type of Change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Security fix
-- [ ] Performance improvement
-- [ ] Code quality improvement
-
-## Testing
-- [ ] I have tested this change locally
-- [ ] I have added tests for this change
-- [ ] All existing tests pass
-- [ ] I have run the linter and it passes (`npm run lint`)
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Other (refactor, build, chore)
 
 ## Checklist
-- [ ] My code follows the project's coding conventions
-- [ ] I have reviewed my own code
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] `npm run lint` passes
+- [ ] Tests pass (`npm run test`), with tests added where it made sense
 
-## Screenshots (if applicable)
-Add screenshots to help explain your changes, especially for UI modifications.
+## Screenshots
+<!-- For UI changes. Delete this section if not applicable. -->
 
-## Additional Context
-Add any other context about the problem here.
+<details>
+<summary>Security, performance, or breaking changes? Expand if relevant.</summary>
 
-## Security Considerations
-- [ ] This change does not introduce any security vulnerabilities
-- [ ] I have considered the security implications of this change
-- [ ] If this change handles user input, it has been properly sanitized/validated
+Note any security implications, performance impact, or breaking changes here,
+including how users should migrate.
 
-## Performance Impact
-- [ ] This change does not negatively impact performance
-- [ ] I have tested the performance impact of this change
-
-## Breaking Changes
-If this PR introduces breaking changes, please describe them here and how users should migrate.
+</details>


### PR DESCRIPTION
Slims `.github/PULL_REQUEST_TEMPLATE.md` from ~23 checkboxes down to 6.

Currently, the template asks for four checkbox sections (Testing, Checklist, Security Considerations, Performance Impact) plus a Breaking Changes block. For a docs fix or a first typo PR, most of it is N/A, and that wall of unchecked boxes is intimidating at the very last step of the contributor funnel.

This PR keeps only the essentials and moves the rest out of the way:

- Description, Type of Change (4 options), and Screenshots stay.
- The Checklist is down to two items: `npm run lint` passes and `npm run test` passes.
- Security, performance, and breaking-change notes now live in a collapsible `<details>` block, so they're there when relevant but don't get in the way otherwise.

## How to test

1. Run `node scripts/documentation-validator.cjs` and check `.github/PULL_REQUEST_TEMPLATE.md` still passes (no internal links to break).
2. Open a draft PR and confirm the template renders, with the `<details>` block collapsed by default.

Closes #2201
