### PR TITLE
docs: fix conflicting dev-server port descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ cd MiniSearch
 docker compose up
 ```
 
-The development server runs at <http://localhost:7860> with hot reload. Before opening a pull request, run the quality gate:
+The development server runs at <http://localhost:7860>. Hot Module Replacement (HMR) is available on <http://localhost:7861>. Before opening a pull request, run the quality gate:
 
 ```bash
 docker compose exec development-server npm run lint

--- a/docs/development-commands.md
+++ b/docs/development-commands.md
@@ -2,7 +2,7 @@
 
 ## Build & Development
 
-- **`docker compose up`**: Start development server with HMR on port 7861
+- **`docker compose up`**: Start development server (main app on 7860, HMR on 7861)
 - **`docker compose up --build`**: Compile for production
 - **`docker compose exec development-server npm run start`**: Preview production build
 - **`docker compose exec development-server npm run lint`**: Check code quality (Biome, TypeScript, knip, jscpd, architectural linter, documentation validator)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -154,7 +154,7 @@ docker compose logs searxng
 **Solution**: Change ports in `docker-compose.yml`:
 ```yaml
 ports:
-  - "7862:7860"  # Use 7862 instead of 7861
+  - "7862:7861"  # Use 7862 instead of 7860 (HMR port)
 ```
 
 ## Next Steps


### PR DESCRIPTION
Closes #2200

## Summary
- Clarify that the main app runs on port 7860 and HMR on 7861
- Fix the port-remap example in `docs/quick-start.md` (was incorrectly mapping 7862:7860 instead of 7862:7861)
- Update `docs/development-commands.md` to mention both ports

## Files changed
- `README.md`
- `docs/quick-start.md`
- `docs/development-commands.md`

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/felladrin/MiniSearch/blob/main/.github/CONTRIBUTING.md)
- [x] This PR targets the `main` branch