### PR TITLE
fix: use SHA-256 for cache keys and include limit in hash input

### DIFF
--- a/client/modules/search.test.ts
+++ b/client/modules/search.test.ts
@@ -33,40 +33,64 @@ describe("Search Module", () => {
   });
 
   describe("Hash Query Function", () => {
-    it("should return the same hash for identical queries", () => {
+    it("should return the same hash for identical queries", async () => {
       const result1 =
-        searchModule.searchServiceInstance.hashQuery("test query");
+        await searchModule.searchServiceInstance.hashQuery("test query");
       const result2 =
-        searchModule.searchServiceInstance.hashQuery("test query");
+        await searchModule.searchServiceInstance.hashQuery("test query");
       expect(result1).toBe(result2);
     });
 
-    it("should return different hashes for different queries", () => {
-      const result1 = searchModule.searchServiceInstance.hashQuery("query one");
-      const result2 = searchModule.searchServiceInstance.hashQuery("query two");
+    it("should return different hashes for different queries", async () => {
+      const result1 =
+        await searchModule.searchServiceInstance.hashQuery("query one");
+      const result2 =
+        await searchModule.searchServiceInstance.hashQuery("query two");
       expect(result1).not.toBe(result2);
     });
 
-    it("should handle empty query string", () => {
-      const result = searchModule.searchServiceInstance.hashQuery("");
+    it("should handle empty query string", async () => {
+      const result = await searchModule.searchServiceInstance.hashQuery("");
       expect(result).toBeTruthy();
       expect(typeof result).toBe("string");
     });
 
-    it("should handle special characters", () => {
+    it("should handle special characters", async () => {
       const hash1 =
-        searchModule.searchServiceInstance.hashQuery("test@query#123");
+        await searchModule.searchServiceInstance.hashQuery("test@query#123");
       expect(hash1).toBe(
-        searchModule.searchServiceInstance.hashQuery("test@query#123"),
+        await searchModule.searchServiceInstance.hashQuery("test@query#123"),
       );
     });
 
-    it("should handle unicode characters", () => {
+    it("should handle unicode characters", async () => {
       const hash1 =
-        searchModule.searchServiceInstance.hashQuery("日本語テスト");
+        await searchModule.searchServiceInstance.hashQuery("日本語テスト");
       expect(hash1).toBe(
-        searchModule.searchServiceInstance.hashQuery("日本語テスト"),
+        await searchModule.searchServiceInstance.hashQuery("日本語テスト"),
       );
+    });
+
+    it("should include limit in the hash so different limits produce different keys", async () => {
+      const hashNoLimit =
+        await searchModule.searchServiceInstance.hashQuery("test query");
+      const hashLimit10 = await searchModule.searchServiceInstance.hashQuery(
+        "test query",
+        10,
+      );
+      const hashLimit20 = await searchModule.searchServiceInstance.hashQuery(
+        "test query",
+        20,
+      );
+      expect(hashNoLimit).not.toBe(hashLimit10);
+      expect(hashLimit10).not.toBe(hashLimit20);
+      expect(hashNoLimit).not.toBe(hashLimit20);
+    });
+
+    it("should return a deterministic hex string of fixed length", async () => {
+      const hash =
+        await searchModule.searchServiceInstance.hashQuery("any query");
+      expect(hash).toMatch(/^[0-9a-f]{16}$/);
     });
   });
 

--- a/client/modules/search.test.ts
+++ b/client/modules/search.test.ts
@@ -87,6 +87,16 @@ describe("Search Module", () => {
       expect(hashNoLimit).not.toBe(hashLimit20);
     });
 
+    it("should treat an omitted limit the same as an explicit undefined", async () => {
+      const hashOmitted =
+        await searchModule.searchServiceInstance.hashQuery("test query");
+      const hashUndefined = await searchModule.searchServiceInstance.hashQuery(
+        "test query",
+        undefined,
+      );
+      expect(hashOmitted).toBe(hashUndefined);
+    });
+
     it("should return a deterministic hex string of fixed length", async () => {
       const hash =
         await searchModule.searchServiceInstance.hashQuery("any query");

--- a/client/modules/search.ts
+++ b/client/modules/search.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from "dexie";
+import { sha256 } from "hash-wasm";
 import { addLogEntry } from "./logEntries";
 import { getSearchTokenHash } from "./searchTokenHash";
 import type { ImageSearchResults, TextSearchResults } from "./types";
@@ -153,7 +154,7 @@ interface SearchExecutionConfig {
 }
 
 interface SearchOperations<T extends SearchResults> {
-  hashQuery: (query: string) => string;
+  hashQuery: (query: string, limit?: number) => string;
   performSearch: (
     endpoint: "text" | "images",
     query: string,
@@ -169,7 +170,7 @@ async function executeCachedSearch<T extends SearchResults>(
 ): Promise<T> {
   await db.cleanExpiredCache(context.storeName);
 
-  const key = operations.hashQuery(query);
+  const key = await operations.hashQuery(query, limit);
   const cachedData = await db.getCachedResult<T>(context.storeName, key);
 
   if (cachedData?.fresh) {
@@ -397,32 +398,15 @@ db.ensureIntegrity().catch((error) => {
 
 const searchService = {
   /**
-   * Generates a hash for query caching
-   * Uses a more robust hashing algorithm to minimize collisions
+   * Generates a SHA-256 hash for query caching.
+   * Includes the limit in the hash input so that different limits
+   * produce different cache keys (fixes stale results when limit changes).
    */
-  hashQuery(query: string): string {
-    // Use a combination of hash algorithms to reduce collision risk
-    const djb2 = (str: string) => {
-      let hash = 5381;
-      for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = (hash << 5) + hash + char;
-      }
-      return hash >>> 0;
-    };
-
-    const murmur = (str: string) => {
-      let hash = 0;
-      for (let i = 0; i < str.length; i++) {
-        hash = Math.imul(hash ^ str.charCodeAt(i), 0x5bd1e9);
-        hash = Math.imul(hash ^ (hash >>> 6), 0x5bd1e9);
-      }
-      return (hash >>> 0) ^ 0x5bd1e9;
-    };
-
-    // Combine multiple hash algorithms for better distribution
-    const combined = djb2(query) ^ murmur(query);
-    return combined.toString(36);
+  async hashQuery(query: string, limit?: number): Promise<string> {
+    const input = limit !== undefined ? `${query}::limit=${limit}` : query;
+    const hash = await sha256(input);
+    // Return first 16 hex chars — enough for cache keys, shorter than full 64
+    return hash.slice(0, 16);
   },
 
   async performSearch<T>(

--- a/client/modules/search.ts
+++ b/client/modules/search.ts
@@ -154,7 +154,7 @@ interface SearchExecutionConfig {
 }
 
 interface SearchOperations<T extends SearchResults> {
-  hashQuery: (query: string, limit?: number) => string;
+  hashQuery: (query: string, limit?: number) => Promise<string>;
   performSearch: (
     endpoint: "text" | "images",
     query: string,


### PR DESCRIPTION
## Root Cause

Issue #2178 pointed out two bugs in `client/modules/search.ts`:

1. **Cache key omits `limit`.** The key was `hashQuery(query)` with no `limit`, so changing `searchResultsLimit` returned stale results sized for the old limit.
2. **Collision-prone 32-bit hash.** `hashQuery` used a custom `djb2 ^ murmur` reduced to base36, so only 32 bits of entropy. Across 100+ cache entries, collisions are possible. `hash-wasm` is already a dependency.

## What Changed

| File | Change |
|------|--------|
| `client/modules/search.ts` | Replace the custom 32-bit djb2+murmur with `sha256` from `hash-wasm` (first 16 hex chars as the key); fold `limit` into the hash input so different limits produce different keys; make `hashQuery` async and fix the `SearchOperations` interface to return `Promise<string>` |
| `client/modules/search.test.ts` | Migrate the existing tests to the async `hashQuery`; add tests for limit differentiation, omitted-vs-`undefined` limit, and the output format |

## How Verified

- `npx vitest run client/modules/search.test.ts` (32 tests pass)
- `npx vitest run` (all 271 tests across 29 files pass)
- `npm run lint` (biome + `tsc` + the rest of the gate, clean)

## Note

This changes the cache key format, so any entry cached before the deploy becomes a permanent miss. Harmless here (stale entries just get re-fetched and expire on their own), but worth knowing.
