### PR TITLE
fix(a11y): add screen-reader landmarks and live region for streaming responses

### DIFF
--- a/client/components/AiResponse/AiResponseContent.tsx
+++ b/client/components/AiResponse/AiResponseContent.tsx
@@ -201,7 +201,12 @@ export default function AiResponseContent({
       </Card.Section>
       <Card.Section withBorder>
         <ConditionalScrollArea>
-          <FormattedMarkdown>{response}</FormattedMarkdown>
+          <FormattedMarkdown
+            aria-live="polite"
+            aria-busy={textGenerationState === "generating"}
+          >
+            {response}
+          </FormattedMarkdown>
         </ConditionalScrollArea>
         {textGenerationState === "failed" && (
           <Alert

--- a/client/components/AiResponse/FormattedMarkdown.test.tsx
+++ b/client/components/AiResponse/FormattedMarkdown.test.tsx
@@ -1,0 +1,32 @@
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import FormattedMarkdown from "./FormattedMarkdown";
+
+describe("FormattedMarkdown", () => {
+  function renderComponent(component: React.ReactElement) {
+    return render(<MantineProvider>{component}</MantineProvider>);
+  }
+
+  it("forwards aria-live and aria-busy to the Typography wrapper", () => {
+    renderComponent(
+      <FormattedMarkdown aria-live="polite" aria-busy={true}>
+        Hello world
+      </FormattedMarkdown>,
+    );
+
+    const typography = screen
+      .getByText("Hello world")
+      .closest("div[aria-live][aria-busy]");
+    expect(typography).toHaveAttribute("aria-live", "polite");
+    expect(typography).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("omits aria attributes when not provided", () => {
+    renderComponent(<FormattedMarkdown>Plain text</FormattedMarkdown>);
+
+    const typography = screen.getByText("Plain text").closest("div");
+    expect(typography).not.toHaveAttribute("aria-live");
+    expect(typography).not.toHaveAttribute("aria-busy");
+  });
+});

--- a/client/components/AiResponse/FormattedMarkdown.tsx
+++ b/client/components/AiResponse/FormattedMarkdown.tsx
@@ -7,12 +7,16 @@ interface FormattedMarkdownProps {
   children: string;
   className?: string;
   enableCopy?: boolean;
+  "aria-live"?: string;
+  "aria-busy"?: boolean;
 }
 
 export default function FormattedMarkdown({
   children,
   className = "",
   enableCopy = true,
+  "aria-live": ariaLive,
+  "aria-busy": ariaBusy,
 }: FormattedMarkdownProps) {
   const { reasoningContent, mainContent, isGenerating } =
     useReasoningContent(children);
@@ -22,7 +26,7 @@ export default function FormattedMarkdown({
   }
 
   return (
-    <Typography p="lg">
+    <Typography p="lg" aria-live={ariaLive} aria-busy={ariaBusy}>
       {reasoningContent && (
         <ReasoningSection
           content={reasoningContent}

--- a/client/components/Pages/Main/MainPage.test.tsx
+++ b/client/components/Pages/Main/MainPage.test.tsx
@@ -202,4 +202,21 @@ describe("MainPage", () => {
     });
     expect(searchAndRespond).not.toHaveBeenCalled();
   });
+
+  it("renders a visually-hidden h1 landmark for screen readers", async () => {
+    await renderMainPage(createPageState());
+
+    const h1 = screen.getByRole("heading", { level: 1, hidden: true });
+    expect(h1).toBeInTheDocument();
+    expect(h1.textContent).toBe(
+      "MiniSearch — Private AI search with sourced answers",
+    );
+  });
+
+  it("wraps content in a main landmark element", async () => {
+    await renderMainPage(createPageState());
+
+    const mainEl = document.querySelector("main");
+    expect(mainEl).toBeInTheDocument();
+  });
 });

--- a/client/components/Pages/Main/MainPage.tsx
+++ b/client/components/Pages/Main/MainPage.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack } from "@mantine/core";
+import { Container, Stack, VisuallyHidden } from "@mantine/core";
 import { usePubSub } from "create-pubsub/react";
 import { lazy, Suspense } from "react";
 import SearchForm from "@/components/Search/Form/SearchForm";
@@ -33,49 +33,58 @@ export default function MainPage() {
 
   return (
     <Container>
-      <Stack py="md" mih="100vh" justify={isQueryEmpty ? "center" : undefined}>
-        <SearchForm
-          query={query}
-          updateQuery={updateQuery}
-          additionalButtons={<MenuButton />}
-        />
-        {!isQueryEmpty && (
-          <>
-            {settings.showEnableAiResponsePrompt && (
-              <Suspense>
-                <EnableAiResponsePrompt
-                  onAccept={() => {
-                    setSettings({
-                      ...settings,
-                      showEnableAiResponsePrompt: false,
-                      enableAiResponse: true,
-                    });
-                    searchAndRespond();
-                  }}
-                  onDecline={() => {
-                    setSettings({
-                      ...settings,
-                      showEnableAiResponsePrompt: false,
-                      enableAiResponse: false,
-                    });
-                  }}
-                />
-              </Suspense>
-            )}
-            {!settings.showEnableAiResponsePrompt &&
-              textGenerationState !== "idle" && (
+      <main>
+        <VisuallyHidden>
+          <h1>MiniSearch — Private AI search with sourced answers</h1>
+        </VisuallyHidden>
+        <Stack
+          py="md"
+          mih="100vh"
+          justify={isQueryEmpty ? "center" : undefined}
+        >
+          <SearchForm
+            query={query}
+            updateQuery={updateQuery}
+            additionalButtons={<MenuButton />}
+          />
+          {!isQueryEmpty && (
+            <>
+              {settings.showEnableAiResponsePrompt && (
                 <Suspense>
-                  <AiResponseSection />
+                  <EnableAiResponsePrompt
+                    onAccept={() => {
+                      setSettings({
+                        ...settings,
+                        showEnableAiResponsePrompt: false,
+                        enableAiResponse: true,
+                      });
+                      searchAndRespond();
+                    }}
+                    onDecline={() => {
+                      setSettings({
+                        ...settings,
+                        showEnableAiResponsePrompt: false,
+                        enableAiResponse: false,
+                      });
+                    }}
+                  />
                 </Suspense>
               )}
-            {(textSearchState !== "idle" || imageSearchState !== "idle") && (
-              <Suspense>
-                <SearchResultsSection />
-              </Suspense>
-            )}
-          </>
-        )}
-      </Stack>
+              {!settings.showEnableAiResponsePrompt &&
+                textGenerationState !== "idle" && (
+                  <Suspense>
+                    <AiResponseSection />
+                  </Suspense>
+                )}
+              {(textSearchState !== "idle" || imageSearchState !== "idle") && (
+                <Suspense>
+                  <SearchResultsSection />
+                </Suspense>
+              )}
+            </>
+          )}
+        </Stack>
+      </main>
     </Container>
   );
 }


### PR DESCRIPTION
## Root Cause

Issue #2186: The streaming AI answer body had no `aria-live` region, so assistive-tech users heard nothing as tokens arrived. Separately, the main page lacked a `<main>` landmark and `<h1>`, giving no document outline or skip target for screen-reader navigation.

## What Changed

| File | Change |
|------|--------|
| `client/components/Pages/Main/MainPage.tsx` | Wrap content in `<main>` landmark; add visually-hidden `<h1>` with value proposition |
| `client/components/AiResponse/AiResponseContent.tsx` | Pass `aria-live="polite"` and `aria-busy` to `FormattedMarkdown` |
| `client/components/AiResponse/FormattedMarkdown.tsx` | Accept and forward `aria-live` / `aria-busy` props to the `Typography` wrapper |
| `client/components/AiResponse/FormattedMarkdown.test.tsx` | **New** — tests for aria attribute forwarding |
| `client/components/Pages/Main/MainPage.test.tsx` | Added tests for `<main>` landmark and hidden `<h1>` |

## How Verified

- All 275 existing tests pass (full suite)
- 2 new tests for landmarks on `MainPage`
- 2 new tests for aria attribute forwarding on `FormattedMarkdown`
- `knip` ran clean (auto-fixed 2 unused imports)