### PR TITLE
fix: surface internal API stream errors

### DIFF
--- a/client/modules/textGenerationWithInternalApi.test.ts
+++ b/client/modules/textGenerationWithInternalApi.test.ts
@@ -5,7 +5,10 @@ import {
   updateResponse,
   updateTextGenerationState,
 } from "./pubSub";
-import { canStartResponding } from "./textGenerationUtilities";
+import {
+  ChatGenerationError,
+  canStartResponding,
+} from "./textGenerationUtilities";
 import type { ChatMessage } from "./types";
 
 vi.mock("./pubSub", () => ({
@@ -164,7 +167,7 @@ describe("textGenerationWithInternalApi", () => {
       expect(onUpdate).toHaveBeenNthCalledWith(2, "Hello world");
     });
 
-    it("skips [DONE] and empty-delta lines instead of treating them as content", async () => {
+    it("skips [DONE], choice-less, and empty-delta lines", async () => {
       const { generateChatWithInternalApi } = await import(
         "./textGenerationWithInternalApi"
       );
@@ -172,6 +175,7 @@ describe("textGenerationWithInternalApi", () => {
       mockFetch.mockResolvedValueOnce(
         streamResponse(
           sseChunks([
+            '{"model":"test-model"}',
             '{"choices":[{"delta":{}}]}',
             '{"choices":[{"delta":{"content":"Hello"}}]}',
           ]),
@@ -186,6 +190,28 @@ describe("textGenerationWithInternalApi", () => {
 
       expect(onUpdate).toHaveBeenCalledTimes(1);
       expect(onUpdate).toHaveBeenCalledWith("Hello");
+    });
+
+    it("throws a ChatGenerationError with the server message from an SSE error frame", async () => {
+      const { generateChatWithInternalApi } = await import(
+        "./textGenerationWithInternalApi"
+      );
+      const errorMessage = "Service unavailable - all models failed";
+
+      mockFetch.mockResolvedValueOnce(
+        streamResponse([
+          `data: ${JSON.stringify({ error: errorMessage })}\n\n`,
+          "data: [DONE]\n\n",
+        ]),
+      );
+
+      const response = generateChatWithInternalApi(
+        [{ role: "user", content: "Hi" }],
+        vi.fn(),
+      );
+
+      await expect(response).rejects.toBeInstanceOf(ChatGenerationError);
+      await expect(response).rejects.toThrow(errorMessage);
     });
   });
 });

--- a/client/modules/textGenerationWithInternalApi.ts
+++ b/client/modules/textGenerationWithInternalApi.ts
@@ -93,7 +93,11 @@ async function processStreamResponse(
       .map((line) => JSON.parse(line));
 
     for (const parsedLine of parsedLines) {
-      const deltaContent = parsedLine.choices[0].delta.content;
+      if (typeof parsedLine?.error === "string") {
+        throw new ChatGenerationError(parsedLine.error);
+      }
+
+      const deltaContent = parsedLine?.choices?.[0]?.delta?.content;
       if (deltaContent) {
         streamedMessage += deltaContent;
         onChunk(streamedMessage);


### PR DESCRIPTION
## Description

Fixes #2176.

When the `/inference` proxy exhausts its models, it sends an SSE frame with an
`error` field and no `choices`. The client previously dereferenced
`choices[0]` for every parsed frame, replacing the useful server message with a
`TypeError`.

This change:

- throws `ChatGenerationError` with the server-provided message for string
  error frames;
- safely skips choice-less and non-content frames; and
- adds focused regression coverage for both behaviors.

The normal content path is unchanged. Chunk-boundary buffering tracked in
#2177 remains outside this patch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## Checklist

- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

<details>
<summary>Security, performance, or breaking changes? Expand if relevant.</summary>

None. The patch changes only client-side handling of an existing server error
frame and adds no new API, dependency, or migration requirement.

</details>
