### PR TITLE
test: improve error frame test to cover realistic content-then-error scenario

### DIFF
--- a/client/modules/textGenerationWithInternalApi.test.ts
+++ b/client/modules/textGenerationWithInternalApi.test.ts
@@ -192,26 +192,30 @@ describe("textGenerationWithInternalApi", () => {
       expect(onUpdate).toHaveBeenCalledWith("Hello");
     });
 
-    it("throws a ChatGenerationError with the server message from an SSE error frame", async () => {
+    it("throws ChatGenerationError after streaming partial content when error frame arrives", async () => {
       const { generateChatWithInternalApi } = await import(
         "./textGenerationWithInternalApi"
       );
-      const errorMessage = "Service unavailable - all models failed";
+      const errorMessage =
+        "Service unavailable - all models failed: connection timeout";
 
       mockFetch.mockResolvedValueOnce(
         streamResponse([
+          'data: {"choices":[{"delta":{"content":"Partial"}}]}\n',
           `data: ${JSON.stringify({ error: errorMessage })}\n\n`,
           "data: [DONE]\n\n",
         ]),
       );
 
+      const onUpdate = vi.fn();
       const response = generateChatWithInternalApi(
         [{ role: "user", content: "Hi" }],
-        vi.fn(),
+        onUpdate,
       );
 
       await expect(response).rejects.toBeInstanceOf(ChatGenerationError);
       await expect(response).rejects.toThrow(errorMessage);
+      expect(onUpdate).toHaveBeenCalledWith("Partial");
     });
   });
 });


### PR DESCRIPTION
## Description

The existing error frame test (#2212) only sends a lone error frame with no preceding content. The real scenario from issue #2176 is that content chunks arrive first, then an error frame arrives mid-stream when all models fail.

This PR updates the test to cover that realistic flow:
- Streams a content chunk first
- Then sends an error frame
- Asserts that `onUpdate` was called with the partial content
- Asserts the promise still rejects with `ChatGenerationError`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Test improvement