### PR TITLE
fix: generate the search token with a CSPRNG

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -44,7 +44,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 
 - Input validation on all endpoints
 - Sanitization of user-generated content
-- Search token generation: a per-build/per-startup token written to a temp file (`server/searchToken.ts`); note this currently uses `Math.random()`, not a cryptographically secure random source
+- Search token generation: a per-build/per-startup token written to a temp file (`server/searchToken.ts`), using 32 bytes from the `node:crypto` CSPRNG
 - HTTPS enforcement in production
 - Regular dependency updates via Renovate
 - **Argon2 Hashing**: Access keys hashed using argon2id for secure validation (not storage encryption)

--- a/server/searchToken.test.ts
+++ b/server/searchToken.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExistsSync = vi.fn();
 const mockReadFileSync = vi.fn();
@@ -22,6 +22,10 @@ beforeEach(() => {
   mockExistsSync.mockReset();
   mockReadFileSync.mockReset();
   mockWriteFileSync.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("searchToken", () => {
@@ -67,5 +71,23 @@ describe("searchToken", () => {
     // Token should be a random string (letters and digits, 2+ chars)
     expect(writtenToken.length).toBeGreaterThan(2);
     expect(writtenToken).toMatch(/^[a-z0-9]+$/);
+  });
+
+  it("regenerateSearchToken should draw the token from a cryptographic source", async () => {
+    mockWriteFileSync.mockReturnValue(undefined);
+    const mathRandomSpy = vi.spyOn(Math, "random");
+
+    const { regenerateSearchToken } = await import("./searchToken");
+    regenerateSearchToken();
+    regenerateSearchToken();
+
+    const [firstToken, secondToken] = mockWriteFileSync.mock.calls.map(
+      (call) => call[1] as string,
+    );
+
+    expect(mathRandomSpy).not.toHaveBeenCalled();
+    // 32 random bytes, hex-encoded
+    expect(firstToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(firstToken).not.toBe(secondToken);
   });
 });

--- a/server/searchToken.ts
+++ b/server/searchToken.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import temporaryDirectory from "temp-dir";
@@ -23,6 +24,6 @@ export const getSearchToken = () => {
  * Generates and saves a new search token
  */
 export function regenerateSearchToken() {
-  const newToken = Math.random().toString(36).substring(2);
+  const newToken = randomBytes(32).toString("hex");
   writeFileSync(getSearchTokenFilePath(), newToken);
 }


### PR DESCRIPTION
## Description

Fixes #2181.

`server/searchToken.ts` mints the shared secret behind every `/search/*` and `/inference` request — the client hashes it with argon2id as `VITE_SEARCH_TOKEN`, and `verifyTokenAndRateLimit` authorizes by verifying that hash against `getSearchToken()`. It was generated with `Math.random().toString(36).substring(2)`, so the secret came from a non-cryptographic PRNG and carried at most the 52 bits a double's mantissa can hold. The encoded string is also variable length — 7 to 15 characters over 2M samples on Node 22, not the ~11 it looks like.

Now it's 32 bytes from `node:crypto`, hex-encoded. The client already reaches for the CSPRNG (`crypto.getRandomValues` in `accessKey.ts` and `searchTokenHash.ts`), so this brings the server side in line.

`docs/security.md` called out the weak source under "Security Best Practices", so that line is updated in the same commit.

Scope note: this changes the *quality* of the secret, not its lifetime — `regenerateSearchToken()` still only runs on build, and `getSearchToken()` still returns the cached temp-file value.

The other `Math.random()` call sites (`history.ts`, `logEntries.ts`, `querySuggestions.ts`, `wllama.ts`, `shared/openaiModels.ts`, and the backoff jitter in `server/utils/streamUtils.ts`) are all non-security and left alone.

The new test pins the invariant rather than the implementation: it spies on `Math.random`, asserts it is never reached, and checks two successive tokens differ. On the previous implementation it fails with `expected "random" to not be called at all, but actually been called 2 times`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

<details>
<summary>Security, performance, or breaking changes? Expand if relevant.</summary>

Security-positive, no migration needed. The token moves from ≤52 bits of `Math.random()` output to 256 bits of CSPRNG output, and from a 7–15 character base-36 string to a fixed 64-character hex string. Existing deployments pick up the new token on their next build, exactly as they already do today — the temp file is rewritten by `regenerateSearchToken()` and re-inlined as `VITE_SEARCH_TOKEN`. argon2id takes the longer password unchanged (verified with a real `hash-wasm` round trip using the client's exact parameters).

</details>
