### PR TITLE
fix: make image thumbnails keyboard accessible

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.module.css
+++ b/client/components/Search/Results/Graphical/ImageResultsList.module.css
@@ -12,12 +12,13 @@
 
 .thumbnailButton {
   display: block;
-  border-radius: var(--mantine-radius-xs);
+  border-radius: var(--mantine-radius-sm);
   cursor: zoom-in;
   line-height: 0;
 }
 
+/* The carousel viewport clips overflow, which would cut the outer edge off the
+   focus ring of the leading slide. Drawing it inside keeps it fully visible. */
 .thumbnailButton:focus-visible {
-  outline: 2px solid var(--mantine-color-blue-5);
-  outline-offset: 3px;
+  outline-offset: -2px;
 }

--- a/client/components/Search/Results/Graphical/ImageResultsList.module.css
+++ b/client/components/Search/Results/Graphical/ImageResultsList.module.css
@@ -9,3 +9,15 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   opacity: 1;
 }
+
+.thumbnailButton {
+  display: block;
+  border-radius: var(--mantine-radius-xs);
+  cursor: zoom-in;
+  line-height: 0;
+}
+
+.thumbnailButton:focus-visible {
+  outline: 2px solid var(--mantine-color-blue-5);
+  outline-offset: 3px;
+}

--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -1,43 +1,9 @@
 import { MantineProvider } from "@mantine/core";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { CSSProperties, ReactNode } from "react";
+import { describe, expect, it } from "vitest";
 import type { ImageSearchResult } from "@/modules/types";
 import ImageResultsList from "./ImageResultsList";
-
-vi.mock("@mantine/carousel", () => {
-  const Carousel = ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  );
-  Carousel.Slide = ({
-    children,
-    style,
-  }: {
-    children: ReactNode;
-    style?: CSSProperties;
-  }) => <div style={style}>{children}</div>;
-
-  return { Carousel };
-});
-
-vi.mock("yet-another-react-lightbox", () => ({
-  default: ({
-    index,
-    open,
-    slides,
-  }: {
-    index: number;
-    open: boolean;
-    slides: { alt?: string }[];
-  }) =>
-    open ? (
-      <div role="dialog" aria-label={slides[index]?.alt ?? "Image preview"} />
-    ) : null,
-}));
-
-vi.mock("yet-another-react-lightbox/plugins/captions", () => ({
-  default: {},
-}));
 
 const imageResults: ImageSearchResult[] = [
   [
@@ -73,20 +39,28 @@ describe("ImageResultsList", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens the lightbox from the keyboard", async () => {
+  it("opens the focused thumbnail in the lightbox from the keyboard", async () => {
     const user = userEvent.setup();
     renderImageResultsList();
 
-    const firstThumbnail = await screen.findByRole("button", {
-      name: "Open image preview: First image",
-    });
-    firstThumbnail.focus();
+    const [firstThumbnail, secondThumbnail] = await Promise.all([
+      screen.findByRole("button", { name: "Open image preview: First image" }),
+      screen.findByRole("button", { name: "Open image preview: Second image" }),
+    ]);
+
+    await user.tab();
     expect(firstThumbnail).toHaveFocus();
+
+    await user.tab();
+    expect(secondThumbnail).toHaveFocus();
 
     await user.keyboard("{Enter}");
 
+    const dialog = await screen.findByRole("dialog");
+    // The lightbox keeps neighbouring slides mounted, so the alt text of every
+    // result is queryable. Only the current slide identifies what the user sees.
     expect(
-      await screen.findByRole("dialog", { name: "First image" }),
-    ).toBeInTheDocument();
+      dialog.querySelector(".yarl__slide_current img")?.getAttribute("alt"),
+    ).toBe("Second image");
   });
 });

--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -1,0 +1,92 @@
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CSSProperties, ReactNode } from "react";
+import type { ImageSearchResult } from "@/modules/types";
+import ImageResultsList from "./ImageResultsList";
+
+vi.mock("@mantine/carousel", () => {
+  const Carousel = ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  );
+  Carousel.Slide = ({
+    children,
+    style,
+  }: {
+    children: ReactNode;
+    style?: CSSProperties;
+  }) => <div style={style}>{children}</div>;
+
+  return { Carousel };
+});
+
+vi.mock("yet-another-react-lightbox", () => ({
+  default: ({
+    index,
+    open,
+    slides,
+  }: {
+    index: number;
+    open: boolean;
+    slides: { alt?: string }[];
+  }) =>
+    open ? (
+      <div role="dialog" aria-label={slides[index]?.alt ?? "Image preview"} />
+    ) : null,
+}));
+
+vi.mock("yet-another-react-lightbox/plugins/captions", () => ({
+  default: {},
+}));
+
+const imageResults: ImageSearchResult[] = [
+  [
+    "First image",
+    "https://example.com/first",
+    "https://example.com/first.jpg",
+    "https://source.example.com/first",
+  ],
+  [
+    "Second image",
+    "https://example.com/second",
+    "https://example.com/second.jpg",
+    "https://source.example.com/second",
+  ],
+];
+
+function renderImageResultsList() {
+  return render(
+    <MantineProvider>
+      <ImageResultsList imageResults={imageResults} />
+    </MantineProvider>,
+  );
+}
+
+describe("ImageResultsList", () => {
+  it("renders thumbnails as named buttons", async () => {
+    renderImageResultsList();
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Open image preview: First image",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the lightbox from the keyboard", async () => {
+    const user = userEvent.setup();
+    renderImageResultsList();
+
+    const firstThumbnail = await screen.findByRole("button", {
+      name: "Open image preview: First image",
+    });
+    firstThumbnail.focus();
+    expect(firstThumbnail).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    expect(
+      await screen.findByRole("dialog", { name: "First image" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -1,5 +1,13 @@
 import { Carousel } from "@mantine/carousel";
-import { Button, Group, rem, Stack, Text, Transition } from "@mantine/core";
+import {
+  Button,
+  Group,
+  rem,
+  Stack,
+  Text,
+  Transition,
+  UnstyledButton,
+} from "@mantine/core";
 import { useEffect, useState } from "react";
 import type { ImageSearchResult } from "@/modules/types";
 import "@mantine/carousel/styles.css";
@@ -72,18 +80,18 @@ export default function ImageResultsList({
           >
             {(styles) => (
               <Carousel.Slide style={styles}>
-                <img
-                  alt={title}
-                  src={thumbnail}
-                  loading="lazy"
+                <UnstyledButton
+                  aria-label={`Open image preview: ${title || getHostname(url)}`}
+                  className={carouselClassNames.thumbnailButton}
                   onClick={() => handleImageClick(index)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      handleImageClick(index);
-                    }
-                  }}
-                  style={imageStyle}
-                />
+                >
+                  <img
+                    alt={title}
+                    src={thumbnail}
+                    loading="lazy"
+                    style={imageStyle}
+                  />
+                </UnstyledButton>
               </Carousel.Slide>
             )}
           </Transition>

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -13,7 +13,7 @@ import type { ImageSearchResult } from "@/modules/types";
 import "@mantine/carousel/styles.css";
 import Lightbox from "yet-another-react-lightbox";
 import Captions from "yet-another-react-lightbox/plugins/captions";
-import carouselClassNames from "./ImageResultsList.module.css";
+import classes from "./ImageResultsList.module.css";
 import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/captions.css";
 import { addLogEntry } from "@/modules/logEntries";
@@ -54,7 +54,6 @@ export default function ImageResultsList({
     width: rem(240),
     borderRadius: rem(4),
     border: `${rem(2)} solid var(--mantine-color-default-border)`,
-    cursor: "zoom-in",
   } as const;
 
   return (
@@ -62,7 +61,7 @@ export default function ImageResultsList({
       <Carousel
         slideSize="0"
         slideGap="xs"
-        classNames={carouselClassNames}
+        classNames={{ root: classes.root, control: classes.control }}
         emblaOptions={{
           align: "start",
           dragFree: true,
@@ -82,7 +81,7 @@ export default function ImageResultsList({
               <Carousel.Slide style={styles}>
                 <UnstyledButton
                   aria-label={`Open image preview: ${title || getHostname(url)}`}
-                  className={carouselClassNames.thumbnailButton}
+                  className={classes.thumbnailButton}
                   onClick={() => handleImageClick(index)}
                 >
                   <img


### PR DESCRIPTION
## Summary
- Render image thumbnails as real `UnstyledButton` controls instead of bare clickable `<img>` elements.
- Add an accessible label from the image title plus a visible focus ring.
- Add a focused regression test that opens the lightbox from the keyboard.

## Why
Fixes #2179.

Before this change, the thumbnails had `onKeyDown` handlers on `<img>` elements, but the images were not focusable, so keyboard and switch users could not reach the handler. Native button semantics now provide click, Enter, and Space activation without custom key handling.

## Verification
- `npm install`
- `npx vitest run client/components/Search/Results/Graphical/ImageResultsList.test.tsx`
- `npx vitest run client/components/Search/Results/Graphical/ImageResultsList.test.tsx client/components/Search/Results/SearchResultsSection.test.tsx client/components/Search/Results/Textual/SearchResultsList.test.tsx`
- `TZ=UTC npm test`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Notes
- Running plain `npm test` in my local `Asia/Shanghai` timezone fails one existing `getSemanticVersion(new Date(2024, 0, 15))` assertion because the implementation formats UTC date parts. `TZ=UTC npm test` passes all 279 tests, matching the usual GitHub Actions timezone behavior.
- `npm run lint` exits 0; it currently prints informational Biome schema/node-protocol notices and existing jscpd clone reports.
