### PR TITLE
fix: harden the search token file permissions and hash digest

### DIFF
--- a/client/modules/searchTokenHash.test.ts
+++ b/client/modules/searchTokenHash.test.ts
@@ -1,0 +1,79 @@
+import { argon2Verify } from "hash-wasm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetLastSearchTokenHash = vi.fn();
+const mockUpdateLastSearchTokenHash = vi.fn();
+
+vi.mock("./logEntries", () => ({ addLogEntry: vi.fn() }));
+
+vi.mock("./pubSub", () => ({
+  getLastSearchTokenHash: () => mockGetLastSearchTokenHash(),
+  updateLastSearchTokenHash: (hash: string) =>
+    mockUpdateLastSearchTokenHash(hash),
+}));
+
+const searchToken = "a".repeat(64);
+
+vi.stubGlobal("VITE_SEARCH_TOKEN", searchToken);
+
+/** Digest length in bytes, read from the trailing field of the encoded hash. */
+function getDigestLength(encodedHash: string) {
+  const digest = encodedHash.split("$").pop() as string;
+  return atob(digest.replace(/-/g, "+").replace(/_/g, "/")).length;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetLastSearchTokenHash.mockReturnValue("");
+});
+
+describe("getSearchTokenHash", () => {
+  it("should produce a hash the server can verify against the search token", async () => {
+    const { getSearchTokenHash } = await import("./searchTokenHash");
+
+    const hash = await getSearchTokenHash();
+
+    // Mirrors the server-side check in verifyTokenAndRateLimit.ts
+    await expect(argon2Verify({ password: searchToken, hash })).resolves.toBe(
+      true,
+    );
+    await expect(
+      argon2Verify({ password: "b".repeat(64), hash }),
+    ).resolves.toBe(false);
+    expect(mockUpdateLastSearchTokenHash).toHaveBeenCalledWith(hash);
+  });
+
+  it("should use a digest long enough to resist blind forgery", async () => {
+    const { getSearchTokenHash } = await import("./searchTokenHash");
+
+    const hash = await getSearchTokenHash();
+
+    expect(getDigestLength(hash)).toBe(32);
+  });
+
+  it("should reuse a cached hash that still matches the search token", async () => {
+    const { getSearchTokenHash } = await import("./searchTokenHash");
+
+    const cachedHash = await getSearchTokenHash();
+    mockGetLastSearchTokenHash.mockReturnValue(cachedHash);
+    mockUpdateLastSearchTokenHash.mockClear();
+
+    expect(await getSearchTokenHash()).toBe(cachedHash);
+    expect(mockUpdateLastSearchTokenHash).not.toHaveBeenCalled();
+  });
+
+  it("should generate a fresh hash when the cached one is from another token", async () => {
+    const { getSearchTokenHash } = await import("./searchTokenHash");
+
+    mockGetLastSearchTokenHash.mockReturnValue(
+      "$argon2id$v=19$m=512,t=16,p=1$c29tZXNhbHRzb21lc2FsdA$0000000000000000000000000000000000000000000",
+    );
+
+    const hash = await getSearchTokenHash();
+
+    await expect(argon2Verify({ password: searchToken, hash })).resolves.toBe(
+      true,
+    );
+    expect(mockUpdateLastSearchTokenHash).toHaveBeenCalledWith(hash);
+  });
+});

--- a/client/modules/searchTokenHash.ts
+++ b/client/modules/searchTokenHash.ts
@@ -29,7 +29,9 @@ export async function getSearchTokenHash() {
     parallelism: 1,
     iterations: 16,
     memorySize: 512,
-    hashLength: 8,
+    // The digest is what a caller without the token would have to guess to
+    // forge a `?token=`, so it sets the ceiling on forgery resistance.
+    hashLength: 32,
     outputType: "encoded",
   });
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,7 +20,7 @@
 
 Every HTTP request from client to backend carries a `token` query parameter for CSRF protection:
 
-1. **Token Generation**: On build/startup, `regenerateSearchToken()` writes a random token to `{os.tempdir()}/minisearch-token`
+1. **Token Generation**: On build/startup, `regenerateSearchToken()` writes a random token to `{os.tempdir()}/minisearch-token`, readable only by the user running the build (`0600`)
 2. **Client Injection**: The token is injected as `VITE_SEARCH_TOKEN` compile-time constant via Vite's `define` option
 3. **Per-Request Auth**: Client includes token as `?token=` parameter on all `/search/text` and `/search/images` requests
 4. **Server Verification**: `handleTokenVerification()` in `searchEndpointServerHook.ts` validates the token before proxying to SearXNG
@@ -44,12 +44,12 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 
 - Input validation on all endpoints
 - Sanitization of user-generated content
-- Search token generation: a per-build/per-startup token written to a temp file (`server/searchToken.ts`), using 32 bytes from the `node:crypto` CSPRNG
+- Search token generation: a per-build/per-startup token written to a temp file (`server/searchToken.ts`), using 32 bytes from the `node:crypto` CSPRNG, with the file restricted to its owner (`0600`)
 - HTTPS enforcement in production
 - Regular dependency updates via Renovate
 - **Argon2 Hashing**: Access keys hashed using argon2id for secure validation (not storage encryption)
 - **Cross-Origin Isolation**: COOP/COEP headers for SharedArrayBuffer security
-- **CSRF Protection**: Search tokens validated via argon2 hash comparison
+- **CSRF Protection**: Search tokens validated via argon2 hash comparison, over a 32-byte digest
 
 ## Server-Side Security Modules
 

--- a/server/searchToken.test.ts
+++ b/server/searchToken.test.ts
@@ -3,16 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockExistsSync = vi.fn();
 const mockReadFileSync = vi.fn();
 const mockWriteFileSync = vi.fn();
+const mockChmodSync = vi.fn();
 
 vi.mock("node:fs", () => ({
   default: {
     existsSync: (...args: unknown[]) => mockExistsSync(...args),
     readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
     writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+    chmodSync: (...args: unknown[]) => mockChmodSync(...args),
   },
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
   readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
   writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  chmodSync: (...args: unknown[]) => mockChmodSync(...args),
 }));
 
 vi.mock("temp-dir", () => ({ default: "/tmp" }));
@@ -22,6 +25,7 @@ beforeEach(() => {
   mockExistsSync.mockReset();
   mockReadFileSync.mockReset();
   mockWriteFileSync.mockReset();
+  mockChmodSync.mockReset();
 });
 
 afterEach(() => {
@@ -60,19 +64,6 @@ describe("searchToken", () => {
     expect(token2).toBe("new-token-456");
   });
 
-  it("regenerateSearchToken should write a new token", async () => {
-    mockWriteFileSync.mockReturnValue(undefined);
-
-    const { regenerateSearchToken } = await import("./searchToken");
-    regenerateSearchToken();
-
-    expect(mockWriteFileSync).toHaveBeenCalled();
-    const writtenToken = mockWriteFileSync.mock.calls[0][1] as string;
-    // Token should be a random string (letters and digits, 2+ chars)
-    expect(writtenToken.length).toBeGreaterThan(2);
-    expect(writtenToken).toMatch(/^[a-z0-9]+$/);
-  });
-
   it("regenerateSearchToken should draw the token from a cryptographic source", async () => {
     mockWriteFileSync.mockReturnValue(undefined);
     const mathRandomSpy = vi.spyOn(Math, "random");
@@ -89,5 +80,19 @@ describe("searchToken", () => {
     // 32 random bytes, hex-encoded
     expect(firstToken).toMatch(/^[0-9a-f]{64}$/);
     expect(firstToken).not.toBe(secondToken);
+  });
+
+  it("regenerateSearchToken should restrict the token file to its owner", async () => {
+    mockWriteFileSync.mockReturnValue(undefined);
+    mockChmodSync.mockReturnValue(undefined);
+
+    const { regenerateSearchToken } = await import("./searchToken");
+    regenerateSearchToken();
+
+    const [filePath, , options] = mockWriteFileSync.mock.calls[0];
+    expect(options).toEqual({ mode: 0o600 });
+    // A file left behind by an earlier build keeps its old permissions,
+    // which `mode` alone would not correct.
+    expect(mockChmodSync).toHaveBeenCalledWith(filePath, 0o600);
   });
 });

--- a/server/searchToken.ts
+++ b/server/searchToken.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import temporaryDirectory from "temp-dir";
 
@@ -24,6 +24,10 @@ export const getSearchToken = () => {
  * Generates and saves a new search token
  */
 export function regenerateSearchToken() {
+  const filePath = getSearchTokenFilePath();
   const newToken = randomBytes(32).toString("hex");
-  writeFileSync(getSearchTokenFilePath(), newToken);
+  writeFileSync(filePath, newToken, { mode: 0o600 });
+  // `mode` only applies when the file is created, so a token file left behind
+  // by an earlier build would keep its old, world-readable permissions.
+  chmodSync(filePath, 0o600);
 }


### PR DESCRIPTION
## Description

Follow-up to #2217, which made the search token a CSPRNG secret. Two things still capped what that secret buys, plus a test cleanup.

**The token file was world-readable.** `regenerateSearchToken()` wrote to the predictable path `{os.tempdir()}/minisearch-token` with default permissions (`0666 & ~umask`), so on a shared host any local user could read the token and mint valid `/search/*` and `/inference` requests, no matter how the bytes were generated. It's now created with `0600`, plus a `chmodSync` right after, because `mode` only applies when the file is created and a token file left behind by an earlier build would otherwise keep its old permissions.

**The argon2 digest was 8 bytes.** The digest is the part a caller without the token would have to guess to forge a `?token=`, so it sets the ceiling on forgery resistance: 8 bytes capped it at 64 bits, whatever the token's own entropy. `hashLength` in `client/modules/searchTokenHash.ts` is now 32. Cost is unchanged (`hashLength` doesn't affect argon2's work, only the output length), and the URL grows by about 32 characters.

**Test cleanup:** the older `regenerateSearchToken should write a new token` test is gone, since its assertions (`length > 2`, lowercase alphanumeric) are both implied by the `/^[0-9a-f]{64}$/` check in the CSPRNG test from #2217.

One suggestion from the review of #2217 is deliberately not here: replacing that PR's `afterEach(vi.restoreAllMocks)` with a scoped `mockRestore()`. `client/modules/notifications.test.ts` already uses the `afterEach` form, so the file matches the existing convention, and the hook still runs when a test fails before reaching a manual restore. Leaving it alone.

| What | Where |
|---|---|
| Token file created `0600`, plus `chmodSync` for files from earlier builds | `server/searchToken.ts` |
| argon2 digest 8 → 32 bytes | `client/modules/searchTokenHash.ts` |
| Test for the file mode; redundant token-shape test dropped | `server/searchToken.test.ts` |
| First tests for the hash module (server-side round trip, digest length, cached-hash reuse) | `client/modules/searchTokenHash.test.ts` |
| Permissions and digest length recorded | `docs/security.md` |

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

## How to test

1. `npm run test` (31 files, 282 tests). Both new tests fail on the pre-change code for the right reason: `expected undefined to deeply equal { mode: 384 }` and `expected 8 to be 32`.
2. `npm run build`, then check the token file: `ls -l "$(node -e "import('temp-dir').then(m => console.log(m.default))")/minisearch-token"`. It should be `-rw-------` and 64 bytes.
3. `chmod 0666` that file, run `npm run build` again, and it should be back to `-rw-------`.

<details>
<summary>Security, performance, or breaking changes? Expand if relevant.</summary>

Security-positive, no migration needed.

The local-read exposure only mattered on hosts where another user shares the temp directory; single-user machines and one-app containers were never affected. Deployments pick both changes up on their next build.

The wider digest needs no migration because every build mints a new token, so a cached `lastSearchTokenHash` from a previous build stops verifying anyway and gets regenerated at 32 bytes. Old 8-byte hashes would still be accepted if the token were unchanged (argon2 reads the parameters from the encoded hash), which is why this doesn't reject short digests explicitly.

One new failure mode worth naming: if the token file is owned by a *different* user, `chmodSync` now throws `EPERM` and the build fails, where before it would silently overwrite that user's file. That's the vulnerable case, so failing loudly is the intent, not a regression to work around.

Verified beyond the unit tests: a real `npm run build` on macOS produced a 64-byte `0600` file and repaired a file I had set to `0666` beforehand; and a client-produced hash with the new parameters was accepted by the real `verifyTokenAndRateLimit()` against the token that build wrote (garbage still gets a 401). No live SearXNG round trip, since the instance here returns 503.

</details>
