### PR TITLE
fix: widen the access key hash digest to 32 bytes

### DIFF
--- a/client/modules/accessKey.test.ts
+++ b/client/modules/accessKey.test.ts
@@ -1,7 +1,28 @@
+import { argon2Verify } from "hash-wasm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+/** Digest length in bytes, read from the trailing field of the encoded hash. */
+function getDigestLength(encodedHash: string) {
+  const digest = encodedHash.split("$").pop() as string;
+  return atob(digest.replace(/-/g, "+").replace(/_/g, "/")).length;
+}
+
+/** Runs a validation and returns the hash that was sent to the server. */
+async function getHashSentFor(accessKey: string) {
+  const { validateAccessKey } = await import("./accessKey");
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({ valid: true }),
+  });
+
+  await validateAccessKey(accessKey);
+
+  const [, requestInit] = mockFetch.mock.calls[0];
+  return JSON.parse(requestInit.body).accessKeyHash as string;
+}
 
 vi.mock("./logEntries", () => ({
   addLogEntry: vi.fn(),
@@ -50,6 +71,22 @@ describe("Access Key Module", () => {
 
       const result = await validateAccessKey("test-key");
       expect(result).toBe(false);
+    });
+
+    it("should send a hash the server can verify against the access key", async () => {
+      const hash = await getHashSentFor("test-key-123");
+
+      // Mirrors the server-side check in validateAccessKeyServerHook.ts
+      await expect(
+        argon2Verify({ password: "test-key-123", hash }),
+      ).resolves.toBe(true);
+      await expect(
+        argon2Verify({ password: "another-key", hash }),
+      ).resolves.toBe(false);
+    });
+
+    it("should use a digest long enough to resist blind forgery", async () => {
+      expect(getDigestLength(await getHashSentFor("test-key-123"))).toBe(32);
     });
 
     it("should return false when response is not ok", async () => {

--- a/client/modules/accessKey.ts
+++ b/client/modules/accessKey.ts
@@ -19,7 +19,9 @@ async function hashAccessKey(accessKey: string): Promise<string> {
     parallelism: 1,
     iterations: 16,
     memorySize: 512,
-    hashLength: 8,
+    // The digest is what a caller without the key would have to guess to pass
+    // validation, so it sets the ceiling on forgery resistance.
+    hashLength: 32,
     outputType: "encoded",
   });
 }


### PR DESCRIPTION
## Description

Same reasoning as the search token hash in #2223, applied to access keys. `hashAccessKey()` in `client/modules/accessKey.ts` used `hashLength: 8`, and the digest is the part a caller without the key would have to guess to pass `/api/validate-access-key`, so it capped forgery resistance at 64 bits however strong the configured `ACCESS_KEYS` are. It's now 32 bytes.

Cost is unchanged, since `hashLength` doesn't affect argon2's work, only the output length.

The module had no coverage of the hash it sends, so this adds two tests: a real argon2 round trip through the same `argon2Verify` call the server makes in `validateAccessKeyServerHook.ts`, and the digest length. The round trip is a regression guard (it passes either way); the length test fails on the current code with `expected 8 to be 32`.

Independent of #2223, and touches no file that PR touches.

| What | Where |
|---|---|
| argon2 digest 8 → 32 bytes | `client/modules/accessKey.ts` |
| Tests for the hash sent to the server (round trip + digest length) | `client/modules/accessKey.test.ts` |

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

## How to test

1. `npm run test` (30 files, 280 tests).
2. To see the new test fail on the old value, set `hashLength` back to `8` in `client/modules/accessKey.ts` and run `npx vitest run client/modules/accessKey.test.ts`.

<details>
<summary>Security, performance, or breaking changes? Expand if relevant.</summary>

Security-positive, no migration needed. The server reads argon2's parameters from the encoded hash, so hashes minted before this change keep validating.

One difference from #2223 worth naming: the search token rotates on every build, so old short hashes there stop verifying immediately. Access keys don't rotate, so an 8-byte hash already in a user's `localStorage` stays valid until `VITE_ACCESS_KEY_TIMEOUT_HOURS` expires it, and only then gets replaced by a 32-byte one. No breakage either way, just a slower rollout for sessions that are already signed in.

Separate from this PR, and not addressed here: `/api/validate-access-key` has no rate limiting, unlike the search endpoints which go through `verifyTokenAndRateLimit()`. Happy to open an issue for it if you want it looked at.

</details>
