### PR TITLE
chore: ignore tsbuildinfo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .env
 /coverage
 .playwright-cli
+*.tsbuildinfo


### PR DESCRIPTION
## Description

Currently, every `npm run lint` leaves `tsconfig.node.tsbuildinfo` behind as an untracked file, so `git status` is dirty after a routine lint run and the artifact is one careless `git add` away from being committed.

It comes from `tsc -p tsconfig.node.json`: that config sets `"composite": true`, which keeps incremental build output even under `--noEmit`. Ignoring the pattern is enough, and `*.tsbuildinfo` also covers any other config that starts emitting one later.

Nothing matching the pattern is tracked today, so no `git rm --cached` is needed.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (refactor, build, chore)

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

## How to test

1. `rm -f tsconfig.node.tsbuildinfo && npm run lint`
2. `git status` should be clean, and `ls tsconfig.node.tsbuildinfo` should still show the file (ignored, not gone).
3. `git check-ignore -v tsconfig.node.tsbuildinfo` should point at the new line.
