### PR TITLE
Set explicit GITHUB_TOKEN permissions on workflow callers

### DIFF
--- a/.github/workflows/on-pull-request-to-main.yml
+++ b/.github/workflows/on-pull-request-to-main.yml
@@ -6,4 +6,6 @@ on:
 jobs:
   check-docker:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-check-docker') }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-check-docker.yml

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -4,4 +4,6 @@ on:
     branches: ["main"]
 jobs:
   check-docker:
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-check-docker.yml


### PR DESCRIPTION
## Description

Adds an explicit `permissions` block to the two jobs that call `reusable-check-docker.yml`, which closes code scanning alerts [1](https://github.com/felladrin/MiniSearch/security/code-scanning/1) and [2](https://github.com/felladrin/MiniSearch/security/code-scanning/2) (`actions/missing-workflow-permissions`).

Currently both callers omit `permissions`, so their `GITHUB_TOKEN` falls back to the repository default. The called workflow already sets `contents: read` on its own job, but that doesn't cover the gap: the docs say that when `jobs.<job_id>.permissions` is missing in the calling job, the called workflow gets the default permissions [1]. So the restriction we thought was in place was never applied.

`contents: read` is the minimum that works here. The called job needs it for `actions/checkout`, and the `{}` the alert suggests would break it, since a caller can only hand down permissions it holds itself (permissions "can be only downgraded (not elevated) by the called workflow" [1]).

Placement matches the four workflows that already declare permissions at the job level, and those four are not flagged by this rule, so the shape is known to satisfy it.

References:

- [1] [Reusing workflow configurations](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

No tests added: the change is workflow configuration, so the `check-docker` run on this PR is the test. If the permissions were too narrow, that job would fail on checkout.

## How to test

1. Check that `check-docker / Check Docker Container` passes on this PR (it exercises the calling job with the new `permissions` block).
2. After merge, confirm alerts 1 and 2 move to Closed on the next scan of `main`.

<details>
<summary>Security, performance, or breaking changes? Expand if relevant.</summary>

Security improvement, no behavior change. The token handed to the Docker check drops from the repository default to `contents: read`. Nothing in that workflow writes through the token: it checks out the repo, runs `docker compose up`, curls localhost, and tears down.

Validated with `actionlint` (exit 0, no findings across all six workflows).

Note: none of the six workflows set a top-level `permissions` baseline; all rely on per-job blocks. A top-level `contents: read` would also cover any job added later without its own block, which is what OpenSSF Scorecard recommends. CodeQL doesn't flag it, so I left it out of this PR.

</details>
