### PR TITLE
Replace llama.cpp with ONNX Runtime for reranking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,3 @@ INTERNAL_OPENAI_COMPATIBLE_API_NAME="Internal API"
 # "horde" -> AI Horde (Pre-configured)
 # "internal" -> $INTERNAL_OPENAI_COMPATIBLE_API_NAME
 DEFAULT_INFERENCE_TYPE="browser"
-
-# ONNX Runtime execution providers for the search-result reranker, in preference
-# order. Leave blank for CPU. `cpu` is always used as the final fallback, so an
-# unavailable accelerator degrades instead of failing to load.
-# "webgpu" -> GPU on Windows, Linux x64 and macOS (about 3x faster than CPU)
-# "cuda"   -> NVIDIA GPU on Linux x64, needs the CUDA v12 execution provider
-RERANKER_EXECUTION_PROVIDERS=""

--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,10 @@ INTERNAL_OPENAI_COMPATIBLE_API_NAME="Internal API"
 # "horde" -> AI Horde (Pre-configured)
 # "internal" -> $INTERNAL_OPENAI_COMPATIBLE_API_NAME
 DEFAULT_INFERENCE_TYPE="browser"
+
+# ONNX Runtime execution providers for the search-result reranker, in preference
+# order. Leave blank for CPU. `cpu` is always used as the final fallback, so an
+# unavailable accelerator degrades instead of failing to load.
+# "webgpu" -> GPU on Windows, Linux x64 and macOS (about 3x faster than CPU)
+# "cuda"   -> NVIDIA GPU on Linux x64, needs the CUDA v12 execution provider
+RERANKER_EXECUTION_PROVIDERS=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,13 @@ RUN npm ci
 
 COPY --chown=${USERNAME}:${USERNAME} . .
 
-RUN git config --global --add safe.directory ${APP_DIR} && \
+# The commit hash is optional build metadata, so a build context without a
+# usable repository must not fail the build. This happens when building from a
+# git worktree, where `.git` is a file pointing at a gitdir outside the context;
+# git then treats every command as fatal, including `config --global`.
+RUN git config --global --add safe.directory ${APP_DIR} 2>/dev/null || true; \
+  git rev-parse --short HEAD >/dev/null 2>&1 || \
+  echo "WARNING: no usable git repository in the build context, so the app will report an empty commit hash."; \
   npm run build
 
 HEALTHCHECK --interval=5m CMD curl -f http://localhost:7860/status || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,3 @@
-FROM node:lts AS llama-builder
-
-ARG LLAMA_CPP_RELEASE_TAG="b6604"
-
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  cmake \
-  ccache \
-  git \
-  curl
-
-RUN cd /tmp && \
-  git clone https://github.com/ggerganov/llama.cpp.git && \
-  cd llama.cpp && \
-  git checkout $LLAMA_CPP_RELEASE_TAG && \
-  cmake -B build -DGGML_NATIVE=OFF -DLLAMA_CURL=OFF && \
-  cmake --build build --config Release -j --target llama-server && \
-  mkdir -p /usr/local/lib/llama && \
-  find build -type f \( -name "libllama.so" -o -name "libmtmd.so" -o -name "libggml.so" -o -name "libggml-base.so" -o -name "libggml-cpu.so" \) -exec cp {} /usr/local/lib/llama/ \;
-
 FROM node:lts
 
 ARG SEARXNG_COMMIT_SHA="6da6eee265daeb4a62ab638d6921522bf405de69"
@@ -59,10 +39,6 @@ RUN chmod 644 $SEARXNG_SETTINGS_PATH && \
   sed -i 's/ultrasecretkey/'$(openssl rand -hex 32)'/g' $SEARXNG_SETTINGS_PATH && \
   /usr/local/searxng/searxng-venv/bin/pip install -r requirements.txt && \
   /usr/local/searxng/searxng-venv/bin/pip install --no-build-isolation -e .
-
-COPY --from=llama-builder /tmp/llama.cpp/build/bin/llama-server /usr/local/bin/
-COPY --from=llama-builder /usr/local/lib/llama/* /usr/local/lib/
-RUN ldconfig /usr/local/lib
 
 USER ${USERNAME}
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ flowchart LR
     subgraph container [Docker container]
         Server[App server]
         SearXNG[SearXNG<br/>metasearch]
-        Reranker[Reranker<br/>llama-server]
+        Reranker[Reranker<br/>ONNX Runtime]
     end
     UI <--> Storage
     UI -->|search| Server

--- a/agents.md
+++ b/agents.md
@@ -30,7 +30,7 @@ This is your navigation hub. Start here, follow the links, and return when you n
 - **`docs/ui-components.md`** - Component architecture and PubSub patterns
 - **`docs/search-history.md`** - History database schema and management
 - **`docs/conversation-memory.md`** - Token budgeting and rolling summaries
-- **`docs/reranking.md`** - Reranker subsystem and llama-server lifecycle
+- **`docs/reranking.md`** - Reranker subsystem and model lifecycle
 - **`docs/glossary.md`** - Codebase-specific terms and domain concepts
 
 ### Development
@@ -128,19 +128,19 @@ Need to:
 - `server/internalApiEndpointServerHook.ts` - `/inference` proxy to self-hosted API
 - `server/validateAccessKeyServerHook.ts` - Access key validation endpoint
 - `server/statusEndpointServerHook.ts` - `/status` health check endpoint
-- `server/rerankerServiceHook.ts` - llama-server lifecycle management for reranking
+- `server/rerankerServiceHook.ts` - Reranker model lifecycle management
 - `server/compressionServerHook.ts` - gzip/brotli compression for responses
 - `server/crossOriginServerHook.ts` - COOP/COEP headers for SharedArrayBuffer
 - `server/cacheServerHook.ts` - Cache-Control headers (preview server only)
 - `server/webSearchService.ts` - SearXNG integration with circuit breaker and retry logic
-- `server/rerankerService.ts` - Reranker service (llama-server process management)
+- `server/rerankerService.ts` - Reranker service (ONNX Runtime inference)
 - `server/rankSearchResults.ts` - Score-based filtering and result reordering
 - `server/searchToken.ts` - CSRF token generation and storage
 - `server/verifiedTokens.ts` - In-memory `Set<string>` of verified session tokens
 - `server/verifyTokenAndRateLimit.ts` - Token verification and rate limiting
 - `server/handleTokenVerification.ts` - Search token validation logic
 - `server/searchesSinceLastRestart.ts` - In-memory search counters for analytics
-- `server/downloadFileFromHuggingFaceRepository.ts` - Downloads GGUF models from HuggingFace
+- `server/downloadFileFromHuggingFaceRepository.ts` - Downloads model files from HuggingFace
 
 ### Hooks
 - `client/hooks/useSearchHistory.ts` - Search history management from IndexedDB

--- a/client/modules/appInfo.test.ts
+++ b/client/modules/appInfo.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { appVersion } from "@/modules/appInfo";
+
+describe("appVersion", () => {
+  it("appends the commit hash as semver build metadata when the build had one", () => {
+    // vitest.config.ts defines VITE_COMMIT_SHORT_HASH as "test-hash".
+    expect(appVersion).toMatch(/^\d{4}\.\d{1,2}\.\d{1,2}\+test-hash$/);
+  });
+
+  it("never leaves a dangling separator", () => {
+    // A build context without a usable git repository yields an empty hash, and
+    // "1.2.3+" is not a valid version string.
+    expect(appVersion.endsWith("+")).toBe(false);
+  });
+});

--- a/client/modules/appInfo.ts
+++ b/client/modules/appInfo.ts
@@ -10,6 +10,12 @@ export const appName = repository.url.split("/").pop();
  */
 export const appRepository = repository.url;
 /**
- * Application version with build timestamp and commit hash
+ * Application version with build timestamp and, when the build had a git
+ * repository available, the commit hash as semver build metadata.
  */
-export const appVersion = `${getSemanticVersion(VITE_BUILD_DATE_TIME)}+${VITE_COMMIT_SHORT_HASH}`;
+export const appVersion = [
+  getSemanticVersion(VITE_BUILD_DATE_TIME),
+  VITE_COMMIT_SHORT_HASH,
+]
+  .filter(Boolean)
+  .join("+");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,12 @@ INTERNAL_OPENAI_COMPATIBLE_API_NAME="Company LLM"
 |----------|---------|-------------|
 | `DEFAULT_INFERENCE_TYPE` | `browser` | Default AI inference type (`browser`, `openai`, `horde`, `internal`) |
 
+### Reranker
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RERANKER_EXECUTION_PROVIDERS` | `''` | Comma-separated ONNX Runtime execution providers, in preference order (e.g. `webgpu` or `cuda`). Blank means CPU. `cpu` is always appended as the final fallback. See `docs/reranking.md#execution-providers` |
+
 ### Server Configuration
 
 These variables control the Vite development/preview server behavior:
@@ -197,16 +203,13 @@ Same structure but without volume mounts and with pre-built assets.
 
 ### Dockerfile Environment
 
-The Dockerfile sets up:
-1. **Builder stage**: Compiles `llama-server` from llama.cpp
-2. **Runtime stage**: 
+The Dockerfile sets up a single runtime stage:
    - Node.js LTS
    - Python 3 + SearXNG
-   - llama-server binary
 
 The app runs under the `node` user, with the app directory at `/home/node/app`. The production image starts the app with `npm start -- --host` (i.e. `vite preview`), not `npm run dev`.
 
-**Multi-service container** runs all three concurrently via shell process composition.
+**Multi-service container** runs SearXNG and Node.js concurrently via shell process composition.
 
 ## Vite Environment Injection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,12 +50,6 @@ INTERNAL_OPENAI_COMPATIBLE_API_NAME="Company LLM"
 |----------|---------|-------------|
 | `DEFAULT_INFERENCE_TYPE` | `browser` | Default AI inference type (`browser`, `openai`, `horde`, `internal`) |
 
-### Reranker
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `RERANKER_EXECUTION_PROVIDERS` | `''` | Comma-separated ONNX Runtime execution providers, in preference order (e.g. `webgpu` or `cuda`). Blank means CPU. `cpu` is always appended as the final fallback. See `docs/reranking.md#execution-providers` |
-
 ### Server Configuration
 
 These variables control the Vite development/preview server behavior:

--- a/docs/development-commands.md
+++ b/docs/development-commands.md
@@ -10,7 +10,7 @@
 
 ## Docker
 
-- **`docker compose up`**: Development environment with SearXNG, llama-server, and Node.js
+- **`docker compose up`**: Development environment with SearXNG and Node.js
 - **`docker compose -f docker-compose.production.yml up --build`**: Production deployment
 
 ## Testing
@@ -70,8 +70,7 @@ Used by both `on-push-to-main` and `on-pull-request-to-main` to run the producti
 ### Docker Image Builds
 
 The Docker image uses a multi-stage build:
-1. **Builder stage** (`llama-builder`): Compiles llama-server from llama.cpp source, extracts shared libraries (`libllama.so`, `libmtmd.so`, `libggml.so`, etc.)
-2. **Runtime stage**: Installs Python/SearXNG, copies llama-server binaries, builds the Vite frontend, runs SearXNG and Node.js in a single container via shell process composition
+The image installs Python/SearXNG, builds the Vite frontend, and runs SearXNG and Node.js in a single container via shell process composition. No compilation step is required: the reranker's ONNX Runtime binaries ship prebuilt with the npm dependency.
 
 The production image is published to `ghcr.io` with multi-platform support (linux/amd64, linux/arm64). Tags and labels are auto-generated from Git metadata via `docker/metadata-action`.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -34,9 +34,9 @@ Instead of a heavy state management library like Redux, MiniSearch uses a minima
 
 ### Reranker
 
-A secondary search stage that takes initial results from SearXNG and re-orders them based on relevance to the query using a cross-encoder model (`jina-reranker-v1-tiny-en`) running on a local `llama-server` instance.
+A secondary search stage that takes initial results from SearXNG and re-orders them based on relevance to the query using a cross-encoder model (`jina-reranker-v1-tiny-en`) running in-process via ONNX Runtime.
 
-- **Implementation**: Spawns `llama-server` child process with `--reranking` and `--pooling rank` flags
+- **Implementation**: Loads the model's ONNX export with `onnxruntime-node`; no child process
 - **Health Check**: Polls `/health` endpoint via `getRerankerStatus`
 - **Scoring**: Results filtered using standard deviation thresholds (`kStandardDeviationFactor = 0.3`)
 - **Fallback**: If reranker is unhealthy, returns unranked SearXNG results
@@ -95,7 +95,7 @@ Middleware registered via Vite plugin hooks (`configureServer`, `configurePrevie
 | `cacheServerHook` | Cache-Control headers |
 | `validateAccessKeyServerHook` | Access key validation |
 | `internalApiEndpointServerHook` | `/inference` proxy |
-| `rerankerServiceHook` | llama-server lifecycle management |
+| `rerankerServiceHook` | Reranker model lifecycle management |
 
 ### Circuit Breaker
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -41,10 +41,10 @@ The application has three primary entry points:
 
 The Docker container runs three services concurrently:
 - **SearXNG** - Privacy-focused metasearch engine
-- **llama-server** - Local AI inference server
+- **ONNX Runtime** - In-process inference for result reranking
 - **Node.js application** - Main application server
 
-The multi-stage build process first compiles llama-server from source, then creates the final runtime image with Node.js and Python environments. The container entrypoint starts SearXNG in the background and then launches the Node.js application.
+The build creates a runtime image with Node.js and Python environments. The container entrypoint starts SearXNG in the background and then launches the Node.js application.
 
 ## State Management Architecture
 
@@ -76,7 +76,7 @@ The system supports two operational modes:
 - Vite preview server (no HMR)
 - Optimized bundle with minification
 
-Both modes run the same underlying services (SearXNG, llama-server) but differ in how the frontend is served and rebuilt.
+Both modes run the same underlying services (SearXNG, the reranker) but differ in how the frontend is served and rebuilt.
 
 ## Search and AI Integration Flow
 
@@ -102,7 +102,7 @@ The system executes two parallel flows when a user submits a query:
 5. Response updates throttled to ~12 updates/sec via `throttleit` to prevent React render overload
 6. Response saved to history database via `saveLlmResponseForQuery`
 
-The `textGeneration` module orchestrates the entire search-to-response flow, managing search requests, LLM context preparation, and response streaming. Search results are optionally reranked using a local llama-server instance before being passed to the LLM for response generation.
+The `textGeneration` module orchestrates the entire search-to-response flow, managing search requests, LLM context preparation, and response streaming. Search results are optionally reranked in-process via ONNX Runtime before being passed to the LLM for response generation.
 
 ### Web Search Service Reliability
 
@@ -192,7 +192,7 @@ MiniSearch implements all server-side logic as Vite plugin hooks. Each hook regi
 | `cacheServerHook` | `server/cacheServerHook.ts` | Cache-Control headers (preview only) |
 | `validateAccessKeyServerHook` | `server/validateAccessKeyServerHook.ts` | Access key validation endpoint |
 | `internalApiEndpointServerHook` | `server/internalApiEndpointServerHook.ts` | `/inference` proxy to self-hosted API |
-| `rerankerServiceHook` | `server/rerankerServiceHook.ts` | llama-server lifecycle management for result reranking |
+| `rerankerServiceHook` | `server/rerankerServiceHook.ts` | Reranker model lifecycle management for result reranking |
 
 Key server-side modules:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -47,7 +47,7 @@ Production mode:
 
 The Docker container runs three services concurrently:
 - **SearXNG** - Privacy-focused metasearch engine (starts in background)
-- **llama-server** - Local AI inference server (for result reranking)
+- **ONNX Runtime** - In-process inference for result reranking
 - **Node.js (Vite)** - Main application server
 
 ### Startup Sequence

--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -1,6 +1,6 @@
 # Search Result Reranking
 
-MiniSearch optionally reranks search results using a cross-encoder model running on a local `llama-server` instance. This secondary search stage reorders initial SearXNG results based on their semantic relevance to the user's query.
+MiniSearch optionally reranks search results using a cross-encoder model running in-process via ONNX Runtime. This secondary search stage reorders initial SearXNG results based on their semantic relevance to the user's query.
 
 ## Architecture Overview
 
@@ -8,7 +8,7 @@ The reranking subsystem consists of three components:
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Service Manager | `server/rerankerService.ts` | llama-server lifecycle, health checks, reranking API calls |
+| Service Manager | `server/rerankerService.ts` | Model loading, readiness state, reranking inference |
 | Ranking Logic | `server/rankSearchResults.ts` | Score-based filtering and result reordering |
 | Server Hook | `server/rerankerServiceHook.ts` | Startup/shutdown coordination with Vite server |
 
@@ -18,51 +18,41 @@ The reranking subsystem consists of three components:
 
 The `rerankerServiceHook` starts the reranker during server initialization:
 
-1. Downloads the model from HuggingFace if not present (`Felladrin/gguf-jina-reranker-v1-tiny-en/jina-reranker-v1-tiny-en-Q8_0.gguf`)
-2. Spawns `llama-server` as a child process
-3. Polls `/health` endpoint until status is `ok`
-4. Performs a warmup rerank request (`query: "test"`, `documents: ["test document"]`) to ensure the model is fully loaded
-5. Sets `isReady = true`
+1. Downloads the model and tokenizer from HuggingFace if not present (`jinaai/jina-reranker-v1-tiny-en`)
+2. Creates an ONNX Runtime inference session
+3. Performs a warmup inference (`query: "test"`, `documents: ["test document"]`) to ensure the graph is initialized
+4. Sets `isReady = true`
 
-### llama-server Configuration
+There is no child process, port, or health endpoint: inference runs inside the Node process.
 
-The reranker process is spawned with these arguments:
+### Execution Providers
 
-| Argument | Value | Purpose |
-|----------|-------|---------|
-| `--model` | `jina-reranker-v1-tiny-en-Q8_0.gguf` | Cross-encoder reranking model |
-| `--ctx-size` | 2048 | Context window size |
-| `--batch-size` | 2048 | Batch processing size |
-| `--ubatch-size` | 2048 | Micro-batch size |
-| `--flash-attn` | auto | Flash attention optimization |
-| `--host` | 127.0.0.1 | Local-only binding |
-| `--port` | 8012 | Service port |
-| `--threads` | 1 | Single-threaded operation |
-| `--parallel` | 1 | Single parallel request |
-| `--reranking` | (flag) | Enable reranking mode |
-| `--pooling` | rank | Rank pooling strategy |
+By default the reranker runs on CPU. Set `RERANKER_EXECUTION_PROVIDERS` to a comma-separated preference list to use an accelerator:
 
-### Automatic Restart
+```sh
+RERANKER_EXECUTION_PROVIDERS=webgpu
+```
 
-If the `llama-server` process exits unexpectedly:
+`cpu` is always appended as the final fallback, so an unavailable accelerator degrades to CPU instead of failing to load. The requested list is logged at startup.
 
-1. `isReady` is set to `false`
-2. A 5-second restart timeout is scheduled
-3. `startRerankerService()` is called again automatically
-4. Binary compatibility errors (`SIGTRAP`, `SIGILL`) are logged with architecture details
+| Provider | Availability | Notes |
+|----------|--------------|-------|
+| `cpu` | Everywhere | Default |
+| `webgpu` | Windows, Linux x64, macOS | Roughly 3x faster than CPU; experimental in ONNX Runtime |
+| `cuda` | Linux x64 (CUDA v12) | The CUDA binaries are not bundled; install them with `npm install onnxruntime-node --onnxruntime-node-install=cuda12` |
+| `coreml` | macOS | Not recommended: slower than CPU for this model's dynamic shapes |
+
+### Batching
+
+Documents are scored in batches of 10. `onnxruntime-node` wraps a synchronous native call, so scoring all 30 results at once would block the event loop for the full duration. Batching yields between calls, capping the stall at roughly 27ms rather than 78ms, at the cost of about 4% more wall time. Scores are identical either way, because padding is per batch but the attention mask excludes it.
 
 ### Shutdown
 
-On server close, `stopRerankerService()` clears any pending restart timeout and kills the child process.
+On server close, `stopRerankerService()` clears the readiness flag and releases the inference session.
 
 ## Health Monitoring
 
-`getRerankerStatus()` performs a live health check by fetching `/health` from the llama-server. Returns `false` if:
-- `isReady` flag is `false`
-- Health endpoint is unreachable
-- Response status is not `ok`
-
-The search endpoint checks reranker health before attempting ranking and falls back to unranked SearXNG results if unhealthy.
+`getRerankerStatus()` reports whether the model finished loading. The search endpoint checks it before attempting ranking and falls back to unranked SearXNG results if the reranker is unavailable.
 
 ## Reranking Process
 
@@ -75,21 +65,23 @@ const doc = `[${title}](${url} "${snippet}")`.toLocaleLowerCase();
 // Truncated to MAX_DOCUMENT_LENGTH (512 characters)
 ```
 
-Both query and documents are lowercased and Unicode surrogates are sanitized before sending to the reranker.
+Both query and documents are lowercased and Unicode surrogates are sanitized before tokenization.
 
 ### Unicode Sanitization
 
-`sanitizeUnicodeSurrogates()` validates Unicode surrogate pairs in input strings. Invalid surrogates are replaced with the Unicode replacement character (`\ufffd`). This prevents crashes when processing malformed UTF-8 from web search results.
+`sanitizeUnicodeSurrogates()` validates Unicode surrogate pairs in input strings. Invalid surrogates are replaced with the Unicode replacement character (`�`). This prevents failures when processing malformed UTF-8 from web search results.
 
 ### Scoring and Filtering
 
-The reranker returns relevance scores for each document. Results are filtered using a two-stage statistical approach:
+The reranker returns the classifier's raw relevance logit for each document. Scores are deliberately not passed through a sigmoid, because the filter below is calibrated against the raw scale. Results are then filtered using a two-stage statistical approach:
 
 1. **Score Normalization**: Scores are shifted to positive range by adding the absolute value of the minimum score
 2. **Standard Deviation Filter**: Results below `mean - kStandardDeviationFactor * standardDeviation` are filtered out
    - `kStandardDeviationFactor = 0.3`
 3. **Percentage Fallback**: If fewer than 40% of results pass the standard deviation filter, a fallback threshold is applied:
    - `minPercentageFallback = 0.4` (40% of the highest normalized score)
+
+This filter is invariant to linear rescaling of the scores, since both the scores and the threshold scale together.
 
 ### Preserve Top Results Mode
 
@@ -121,21 +113,32 @@ Reranking is applied to both text and image search results. For image results, t
 | Property | Value |
 |----------|-------|
 | Model | jina-reranker-v1-tiny-en |
-| Format | GGUF (Q8_0 quantized) |
-| HuggingFace Repo | Felladrin/gguf-jina-reranker-v1-tiny-en |
+| Format | ONNX (fp32) |
+| HuggingFace Repo | jinaai/jina-reranker-v1-tiny-en |
 | Type | Cross-encoder reranker |
-| Language | English |
-| Storage | `server/models/Felladrin/gguf-jina-reranker-v1-tiny-en/` |
+| Size | 4 layers, 33M parameters |
+| Storage | `server/models/jinaai/jina-reranker-v1-tiny-en/` |
+
+Despite being an English model, it ranks non-English results (Portuguese, for example) well in practice, which is why it is preferred over larger alternatives.
+
+Quantized variants are deliberately not used. The `q8` export measurably degrades ranking quality on this 33M-parameter model, and the `fp16` export fails to load in `onnxruntime-node`.
+
+## Testing
+
+`server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality against English and Portuguese fixtures. It downloads ~130MB, so it is excluded from the default suite:
+
+```sh
+npx vitest run --config vitest.integration.config.ts
+```
 
 ## Error Handling
 
 | Scenario | Behavior |
 |----------|----------|
 | Reranker not ready | Falls back to unranked SearXNG results |
-| Reranking API error | `isReady` set to `false`, process killed, auto-restart scheduled |
-| Empty documents array | Returns empty array without calling reranker |
+| Model fails to load | Logged by the hook; reranker stays unready and search returns unranked results |
+| Empty documents array | Returns empty array without running inference |
 | Unicode sanitization needed | Logs warning, continues with sanitized input |
-| Binary architecture mismatch | Logs `SIGTRAP`/`SIGILL` error with architecture details |
 
 ## Related Topics
 

--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -27,20 +27,18 @@ There is no child process, port, or health endpoint: inference runs inside the N
 
 ### Execution Providers
 
-By default the reranker runs on CPU. Set `RERANKER_EXECUTION_PROVIDERS` to a comma-separated preference list to use an accelerator:
+The session requests `["webgpu", "cpu"]`, with no configuration to set. WebGPU is roughly 3x faster than CPU (24ms against 77ms for 30 documents) and agrees with it to within float32 rounding (1e-6, identical ordering), so it is preferred where it works. Listing `cpu` after it means hosts without a usable GPU provider fall back rather than failing to load. The list is logged at startup.
 
-```sh
-RERANKER_EXECUTION_PROVIDERS=webgpu
-```
+Note that ONNX Runtime's WebGPU provider here is native, part of the `onnxruntime-node` binary. It is not the browser API, so it needs neither a browser nor Deno.
 
-`cpu` is always appended as the final fallback, so an unavailable accelerator degrades to CPU instead of failing to load. The requested list is logged at startup.
+| Provider | Availability in the Node binding | Notes |
+|----------|----------------------------------|-------|
+| `cpu` | Everywhere | Fallback |
+| `webgpu` | Windows, Linux x64, macOS | Preferred; experimental in ONNX Runtime |
+| `cuda` | Linux x64 (CUDA v12) | Not used: the binaries are not bundled, and would need `npm install onnxruntime-node --onnxruntime-node-install=cuda12` |
+| `coreml` | macOS | Not used: slower than CPU for this model's dynamic shapes |
 
-| Provider | Availability | Notes |
-|----------|--------------|-------|
-| `cpu` | Everywhere | Default |
-| `webgpu` | Windows, Linux x64, macOS | Roughly 3x faster than CPU; experimental in ONNX Runtime |
-| `cuda` | Linux x64 (CUDA v12) | The CUDA binaries are not bundled; install them with `npm install onnxruntime-node --onnxruntime-node-install=cuda12` |
-| `coreml` | macOS | Not recommended: slower than CPU for this model's dynamic shapes |
+There is no GPU provider for Linux arm64, so those hosts always run on CPU.
 
 ### Batching
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.0",
         "@huggingface/hub": "^2.0.0",
+        "@huggingface/tokenizers": "^0.1.3",
         "@leeoniya/ufuzzy": "^1.0.19",
         "@mantine/carousel": "^9.0.0",
         "@mantine/code-highlight": "^9.0.0",
@@ -34,6 +35,7 @@
         "http-compression": "^1.0.20",
         "keyword-extractor": "^0.0.28",
         "node-emoji": "^2.1.3",
+        "onnxruntime-node": "^1.24.3",
         "postcss": "^8.4.45",
         "postcss-preset-mantine": "^1.17.0",
         "postcss-simple-vars": "^7.0.1",
@@ -730,6 +732,12 @@
       "resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.21.30.tgz",
       "integrity": "sha512-PuVs9EEstMxlSx7s2iP2W6N/sRFmPPB6etH6KswryOrszrC8wFqoAWyeEFm6fjhvZ1N6WaUJrtpioRpEiPtGKA==",
       "license": "MIT"
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@huggingface/xetchunk-wasm": {
       "version": "0.1.0",
@@ -2817,6 +2825,15 @@
       "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/ai": {
       "version": "7.0.40",
       "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.40.tgz",
@@ -2915,6 +2932,13 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -3275,6 +3299,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -3286,6 +3327,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dequal": {
@@ -3306,6 +3364,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -3483,11 +3547,35 @@
         "errno": "cli.js"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "license": "MIT"
     },
     "node_modules/escalade": {
@@ -3672,6 +3760,23 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/globals": {
       "version": "17.8.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
@@ -3683,6 +3788,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gpt-tokenizer": {
@@ -3707,6 +3840,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash-wasm": {
@@ -4338,6 +4483,12 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/keyword-extractor": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/keyword-extractor/-/keyword-extractor-0.0.28.tgz",
@@ -4785,6 +4936,30 @@
       "dependencies": {
         "semver": "^7.5.3"
       },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -5738,6 +5913,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -5764,6 +5948,29 @@
         "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
       }
     },
     "node_modules/open": {
@@ -6595,6 +6802,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -6747,13 +6971,45 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/shiki": {
@@ -6836,6 +7092,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.0",
     "@huggingface/hub": "^2.0.0",
+    "@huggingface/tokenizers": "^0.1.3",
     "@leeoniya/ufuzzy": "^1.0.19",
     "@mantine/carousel": "^9.0.0",
     "@mantine/code-highlight": "^9.0.0",
@@ -53,6 +54,7 @@
     "http-compression": "^1.0.20",
     "keyword-extractor": "^0.0.28",
     "node-emoji": "^2.1.3",
+    "onnxruntime-node": "^1.24.3",
     "postcss": "^8.4.45",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",

--- a/server/rerankerService.integration.test.ts
+++ b/server/rerankerService.integration.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment node
+
+/**
+ * Exercises the real reranker model end to end, including the multilingual
+ * behaviour that motivated picking jina-reranker-v1-tiny-en. Downloads ~130MB
+ * on first run, so it is excluded from the default suite:
+ *
+ *   npx vitest run --config vitest.integration.config.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getRerankerStatus,
+  rerank,
+  startRerankerService,
+  stopRerankerService,
+} from "./rerankerService";
+
+type SearchResult = [title: string, content: string, url: string];
+
+type Fixture = {
+  name: string;
+  query: string;
+  results: SearchResult[];
+  /** Indices of `results` a human would consider relevant to `query`. */
+  relevant: number[];
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: "english / factual",
+    query: "how to reverse a string in javascript",
+    results: [
+      [
+        "Reverse a String in JavaScript",
+        "Use split(''), reverse() and join('') to reverse a string in JavaScript.",
+        "https://a.dev/reverse",
+      ],
+      [
+        "Best Hotels in Reverse, Texas",
+        "Compare 240 hotels in Reverse with free cancellation and instant booking.",
+        "https://hotels.com/reverse-tx",
+      ],
+      [
+        "How do I reverse a string in JS? - Stack Overflow",
+        "I want to take a string and reverse its characters. What is the idiomatic way?",
+        "https://so.com/q/958908",
+      ],
+      [
+        "String Manipulation in Python",
+        "Learn slicing, concatenation and formatting of Python strings from scratch.",
+        "https://py.io/strings",
+      ],
+      [
+        "Reverse Mortgage Calculator 2026",
+        "Estimate how much equity you can access with a reverse mortgage this year.",
+        "https://finance.com/reverse-mortgage",
+      ],
+      [
+        "Reversing Unicode strings correctly",
+        "Naive reversal breaks emoji and combining characters. Use Intl.Segmenter instead.",
+        "https://a.dev/unicode-reverse",
+      ],
+    ],
+    relevant: [0, 2, 5],
+  },
+  {
+    name: "portuguese / recipe",
+    query: "como fazer pão de queijo caseiro",
+    results: [
+      [
+        "Receita de Pão de Queijo Caseiro Fácil",
+        "Aprenda a fazer pão de queijo mineiro com polvilho doce, queijo meia cura e leite.",
+        "https://receitas.com/pao-de-queijo",
+      ],
+      [
+        "Onde comprar polvilho azedo online",
+        "Compare preços de polvilho azedo e doce em 12 lojas com entrega para todo o Brasil.",
+        "https://mercado.br/polvilho",
+      ],
+      [
+        "Pão de Queijo: a receita original de Minas Gerais",
+        "O segredo do pão de queijo caseiro está no polvilho azedo e no ponto da massa escaldada.",
+        "https://cozinha.br/pao-queijo-mg",
+      ],
+      [
+        "Bolo de cenoura com cobertura de chocolate",
+        "Receita de bolo de cenoura fofinho com cobertura cremosa de chocolate meio amargo.",
+        "https://receitas.com/bolo-cenoura",
+      ],
+      [
+        "Queijo Minas Artesanal: história e produção",
+        "Conheça o processo de maturação do queijo minas e as regiões produtoras do estado.",
+        "https://queijos.br/minas-artesanal",
+      ],
+    ],
+    relevant: [0, 2],
+  },
+  {
+    name: "portuguese / technical",
+    query: "configurar nginx como proxy reverso",
+    results: [
+      [
+        "Como configurar o Nginx como proxy reverso",
+        "Tutorial passo a passo para configurar proxy_pass, headers e upstream no Nginx.",
+        "https://tutoriais.br/nginx-proxy-reverso",
+      ],
+      [
+        "Certificados SSL grátis com Let's Encrypt",
+        "Emita e renove certificados SSL automaticamente usando o Certbot.",
+        "https://tutoriais.br/lets-encrypt",
+      ],
+      [
+        "Nginx Reverse Proxy Guide",
+        "Configure Nginx as a reverse proxy with proxy_pass, load balancing and SSL termination.",
+        "https://docs.nginx.com/reverse-proxy",
+      ],
+      [
+        "Instalando o Nginx no Ubuntu 24.04",
+        "Guia de instalação do Nginx via apt e configuração inicial do firewall.",
+        "https://tutoriais.br/instalar-nginx",
+      ],
+      [
+        "Nginx: erro 502 Bad Gateway ao usar proxy_pass",
+        "Como diagnosticar e resolver o erro 502 na configuração de proxy reverso do Nginx.",
+        "https://forum.br/nginx-502",
+      ],
+    ],
+    relevant: [0, 2, 4],
+  },
+  {
+    name: "english / ambiguous term",
+    query: "jaguar animal habitat and diet",
+    results: [
+      [
+        "Jaguar F-PACE 2026 Review",
+        "The F-PACE gets a refreshed interior and a new mild-hybrid powertrain for 2026.",
+        "https://cars.com/jaguar-f-pace",
+      ],
+      [
+        "Jaguar | Species Profile - WWF",
+        "The jaguar is the largest cat in the Americas, living in rainforest and wetland habitats.",
+        "https://wwf.org/jaguar",
+      ],
+      [
+        "Jacksonville Jaguars 2026 Schedule",
+        "Full regular season schedule, opponents and kickoff times for the Jaguars.",
+        "https://nfl.com/jaguars-schedule",
+      ],
+      [
+        "What do jaguars eat?",
+        "Jaguars are apex predators feeding on capybara, caiman, peccary, deer and fish.",
+        "https://animals.net/jaguar-diet",
+      ],
+      [
+        "Jaguar XJ220: the 1990s supercar",
+        "How Jaguar built a 217mph V6 supercar and then struggled to sell it.",
+        "https://classics.com/xj220",
+      ],
+    ],
+    relevant: [1, 3],
+  },
+];
+
+const MAX_DOCUMENT_LENGTH = 512;
+
+/** Mirrors the document formatting in rankSearchResults.ts. */
+function buildDocuments(results: SearchResult[]) {
+  return results.map(([title, snippet, url]) => {
+    const doc =
+      `[${title}](${url} "${snippet.replaceAll('"', "'")}")`.toLocaleLowerCase();
+    return doc.length > MAX_DOCUMENT_LENGTH
+      ? doc.slice(0, MAX_DOCUMENT_LENGTH)
+      : doc;
+  });
+}
+
+describe("reranker service", () => {
+  beforeAll(async () => {
+    await startRerankerService();
+  }, 600_000);
+
+  afterAll(async () => {
+    await stopRerankerService();
+  });
+
+  it("reports ready after startup", async () => {
+    expect(await getRerankerStatus()).toBe(true);
+  });
+
+  it("returns an empty array without calling the model", async () => {
+    expect(await rerank("anything", [])).toEqual([]);
+  });
+
+  for (const fixture of fixtures) {
+    it(`ranks relevant results first: ${fixture.name}`, async () => {
+      const documents = buildDocuments(fixture.results);
+      const scored = await rerank(fixture.query.toLocaleLowerCase(), documents);
+
+      expect(scored).toHaveLength(fixture.results.length);
+      expect(
+        scored.every(({ relevance_score }) => Number.isFinite(relevance_score)),
+      ).toBe(true);
+
+      const ordered = scored
+        .slice()
+        .sort((a, b) => b.relevance_score - a.relevance_score)
+        .map(({ index }) => index);
+
+      expect(fixture.relevant).toContain(ordered[0]);
+
+      const topRelevant = ordered
+        .slice(0, fixture.relevant.length)
+        .filter((index) => fixture.relevant.includes(index)).length;
+      expect(topRelevant / fixture.relevant.length).toBeGreaterThanOrEqual(0.5);
+    }, 120_000);
+  }
+});

--- a/server/rerankerService.integration.test.ts
+++ b/server/rerankerService.integration.test.ts
@@ -207,12 +207,14 @@ describe("reranker service", () => {
         .sort((a, b) => b.relevance_score - a.relevance_score)
         .map(({ index }) => index);
 
-      expect(fixture.relevant).toContain(ordered[0]);
-
-      const topRelevant = ordered
+      // Every relevant result must outrank every irrelevant one. The model
+      // clears this with a score gap of at least 0.99 between the two groups,
+      // so it is not sensitive to the ~1e-6 difference between the CPU and
+      // WebGPU execution providers.
+      const topIndices = ordered
         .slice(0, fixture.relevant.length)
-        .filter((index) => fixture.relevant.includes(index)).length;
-      expect(topRelevant / fixture.relevant.length).toBeGreaterThanOrEqual(0.5);
+        .sort((a, b) => a - b);
+      expect(topIndices).toEqual([...fixture.relevant].sort((a, b) => a - b));
     }, 120_000);
   }
 });

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -34,21 +34,14 @@ const MAX_SEQUENCE_LENGTH = 2048;
 const BATCH_SIZE = 10;
 
 /**
- * ONNX Runtime execution providers, in preference order. Defaults to CPU;
- * `cpu` is always appended so an unavailable accelerator degrades instead of
- * failing to load. Set RERANKER_EXECUTION_PROVIDERS=webgpu to opt into GPU
- * where one is available (WebGPU is supported on Windows, Linux x64 and macOS,
- * and CUDA v12 on Linux x64). Avoid `coreml`: it is slower than CPU for this
- * model's dynamic shapes.
+ * ONNX Runtime execution providers, in preference order. WebGPU is roughly 3x
+ * faster than CPU here and agrees with it to within float32 rounding, so it is
+ * preferred when available; listing `cpu` after it means platforms without a
+ * usable GPU provider (Linux arm64, or any host without a GPU) fall back
+ * instead of failing to load. `coreml` is deliberately absent: it is slower
+ * than CPU for this model's dynamic shapes.
  */
-function getExecutionProviders() {
-  const configured = (process.env.RERANKER_EXECUTION_PROVIDERS ?? "")
-    .split(",")
-    .map((provider) => provider.trim())
-    .filter(Boolean);
-
-  return configured.includes("cpu") ? configured : [...configured, "cpu"];
-}
+const EXECUTION_PROVIDERS = ["webgpu", "cpu"];
 
 let isReady = false;
 let session: InferenceSession | null = null;
@@ -121,10 +114,8 @@ export async function startRerankerService() {
     ensureFileExists(TOKENIZER_CONFIG_HF_FILE),
   ]);
 
-  const executionProviders = getExecutionProviders();
-
   printMessage(
-    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${executionProviders.join(", ")})...`,
+    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${EXECUTION_PROVIDERS.join(", ")})...`,
   );
 
   tokenizer = new Tokenizer(
@@ -132,7 +123,12 @@ export async function startRerankerService() {
     JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
   );
 
-  session = await InferenceSession.create(modelPath, { executionProviders });
+  session = await InferenceSession.create(modelPath, {
+    executionProviders: EXECUTION_PROVIDERS,
+    // Errors only. ONNX Runtime otherwise warns on every startup that it
+    // assigned shape operators to CPU, which is expected and not actionable.
+    logSeverityLevel: 3,
+  });
 
   await score("test", ["test document"]);
 

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -1,22 +1,58 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Tokenizer } from "@huggingface/tokenizers";
 import debug from "debug";
+import { InferenceSession, Tensor } from "onnxruntime-node";
 import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository";
 
 const fileName = path.basename(import.meta.url);
 const printMessage = debug(fileName);
 printMessage.enabled = true;
 
-const SERVICE_HOST = "127.0.0.1";
-const SERVICE_PORT = 8012;
-const VERBOSE_MODE = false;
-const MODEL_HF_REPO = "Felladrin/gguf-jina-reranker-v1-tiny-en";
-const MODEL_HF_FILE = "jina-reranker-v1-tiny-en-Q8_0.gguf";
+const MODEL_HF_REPO = "jinaai/jina-reranker-v1-tiny-en";
+const MODEL_HF_FILE = "onnx/model.onnx";
+const TOKENIZER_HF_FILE = "tokenizer.json";
+const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
+
+/** From the model's config.json. */
+const PAD_TOKEN_ID = 0;
+
+/**
+ * Documents are truncated to 512 characters upstream, so this only guards
+ * against pathological tokenization.
+ */
+const MAX_SEQUENCE_LENGTH = 2048;
+
+/**
+ * onnxruntime-node wraps a synchronous native call, so a single large batch
+ * blocks the event loop for its whole duration. Scoring in batches yields
+ * between them, capping the stall at ~27ms instead of ~78ms for 30 results,
+ * for about 4% more wall time. Scores are unaffected: padding is per batch but
+ * the attention mask makes the result identical either way.
+ */
+const BATCH_SIZE = 10;
+
+/**
+ * ONNX Runtime execution providers, in preference order. Defaults to CPU;
+ * `cpu` is always appended so an unavailable accelerator degrades instead of
+ * failing to load. Set RERANKER_EXECUTION_PROVIDERS=webgpu to opt into GPU
+ * where one is available (WebGPU is supported on Windows, Linux x64 and macOS,
+ * and CUDA v12 on Linux x64). Avoid `coreml`: it is slower than CPU for this
+ * model's dynamic shapes.
+ */
+function getExecutionProviders() {
+  const configured = (process.env.RERANKER_EXECUTION_PROVIDERS ?? "")
+    .split(",")
+    .map((provider) => provider.trim())
+    .filter(Boolean);
+
+  return configured.includes("cpu") ? configured : [...configured, "cpu"];
+}
 
 let isReady = false;
-let serverProcess: ChildProcess | null = null;
-let restartTimeout: NodeJS.Timeout | null = null;
+let session: InferenceSession | null = null;
+let tokenizer: Tokenizer | null = null;
 
 /**
  * Sanitizes Unicode surrogate pairs in input string
@@ -57,170 +93,125 @@ export function sanitizeUnicodeSurrogates(input: string) {
   return output;
 }
 
-export function getRerankerModelPath() {
+function resolveModelPath(hfRepoFile: string) {
   return path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "models",
     MODEL_HF_REPO,
-    MODEL_HF_FILE,
+    hfRepoFile,
   );
 }
 
-async function ensureModelExists(modelPath: string) {
+async function ensureFileExists(hfRepoFile: string) {
+  const localPath = resolveModelPath(hfRepoFile);
   await downloadFileFromHuggingFaceRepository(
     MODEL_HF_REPO,
-    MODEL_HF_FILE,
-    modelPath,
+    hfRepoFile,
+    localPath,
   );
+  return localPath;
 }
 
 export async function startRerankerService() {
   printMessage("Preparing model...");
-  const modelPath = getRerankerModelPath();
-  await ensureModelExists(modelPath);
+
+  const [modelPath, tokenizerPath, tokenizerConfigPath] = await Promise.all([
+    ensureFileExists(MODEL_HF_FILE),
+    ensureFileExists(TOKENIZER_HF_FILE),
+    ensureFileExists(TOKENIZER_CONFIG_HF_FILE),
+  ]);
+
+  const executionProviders = getExecutionProviders();
+
   printMessage(
-    `Starting service (arch: ${process.arch}, platform: ${process.platform})...`,
+    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${executionProviders.join(", ")})...`,
   );
 
-  const contextSize = 2048;
-
-  serverProcess = spawn(
-    "llama-server",
-    [
-      "--model",
-      modelPath,
-      "--ctx-size",
-      contextSize.toString(),
-      "--batch-size",
-      contextSize.toString(),
-      "--ubatch-size",
-      contextSize.toString(),
-      "--flash-attn",
-      "auto",
-      "--host",
-      SERVICE_HOST,
-      "--port",
-      SERVICE_PORT.toString(),
-      "--log-verbosity",
-      VERBOSE_MODE ? "1" : "0",
-      "--threads",
-      "1",
-      "--parallel",
-      "1",
-      "--reranking",
-      "--pooling",
-      "rank",
-    ],
-    {
-      stdio: [
-        "ignore",
-        VERBOSE_MODE ? "pipe" : "ignore",
-        VERBOSE_MODE ? "pipe" : "ignore",
-      ],
-    },
+  tokenizer = new Tokenizer(
+    JSON.parse(fs.readFileSync(tokenizerPath, "utf8")),
+    JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
   );
 
-  serverProcess.stderr?.on("data", (data) => {
-    printMessage(data.toString());
-  });
+  session = await InferenceSession.create(modelPath, { executionProviders });
 
-  serverProcess.on("exit", (code: number | null, signal: string | null) => {
-    printMessage(
-      `Reranker service exited with code: ${code}, signal: ${signal}`,
-    );
-    if (signal === "SIGTRAP" || signal === "SIGILL") {
-      printMessage(
-        `Binary compatibility issue detected (${signal}). The llama-server binary may not match the current CPU architecture (${process.arch}).`,
-      );
-    }
-    isReady = false;
+  await score("test", ["test document"]);
 
-    if (restartTimeout) clearTimeout(restartTimeout);
-    restartTimeout = setTimeout(() => {
-      printMessage("Attempting to restart reranker service...");
-      startRerankerService();
-    }, 5000);
-  });
-
-  serverProcess.on("error", (error: Error) => {
-    printMessage(`Reranker service error: ${error.message}`);
-    isReady = false;
-  });
-
-  await new Promise<void>((resolve) => {
-    const checkReady = async () => {
-      try {
-        const response = await fetch(
-          `http://${SERVICE_HOST}:${SERVICE_PORT}/health`,
-        );
-        const responseJson = (await response.json()) as {
-          status: "ok" | string;
-        };
-        if (responseJson.status === "ok") {
-          const warmupResponse = await fetch(
-            `http://${SERVICE_HOST}:${SERVICE_PORT}/v1/rerank`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                model: "rerank",
-                query: "test",
-                documents: ["test document"],
-                top_n: 1,
-              }),
-            },
-          );
-          if (warmupResponse.ok) {
-            isReady = true;
-            resolve();
-          } else {
-            const errorBody = await warmupResponse.text().catch(() => "");
-            printMessage(
-              `Warmup failed: ${warmupResponse.statusText} - ${errorBody}`,
-            );
-            setTimeout(checkReady, 500);
-          }
-        } else {
-          setTimeout(checkReady, 100);
-        }
-      } catch {
-        setTimeout(checkReady, 100);
-      }
-    };
-    checkReady();
-  });
-
+  isReady = true;
   printMessage("Service ready!");
-
-  return serverProcess;
 }
 
-export function stopRerankerService() {
-  if (restartTimeout) {
-    clearTimeout(restartTimeout);
-    restartTimeout = null;
-  }
-
-  if (serverProcess) {
-    serverProcess.kill();
-    serverProcess = null;
-  }
+export async function stopRerankerService() {
+  isReady = false;
+  const currentSession = session;
+  session = null;
+  tokenizer = null;
+  await currentSession?.release();
 }
 
 export async function getRerankerStatus() {
-  if (!isReady) {
-    return false;
+  return isReady;
+}
+
+async function scoreBatch(
+  activeSession: InferenceSession,
+  encodings: number[][],
+) {
+  const paddedLength = Math.max(...encodings.map(({ length }) => length));
+  const inputIds = new BigInt64Array(encodings.length * paddedLength);
+  const attentionMask = new BigInt64Array(encodings.length * paddedLength);
+
+  encodings.forEach((ids, row) => {
+    const offset = row * paddedLength;
+    for (let column = 0; column < paddedLength; column += 1) {
+      const isPadding = column >= ids.length;
+      inputIds[offset + column] = BigInt(
+        isPadding ? PAD_TOKEN_ID : ids[column],
+      );
+      attentionMask[offset + column] = isPadding ? 0n : 1n;
+    }
+  });
+
+  const dimensions = [encodings.length, paddedLength];
+  const { logits } = await activeSession.run({
+    input_ids: new Tensor("int64", inputIds, dimensions),
+    attention_mask: new Tensor("int64", attentionMask, dimensions),
+  });
+
+  return Array.from(logits.data as Float32Array, Number);
+}
+
+/**
+ * Returns the cross-encoder's raw relevance logit per document. Deliberately
+ * not squashed through sigmoid: the standard-deviation filter in
+ * rankSearchResults is calibrated against this scale.
+ */
+async function score(query: string, documents: string[]) {
+  if (!session || !tokenizer) {
+    throw new Error("Reranker model is not loaded");
   }
 
-  try {
-    const response = await fetch(
-      `http://${SERVICE_HOST}:${SERVICE_PORT}/health`,
+  const activeSession = session;
+  const loadedTokenizer = tokenizer;
+
+  const encodings = documents.map((document) => {
+    const { ids } = loadedTokenizer.encode(query, { text_pair: document });
+    return ids.length > MAX_SEQUENCE_LENGTH
+      ? ids.slice(0, MAX_SEQUENCE_LENGTH)
+      : ids;
+  });
+
+  const scores: number[] = [];
+
+  for (let offset = 0; offset < encodings.length; offset += BATCH_SIZE) {
+    scores.push(
+      ...(await scoreBatch(
+        activeSession,
+        encodings.slice(offset, offset + BATCH_SIZE),
+      )),
     );
-    const responseJson = (await response.json()) as { status: "ok" | string };
-    return responseJson.status === "ok";
-  } catch {
-    return false;
   }
+
+  return scores;
 }
 
 export async function rerank(query: string, documents: string[]) {
@@ -232,82 +223,22 @@ export async function rerank(query: string, documents: string[]) {
     throw new Error("Reranker service is not ready");
   }
 
-  if (VERBOSE_MODE) {
-    console.time("Time to rerank");
+  const sanitizedQuery = sanitizeUnicodeSurrogates(query);
+  const sanitizedDocuments = documents.map(sanitizeUnicodeSurrogates);
+
+  if (sanitizedQuery !== query) {
+    printMessage(
+      "Rerank query contained invalid Unicode surrogates; sanitized",
+    );
   }
 
-  try {
-    const sanitizedQuery = sanitizeUnicodeSurrogates(query);
-    const sanitizedDocuments = documents.map((document) =>
-      sanitizeUnicodeSurrogates(document),
+  if (sanitizedDocuments.some((doc, index) => doc !== documents[index])) {
+    printMessage(
+      "One or more rerank documents contained invalid Unicode surrogates; sanitized",
     );
-
-    if (sanitizedQuery !== query) {
-      printMessage(
-        "Rerank query contained invalid Unicode surrogates; sanitized",
-      );
-    }
-
-    if (sanitizedDocuments.some((doc, index) => doc !== documents[index])) {
-      printMessage(
-        "One or more rerank documents contained invalid Unicode surrogates; sanitized",
-      );
-    }
-
-    const response = await fetch(
-      `http://${SERVICE_HOST}:${SERVICE_PORT}/v1/rerank`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "rerank",
-          query: sanitizedQuery,
-          documents: sanitizedDocuments,
-          top_n: sanitizedDocuments.length,
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      const errorBody = await response
-        .text()
-        .catch(() => "Unable to read error body");
-      printMessage(`Reranking error response: ${errorBody}`);
-      throw new Error(
-        `Reranking failed: ${response.statusText} - ${errorBody}`,
-      );
-    }
-
-    const jsonResponse = await response.json();
-
-    const results = jsonResponse.results as {
-      index: number;
-      relevance_score: number;
-    }[];
-
-    if (VERBOSE_MODE) {
-      console.timeEnd("Time to rerank");
-      const sortedResults = results
-        .slice()
-        .sort((a, b) => b.relevance_score - a.relevance_score);
-      const rankedDocuments = results.map(({ index, relevance_score }) => ({
-        document: sanitizedDocuments[index],
-        ranking_position:
-          sortedResults.findIndex((result) => result.index === index) + 1,
-        relevance_score,
-      }));
-      printMessage(rankedDocuments);
-    }
-
-    return results;
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("Reranking failed")) {
-      printMessage("Reranking service error detected, marking as not ready");
-      isReady = false;
-      serverProcess?.kill();
-    }
-    throw error;
   }
+
+  const scores = await score(sanitizedQuery, sanitizedDocuments);
+
+  return scores.map((relevance_score, index) => ({ index, relevance_score }));
 }

--- a/server/rerankerServiceHook.ts
+++ b/server/rerankerServiceHook.ts
@@ -18,6 +18,8 @@ export async function rerankerServiceHook<
   }
 
   server.httpServer?.on("close", () => {
-    stopRerankerService();
+    stopRerankerService().catch((error) => {
+      console.error("Failed to stop reranker service:", error);
+    });
   });
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: resolve(__dirname, "client/setupTests.ts"),
+    // Loads the real model; runs via vitest.integration.config.ts instead.
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "server/**/*.integration.test.ts",
+    ],
     alias: {
       "@": resolve(__dirname, "client"),
       "@/modules": resolve(__dirname, "client/modules"),

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Runs the reranker integration test, which loads the real ONNX model. Kept
+ * separate from vitest.config.ts because it needs the node environment and must
+ * not load the jsdom-only client setup file.
+ *
+ *   npx vitest run --config vitest.integration.config.ts
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["server/**/*.integration.test.ts"],
+    testTimeout: 600_000,
+    hookTimeout: 900_000,
+  },
+});


### PR DESCRIPTION
## Description

Currently, the reranker spawns `llama-server`, so the Docker image has to compile llama.cpp from source in a dedicated builder stage. On a fresh environment that stage alone takes 168s (measured with `--no-cache`), and it needs `build-essential`, `cmake` and `ccache` in the image.

This PR runs the same model in-process through `onnxruntime-node`, whose binaries ship prebuilt for every supported platform. The builder stage is gone, and no compiler is needed at all.

The model is unchanged (`jina-reranker-v1-tiny-en`), only the engine differs. That was the constraint: it's the best reranker I found for this task, and it works surprisingly well on non-English results too.

### What changed

| Area | Before | After |
|------|--------|-------|
| Engine | `llama-server` child process, GGUF Q8_0 | `onnxruntime-node` in-process, ONNX fp32 |
| Tokenizer | Handled by llama.cpp | `@huggingface/tokenizers` (zero dependencies, ~8kB) |
| Docker | Builder stage compiling llama.cpp | No builder stage |
| Service management | Spawn, port 8012, `/health` polling, warmup POST, 5s restart loop, `SIGTRAP`/`SIGILL` handling | Load the session, release it on close |
| Local development | Needed `llama-server` on `PATH` | Nothing to install |
| Model on disk | 36MB | 131MB |

`server/rerankerService.ts` keeps the same exports (`rerank`, `getRerankerStatus`, `startRerankerService`, `stopRerankerService`, `sanitizeUnicodeSurrogates`), so `rankSearchResults.ts`, `searchEndpointServerHook.ts` and `statusEndpointServerHook.ts` are untouched. Two signature details for reviewers:

- `stopRerankerService` is now `async` (it awaits the session release). `rerankerServiceHook` is the only caller and now logs a rejection instead of leaving a floating promise.
- `getRerankerModelPath` is no longer exported. It was only used inside the module, and there are now three files to resolve rather than one.

### Ranking quality

I compared both engines on identical inputs, feeding the scores through the real `rankSearchResults` before comparing.

| Case | Spearman | Top-1 | p@3 llama.cpp | p@3 ONNX |
|------|----------|-------|---------------|----------|
| English / factual | 0.976 | identical | 1.00 | 1.00 |
| Portuguese / recipe | 0.976 | identical | 0.67 | 0.67 |
| Portuguese / technical | 0.976 | identical | 1.00 | 0.67 |
| English / ambiguous ("jaguar") | 1.000 | identical | 1.00 | 1.00 |

Top-1 matched in every case. The one p@3 difference is a single adjacent swap in the nginx case.

The Portuguese behavior carries over, and the clearest evidence is that both engines make the *same* mistakes: on "como fazer pão de queijo caseiro" both rank a pizza recipe second, and both bury the English "Cheese Bread Recipe (Brazilian Pão de Queijo)". Same weights, same quirks.

Note: ONNX logits spread wider than llama.cpp's compressed scores, so the standard-deviation filter keeps slightly fewer results (4-6 of 8 where llama.cpp kept 5-7). Ordering is unaffected. I tried squashing the logits through a sigmoid to match the retention, but it only helped in 1 of the 4 cases, so I left the raw scale.

### Why fp32

- `q8` measurably degrades ranking on a 33M-parameter model (Spearman drops to 0.90, and p@3 drops in 2 of the 4 cases).
- `fp16` fails to load in `onnxruntime-node` (a graph fusion error in `SimplifiedLayerNormFusion`).

So fp32 it is, at the cost of a larger file on disk.

### Performance

Measured at the production result count (30 documents):

| Configuration | Median |
|---------------|--------|
| llama.cpp, CPU, `--threads 1` (what we run today) | 397ms |
| llama.cpp, CPU, 8 threads | 88ms |
| ONNX, CPU, batched (the fallback path) | 81ms |
| ONNX, WebGPU, batched (the default where available) | 32ms |

Not a regression on either path: even the CPU fallback is about 4x faster than what we run today, because `--threads 1` left cores idle and ONNX Runtime uses them by default. Cold start also drops to 0.16s once the model is cached.

These are medians on an unpinned laptop, so treat them as ±15%. The two ONNX rows are from one run with the batching this PR ships, so they are comparable to each other; the llama.cpp rows were measured separately.

### Event-loop blocking

`onnxruntime-node` wraps a *synchronous* native call in `setImmediate` (see `run()` in [`js/node/lib/backend.ts`](https://github.com/microsoft/onnxruntime/blob/main/js/node/lib/backend.ts)), so inference blocks the event loop for its whole duration. Scoring 30 documents in one batch blocked it for 78ms with zero timer ticks.

Documents are now scored in batches of 10, which yields between calls and caps the stall at ~27ms for about 4% more wall time. Scores are bit-identical either way, since padding is per batch but the attention mask excludes it.

This is the one real trade-off against the old design: `llama-server` ran in its own process, so reranking never blocked Node. If the remaining ~27ms ever matters, moving inference to a worker thread would remove it entirely.

### GPU

The session requests `["webgpu", "cpu"]`, with nothing to configure. WebGPU is about 3x faster than CPU (24ms vs 77ms for 30 documents) and matches CPU numerically to 1e-6 with identical ordering, so there's no reason to make it opt-in. Hosts with no usable GPU provider (Linux arm64, or any host without a GPU) fall back to CPU rather than failing to load.

Worth noting: ONNX Runtime's WebGPU provider here is native, compiled into the `onnxruntime-node` binary. It is not the browser API, so it needs neither a browser nor Deno.

CoreML and CUDA are deliberately left out. CoreML is 2.8x *slower* than CPU for this model's dynamic shapes, and the CUDA binaries aren't bundled with the package.

ONNX Runtime's startup warnings are also silenced (it warns on every launch that it assigned shape operators to CPU, which is expected), matching the quiet startup `llama-server` had.

### Building without a git repository

`docker compose up --build` failed from a git worktree, where `.git` is a file pointing at a gitdir outside the build context. Git resolves the repository before running any subcommand, so even `git config --global --add safe.directory` exited 128 and killed the build.

The commit hash is optional build metadata, so the build now tolerates its absence and prints a warning instead of failing. `helper-git-hash` already returned an empty string on failure, so nothing else needed changing.

Consequences when no repository is available:

- The build logs `WARNING: no usable git repository in the build context, ...`.
- `/status` reports `build.gitCommit` as `""`.
- The version in the menu shows `v2026.7.28` instead of `v2026.7.28+0d0fe9a`. `appVersion` now omits the separator rather than rendering a dangling `2026.7.28+`.
- Nothing else changes: the AI Horde client agent string just carries the shorter version.

Builds from a normal checkout are unaffected and still embed the hash.

### Dependencies

`onnxruntime-node` + `@huggingface/tokenizers`, which adds 263 lines to the lockfile. I also prototyped this with `@huggingface/transformers` and it produced bit-identical scores, but it pulls `sharp` (image processing the reranker never touches) for 51 packages, 381MB and 4 advisories, against 26 packages, 214MB and 2 advisories here.

Both remaining advisories are `adm-zip`, reached only through `onnxruntime-node`'s install script, which downloads the binaries that aren't bundled (the CUDA EP). On a default CPU install it exits early and never opens an archive.

### Documentation

`docs/reranking.md` is largely rewritten (service lifecycle, execution providers, batching, why fp32, how to run the integration test). Smaller updates remove the `llama-server` references from `README.md` (the architecture diagram node), `agents.md`, `docs/overview.md`, `docs/quick-start.md`, `docs/development-commands.md`, `docs/glossary.md` and `docs/configuration.md`.

The llama.cpp mentions left in `README.md` and `docs/ai-integration.md` are deliberate: those describe llama.cpp as an OpenAI-compatible backend users can point MiniSearch at, which is unrelated to reranking. `@wllama/wllama` (browser-side inference) is untouched.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (refactor, build, chore)

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

`server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality on the English and Portuguese fixtures. It downloads ~130MB, so it's excluded from the default suite:

```sh
npx vitest run --config vitest.integration.config.ts
```

## How to test

1. `npm run lint` and `npm run test` (288 tests).
2. `npx vitest run --config vitest.integration.config.ts` to exercise the real model (6 tests). Delete `server/models` first if you want to check the download path.
3. `docker build -t minisearch .` and confirm there's no compile step. It also works from a git worktree now.
4. Run the container and search for something in Portuguese, then confirm `/status` reports the reranker as available.

<details>
<summary>Security, performance, or breaking changes? Expand if relevant.</summary>

No breaking changes for users: no new required configuration, and the model still downloads on first start.

Performance: reranking gets faster (397ms to 81ms on CPU, 32ms on WebGPU, at 30 results), but inference now blocks the event loop for up to ~27ms per search, where before it ran in a separate process. See the sections above.

Security: adds 2 high advisories, both `adm-zip` via `onnxruntime-node`, on a code path a default CPU install doesn't reach. In exchange it drops the `git`/`cmake`/`build-essential` toolchain and a from-source clone of llama.cpp from the image build.

GPU is used automatically where ONNX Runtime has a working provider, with a CPU fallback everywhere else. No new configuration.

</details>

