### PR TITLE
Add a How to test section to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,14 @@
 ## Description
-<!-- What does this PR change, and why? -->
+<!-- What does this PR change, and why? Add ### subsections for anything that needs it. -->
 
 ## Type of Change
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Documentation
 - [ ] Other (refactor, build, chore)
+
+## How to test
+<!-- Numbered steps a reviewer can follow. Say plainly what you could not test. -->
 
 ## Checklist
 - [ ] `npm run lint` passes
@@ -14,10 +17,5 @@
 ## Screenshots
 <!-- For UI changes. Delete this section if not applicable. -->
 
-<details>
-<summary>Security, performance, or breaking changes? Expand if relevant.</summary>
-
-Note any security implications, performance impact, or breaking changes here,
-including how users should migrate.
-
-</details>
+## Security, performance, or breaking changes
+<!-- Delete this section if none. Include how users should migrate. -->


### PR DESCRIPTION
## Description

Adds a `## How to test` section to the PR template, and promotes the collapsed security/performance/breaking-changes block to a normal section.

Currently the checklist asserts that tests passed, but the template has nowhere for the steps a reviewer follows to see that for themselves, so PRs keep inventing the section by hand (#2235 did).

On the fold: collapsing security, performance and breaking changes into one `<details>` hides the content that needs the most scrutiny. It also pushes an author to cover those topics twice when they are central rather than incidental, once as a real section and once inside the fold, because leaving the fold empty reads as negligent while burying the content there reads as evasive.

Net change: one section added, one fold removed. The template stays short, which is the thing worth protecting about it.

The comment under `## Description` now also mentions `###` subsections, since a large PR needs its own structure inside that one prose slot.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other (refactor, build, chore)

## How to test

This PR's own body uses the proposed structure, so it doubles as the preview.

A template only takes effect for PRs opened after it merges, so there is no way to exercise the real thing beforehand. What I did check:

1. `npm run lint` passes, including `scripts/documentation-validator.cjs`, which validates `.github/PULL_REQUEST_TEMPLATE.md`.
2. The rendered markdown has no broken structure: five `##` sections plus HTML comments, no stray `<details>` tags left behind.

## Checklist
- [x] `npm run lint` passes
- [ ] Tests pass (`npm run test`), with tests added where it made sense

No tests: the change is a markdown template with no code path to cover.

## Security, performance, or breaking changes

None. Nothing here affects the app, the build, or contributors' existing branches. Open PRs keep whatever body they already have.
