### PR TITLE
Credit ONNX Runtime for reranking in the acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ MiniSearch builds on the work of these projects:
 | Project | Role |
 | --- | --- |
 | [SearXNG](https://github.com/searxng/searxng) | Metasearch engine behind the results |
-| [wllama](https://github.com/ngxson/wllama) and [llama.cpp](https://github.com/ggml-org/llama.cpp) | In-browser inference and local reranking |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Local reranking of the search results |
+| [wllama](https://github.com/ngxson/wllama) and [llama.cpp](https://github.com/ggml-org/llama.cpp) | In-browser inference |
 | [AI Horde](https://aihorde.net) | Crowdsourced distributed inference |
 | [AI SDK](https://github.com/vercel/ai) | Client for OpenAI-compatible APIs |
 | [Mantine](https://mantine.dev) | UI components |


### PR DESCRIPTION
## Description

Credits ONNX Runtime for reranking in the acknowledgments table. Reranking moved off llama.cpp in #2235, but the table still credited it for that role.

llama.cpp keeps its row: [wllama](https://github.com/ngxson/wllama) is llama.cpp compiled to WebAssembly and still powers in-browser inference, so only the reranking half of that row's role moves out.

Before:

| Project | Role |
| --- | --- |
| wllama and llama.cpp | In-browser inference and local reranking |

After:

| Project | Role |
| --- | --- |
| ONNX Runtime | Local reranking of the search results |
| wllama and llama.cpp | In-browser inference |

The new row sits directly after SearXNG, so the table follows the pipeline: aggregate the results, rerank them, then generate the answer.

Nothing else in the README needed changing. The architecture diagram already says `Reranker / ONNX Runtime`, and the prose describes reranking without naming an engine ("reranked locally by a cross-encoder model"). The llama.cpp mention further up is about pointing MiniSearch at a llama.cpp server as an OpenAI-compatible backend, which is unrelated.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other (refactor, build, chore)

## How to test

1. `npm run lint` passes, including `scripts/documentation-validator.cjs`, which checks every link in `README.md`.
2. `https://github.com/microsoft/onnxruntime` returns HTTP 200.
3. Read the Acknowledgments table on this branch and confirm the two rows render as above.

## Checklist
- [x] `npm run lint` passes
- [ ] Tests pass (`npm run test`), with tests added where it made sense

No tests: the change is one table row in the README.

## Security, performance, or breaking changes

None.
