### PR TITLE
Validate cached model files before reusing them

### DIFF
--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -25,6 +25,14 @@ The `rerankerServiceHook` starts the reranker during server initialization:
 
 There is no child process, port, or health endpoint: inference runs inside the Node process.
 
+### Model Cache Integrity
+
+`downloadFileFromHuggingFaceRepository` compares each cached file against the size the Hub reports, so a file downloaded only in part is replaced instead of being loaded. Without that check a truncated model made every later startup fail with `Protobuf parsing failed`, and only deleting `server/models/` by hand recovered.
+
+Downloads land on a sibling `.part-<pid>` path and are renamed once the whole body is on disk, which keeps an interrupted write from being visible where the next startup would trust it. Files are also checked individually, so a missing tokenizer is fetched on its own while the 130MB model stays cached.
+
+The size check costs one metadata request per file at startup (roughly 600ms for the three of them). When the Hub is unreachable the cached files are used as they are, so an offline server still starts with a warm cache.
+
 ### Execution Providers
 
 The session requests `["webgpu", "cpu"]`, with no configuration to set. WebGPU is roughly 3x faster than CPU (24ms against 77ms for 30 documents) and agrees with it to within float32 rounding (1e-6, identical ordering), so it is preferred where it works. Listing `cpu` after it means hosts without a usable GPU provider fall back rather than failing to load. The list is logged at startup.
@@ -135,6 +143,9 @@ npx vitest run --config vitest.integration.config.ts
 |----------|----------|
 | Reranker not ready | Falls back to unranked SearXNG results |
 | Model fails to load | Logged by the hook; reranker stays unready and search returns unranked results |
+| Cached file of the wrong size | Logged, then downloaded again before the session is created |
+| Download shorter than the reported size | Throws before anything is written, so the cache keeps no partial file |
+| HuggingFace unreachable with a warm cache | Metadata failure is logged and the cached files are used unchanged |
 | Empty documents array | Returns empty array without running inference |
 | Unicode sanitization needed | Logs warning, continues with sanitized input |
 

--- a/server/downloadFileFromHuggingFaceRepository.test.ts
+++ b/server/downloadFileFromHuggingFaceRepository.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { downloadFile, fileDownloadInfo } from "@huggingface/hub";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository";
+
+vi.mock("@huggingface/hub", () => ({
+  downloadFile: vi.fn(),
+  fileDownloadInfo: vi.fn(),
+}));
+
+const REPO = "jinaai/jina-reranker-v1-tiny-en";
+const REPO_FILE = "onnx/model.onnx";
+const REMOTE_CONTENT = "complete model bytes";
+
+let temporaryDirectory: string;
+let localFilePath: string;
+
+function serveRemoteFile(content = REMOTE_CONTENT) {
+  vi.mocked(fileDownloadInfo).mockResolvedValue({
+    size: Buffer.byteLength(REMOTE_CONTENT),
+    etag: "etag",
+    url: `https://huggingface.co/${REPO}/resolve/main/${REPO_FILE}`,
+  });
+  vi.mocked(downloadFile).mockImplementation(async () => new Blob([content]));
+}
+
+function download(filePath = localFilePath) {
+  return downloadFileFromHuggingFaceRepository(REPO, REPO_FILE, filePath);
+}
+
+function listDirectory(directory = path.dirname(localFilePath)) {
+  return fs.existsSync(directory) ? fs.readdirSync(directory).sort() : [];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "hf-download-"));
+  localFilePath = path.join(temporaryDirectory, "onnx", "model.onnx");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+describe("downloadFileFromHuggingFaceRepository", () => {
+  it("downloads a file that is not cached yet", async () => {
+    serveRemoteFile();
+
+    await download();
+
+    expect(fs.readFileSync(localFilePath, "utf8")).toBe(REMOTE_CONTENT);
+    expect(listDirectory()).toEqual(["model.onnx"]);
+  });
+
+  it("keeps a cached file whose size matches the repository", async () => {
+    serveRemoteFile();
+    fs.mkdirSync(path.dirname(localFilePath), { recursive: true });
+    fs.writeFileSync(localFilePath, REMOTE_CONTENT);
+
+    await download();
+
+    expect(downloadFile).not.toHaveBeenCalled();
+  });
+
+  it("only downloads the missing file when a sibling is already cached", async () => {
+    serveRemoteFile();
+    const cachedFilePath = path.join(temporaryDirectory, "tokenizer.json");
+    fs.writeFileSync(cachedFilePath, REMOTE_CONTENT);
+
+    await download(cachedFilePath);
+    await download();
+
+    expect(downloadFile).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(localFilePath, "utf8")).toBe(REMOTE_CONTENT);
+  });
+
+  it("replaces a truncated cached file instead of trusting it", async () => {
+    serveRemoteFile();
+    fs.mkdirSync(path.dirname(localFilePath), { recursive: true });
+    fs.writeFileSync(localFilePath, REMOTE_CONTENT.slice(0, 5));
+
+    await download();
+
+    expect(downloadFile).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(localFilePath, "utf8")).toBe(REMOTE_CONTENT);
+  });
+
+  it("keeps a cached file when the repository metadata is unreachable", async () => {
+    vi.mocked(fileDownloadInfo).mockRejectedValue(new Error("offline"));
+    fs.mkdirSync(path.dirname(localFilePath), { recursive: true });
+    fs.writeFileSync(localFilePath, REMOTE_CONTENT.slice(0, 5));
+
+    await download();
+
+    expect(downloadFile).not.toHaveBeenCalled();
+    expect(fs.readFileSync(localFilePath, "utf8")).toBe(
+      REMOTE_CONTENT.slice(0, 5),
+    );
+  });
+
+  it("writes nothing when the response is shorter than the expected size", async () => {
+    serveRemoteFile("truncated");
+
+    await expect(download()).rejects.toThrow(/9 bytes instead of 20/);
+
+    expect(listDirectory()).toEqual([]);
+  });
+
+  it("leaves no partial file behind when the disk fills up mid-write", async () => {
+    serveRemoteFile();
+    vi.spyOn(fs, "writeFileSync").mockImplementation((filePath) => {
+      const fileDescriptor = fs.openSync(filePath as string, "w");
+      fs.writeSync(fileDescriptor, REMOTE_CONTENT.slice(0, 5));
+      fs.closeSync(fileDescriptor);
+      throw new Error("ENOSPC: no space left on device");
+    });
+
+    await expect(download()).rejects.toThrow("ENOSPC");
+
+    expect(listDirectory()).toEqual([]);
+  });
+});

--- a/server/downloadFileFromHuggingFaceRepository.ts
+++ b/server/downloadFileFromHuggingFaceRepository.ts
@@ -1,13 +1,57 @@
 import fs from "node:fs";
 import path from "node:path";
-import { downloadFile } from "@huggingface/hub";
+import { downloadFile, fileDownloadInfo } from "@huggingface/hub";
+import debug from "debug";
 
+const printMessage = debug(path.basename(import.meta.url));
+printMessage.enabled = true;
+
+/**
+ * Size the repository reports for the file, or `undefined` when the Hub cannot
+ * be reached. Callers must read "unknown" as "keep whatever is cached", so a
+ * warm cache still starts the server while offline.
+ */
+async function getRemoteFileSize(hfRepo: string, hfRepoFile: string) {
+  try {
+    const downloadInfo = await fileDownloadInfo({
+      repo: hfRepo,
+      path: hfRepoFile,
+    });
+    return downloadInfo?.size;
+  } catch (error) {
+    printMessage(
+      `Could not read the metadata of ${hfRepo}/${hfRepoFile}: ${error}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Downloads a repository file to `localFilePath`, skipping the transfer when the
+ * cached copy already matches the size the Hub reports. A cached file of the
+ * wrong size is replaced instead of trusted, so a truncated model recovers on
+ * the next startup rather than failing to load forever.
+ */
 export async function downloadFileFromHuggingFaceRepository(
   hfRepo: string,
   hfRepoFile: string,
   localFilePath: string,
 ): Promise<void> {
-  if (fs.existsSync(localFilePath)) return;
+  const cachedFileSize = fs.existsSync(localFilePath)
+    ? fs.statSync(localFilePath).size
+    : undefined;
+
+  const expectedFileSize = await getRemoteFileSize(hfRepo, hfRepoFile);
+
+  if (cachedFileSize !== undefined) {
+    if (expectedFileSize === undefined || cachedFileSize === expectedFileSize) {
+      return;
+    }
+
+    printMessage(
+      `Cached ${hfRepoFile} has ${cachedFileSize} bytes instead of ${expectedFileSize}, so it will be downloaded again.`,
+    );
+  }
 
   const downloadResponse = await downloadFile({
     repo: hfRepo,
@@ -22,11 +66,27 @@ export async function downloadFileFromHuggingFaceRepository(
 
   const fileBuffer = Buffer.from(fileArrayBuffer);
 
-  const fileDirectory = path.dirname(localFilePath);
-
-  if (!fs.existsSync(fileDirectory)) {
-    fs.mkdirSync(fileDirectory, { recursive: true });
+  if (
+    expectedFileSize !== undefined &&
+    fileBuffer.byteLength !== expectedFileSize
+  ) {
+    throw new Error(
+      `Downloaded ${hfRepo}/${hfRepoFile} with ${fileBuffer.byteLength} bytes instead of ${expectedFileSize}`,
+    );
   }
 
-  fs.writeFileSync(localFilePath, fileBuffer);
+  fs.mkdirSync(path.dirname(localFilePath), { recursive: true });
+
+  // Writing to a sibling path and renaming afterwards keeps a partial write
+  // (interrupted process, full disk) from ever being visible at localFilePath,
+  // where the next startup would take it for a complete file.
+  const partialFilePath = `${localFilePath}.part-${process.pid}`;
+
+  try {
+    fs.writeFileSync(partialFilePath, fileBuffer);
+    fs.renameSync(partialFilePath, localFilePath);
+  } catch (error) {
+    fs.rmSync(partialFilePath, { force: true });
+    throw error;
+  }
 }


### PR DESCRIPTION
## Description

Currently, `downloadFileFromHuggingFaceRepository` returns early on `fs.existsSync(localFilePath)`, so any file already in `server/models/` is trusted without validation. A file downloaded only in part (process killed during `fs.writeFileSync`, disk full) is never fetched again: the reranker fails with `Load model from ... failed:Protobuf parsing failed.` on every startup, and only deleting the directory by hand recovers.

This PR does two things:

- Compares each cached file against the size the Hub reports (`fileDownloadInfo`) and downloads it again when they differ, so an already corrupt cache recovers on its own. The downloaded body is checked against that size too, before anything touches the models directory.
- Writes to a sibling `.part-<pid>` path and renames it once the whole body is on disk, so an interrupted write is never visible where the next startup would trust it.

Files are still checked one by one, so a missing `tokenizer.json` is fetched on its own while the 130MB model stays cached.

This is pre-existing behavior, not something the ONNX migration introduced: the same short-circuit served the old GGUF download, and a truncated GGUF failed identically under llama-server.

### Known limitations

The size check costs one metadata request per file at startup, about 600ms for the three of them. When the Hub is unreachable the failure is logged and the cached files are used as they are, so an offline server still starts with a warm cache (a corrupt cache can only be detected against the Hub).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## How to test

1. Populate the cache: `npx vitest run --config vitest.integration.config.ts`
2. Truncate the model:
```sh
head -c 5000000 server/models/jinaai/jina-reranker-v1-tiny-en/onnx/model.onnx > /tmp/t && mv /tmp/t server/models/jinaai/jina-reranker-v1-tiny-en/onnx/model.onnx
```
3. Run the integration test again. It downloads the model again and passes, logging:
```
Cached onnx/model.onnx has 5000000 bytes instead of 132350375, so it will be downloaded again.
```
   On `main` this step fails with `Protobuf parsing failed`, and keeps failing on every later run.
4. Delete only `server/models/jinaai/jina-reranker-v1-tiny-en/tokenizer.json` and run it once more. Just that file is fetched (the run finishes in about a second), so the model is not downloaded again.
5. `npx vitest run server/downloadFileFromHuggingFaceRepository.test.ts` for the unit tests. Three of them fail on `main`: the truncated cache is trusted, a short response resolves instead of throwing, and a write that fails mid-way leaves `model.onnx` behind.

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense
