### PR TITLE
Fix the Hugging Face deploy by pinning the action's build branch

### DIFF
--- a/.github/workflows/deploy-to-hugging-face.yml
+++ b/.github/workflows/deploy-to-hugging-face.yml
@@ -11,7 +11,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: JacobLinCool/huggingface-sync@60850d5a74ea004fc094f77c960c2c8bd9a0f9d1 # v1.3.1
+      # Pin to the tip of the action's `v1` branch, which is where its build
+      # output lives. Its release tags point at source commits, and `dist/` is
+      # gitignored there, so a tag digest resolves to a tree with no
+      # `dist/index.js` and the step fails before it runs.
+      - uses: JacobLinCool/huggingface-sync@48eb49940149dc1015d8294621cb203635fe9ff3 # v1 branch, 2026-05-12
         with:
           github: ${{ secrets.GITHUB_TOKEN }}
           user: ${{ vars.HF_SPACE_OWNER }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>felladrin/.github:renovate-config"]
+  "extends": ["local>felladrin/.github:renovate-config"],
+  "packageRules": [
+    {
+      "description": "Keep the pin on the action's v1 branch tip. Its release tags point at source commits where dist/ is gitignored, so any tag digest resolves to a tree with no dist/index.js and the deploy fails. Renovate cannot resolve a branch tip, so it has nothing correct to offer here.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["JacobLinCool/huggingface-sync"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Description

Fixes the Hugging Face deploy, which fails immediately with:

```
File not found: '/home/runner/work/_actions/JacobLinCool/huggingface-sync/60850d5a.../dist/index.js'
```

`JacobLinCool/huggingface-sync` gitignores `dist/` and publishes its build output on its `v1` **branch**. Its release tags point at source commits, so a digest resolved from a tag lands on a tree with no `dist/index.js`, and the step fails before any of its code runs. Every tag is affected, `v1.0.0` through `v1.3.1`.

The workflow used the mutable `v1` ref until #2145 pinned it by digest. Today's dispatch was the first one since, which is why the last success (2026-07-16) predates the pin:

| Date | Ref | Result |
|------|-----|--------|
| up to 2026-06-18 | `@v1` (branch) | working |
| 2026-07-21 (#2145) | `@3e022764` (the `v1.3.1` tag object) | never dispatched |
| 2026-07-21 (#2159) | `@60850d5a` (the commit that tag points at) | fails |

This pins the tip of the `v1` branch, `48eb4994`, which keeps a digest pin while pointing at a tree that actually contains the entrypoint. It is not a regression of #2145's hardening: the ref is still an immutable commit SHA, just one on the branch that carries the build.

That commit also declares `using: node24` rather than `node20`, so the deprecation warning in the failed run goes away as well.

Nothing about this is related to the reranker work in #2235. The action never got far enough to read the repository.

### Renovate

Renovate resolves action digests from tags, so for this action every update it proposes reintroduces the same breakage. It has already done so twice, in #2145 and #2159, and both times the failure was invisible until someone dispatched the workflow by hand.

`renovate.json` now disables updates for this one action, with the reason recorded inline. The trade-off is deliberate: automated bumps here have a 100% failure rate, so the pin is better maintained by hand.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## How to test

I did not dispatch the workflow, because a successful run publishes to the live Space. That is yours to trigger when you want the deploy to happen.

What I verified without running it:

1. `dist/index.js` exists at the new pin (1,064,554 bytes):
   `gh api "repos/JacobLinCool/huggingface-sync/contents/dist?ref=48eb49940149dc1015d8294621cb203635fe9ff3"`
2. It is absent at the old pin and at every release tag:
   `gh api "repos/JacobLinCool/huggingface-sync/contents/dist?ref=v1.3.1"` returns 404.
3. `action.yml` at the new pin declares `main: "dist/index.js"` with `using: "node24"`.
4. `48eb4994` is the current tip of `refs/heads/v1`, so it is the same code the workflow ran successfully before #2145.
5. The workflow YAML still parses and all five inputs are preserved.
6. `renovate-config-validator renovate.json` reports `Config validated successfully`.

To confirm end to end, run the **Deploy to Hugging Face** workflow from this branch and check the step gets past loading the action.

## Checklist
- [x] `npm run lint` passes
- [ ] Tests pass (`npm run test`), with tests added where it made sense

No tests: the change is a workflow pin and a Renovate rule, neither of which the suite covers.

## Security, performance, or breaking changes

The action is still pinned to an immutable commit SHA, so #2145's supply-chain intent holds. The one reduction in automation is that Renovate no longer watches this action, so a genuine upstream fix will need picking up by hand. Worth revisiting if upstream starts shipping `dist/` on its tags.
