### PR TITLE
Retry the reranker session on CPU when the GPU provider fails to initialize

### DIFF
--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -35,14 +35,16 @@ The size check costs one metadata request per file at startup (roughly 600ms for
 
 ### Execution Providers
 
-The session requests `["webgpu", "cpu"]`, with no configuration to set. WebGPU is roughly 3x faster than CPU (24ms against 77ms for 30 documents) and agrees with it to within float32 rounding (1e-6, identical ordering), so it is preferred where it works. Listing `cpu` after it means hosts without a usable GPU provider fall back rather than failing to load. The list is logged at startup.
+The session is created with `["webgpu", "cpu"]`, with no configuration to set. WebGPU is roughly 3x faster than CPU (24ms against 77ms for 30 documents) and agrees with it to within float32 rounding (1e-6, identical ordering), so it is preferred where it works.
+
+When that session fails to be created, the reason is logged and a second session is created with `["cpu"]`. The retry is what makes hosts without a GPU work: a trailing `cpu` in the provider list is not a fallback chain, because ONNX Runtime only falls back per operator once a provider has been registered. A provider that fails to initialize at all rejects `InferenceSession.create` outright, and the entries behind it never get a chance. On Hugging Face Spaces, for instance, Dawn cannot find `libvulkan.so.1`, WebGPU then reports `No supported adapters`, and before the retry existed that left the reranker permanently unready with every search falling back to unranked results. The providers of each attempt are logged.
 
 Note that ONNX Runtime's WebGPU provider here is native, part of the `onnxruntime-node` binary. It is not the browser API, so it needs neither a browser nor Deno.
 
 | Provider | Availability in the Node binding | Notes |
 |----------|----------------------------------|-------|
-| `cpu` | Everywhere | Fallback |
-| `webgpu` | Windows, Linux x64, macOS | Preferred; experimental in ONNX Runtime |
+| `cpu` | Everywhere | Fallback, retried as its own session |
+| `webgpu` | Windows, Linux x64, macOS | Preferred; experimental in ONNX Runtime, and needs a real GPU adapter plus a Vulkan loader on Linux |
 | `cuda` | Linux x64 (CUDA v12) | Not used: the binaries are not bundled, and would need `npm install onnxruntime-node --onnxruntime-node-install=cuda12` |
 | `coreml` | macOS | Not used: slower than CPU for this model's dynamic shapes |
 
@@ -131,6 +133,8 @@ Quantized variants are deliberately not used. The `q8` export measurably degrade
 
 ## Testing
 
+`server/rerankerService.test.ts` runs in the default suite and covers Unicode sanitization plus the execution-provider fallback, with the ONNX Runtime session, the tokenizer, and the model download all mocked.
+
 `server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality against English and Portuguese fixtures. It downloads ~130MB, so it is excluded from the default suite:
 
 ```sh
@@ -142,6 +146,7 @@ npx vitest run --config vitest.integration.config.ts
 | Scenario | Behavior |
 |----------|----------|
 | Reranker not ready | Falls back to unranked SearXNG results |
+| GPU provider unavailable | Logged, then the session is created again with `["cpu"]` |
 | Model fails to load | Logged by the hook; reranker stays unready and search returns unranked results |
 | Cached file of the wrong size | Logged, then downloaded again before the session is created |
 | Download shorter than the reported size | Throws before anything is written, so the cache keeps no partial file |

--- a/server/rerankerService.test.ts
+++ b/server/rerankerService.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, it } from "vitest";
-import { sanitizeUnicodeSurrogates } from "./rerankerService";
+import fs from "node:fs";
+import { InferenceSession } from "onnxruntime-node";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getRerankerStatus,
+  sanitizeUnicodeSurrogates,
+  startRerankerService,
+  stopRerankerService,
+} from "./rerankerService";
+
+vi.mock("@huggingface/tokenizers", () => ({
+  Tokenizer: class {
+    encode() {
+      return { ids: [1, 2, 3] };
+    }
+  },
+}));
+
+vi.mock("./downloadFileFromHuggingFaceRepository", () => ({
+  downloadFileFromHuggingFaceRepository: vi.fn(),
+}));
+
+vi.mock("onnxruntime-node", () => ({
+  InferenceSession: { create: vi.fn() },
+  Tensor: class {},
+}));
 
 describe("sanitizeUnicodeSurrogates", () => {
   describe("valid input passthrough", () => {
@@ -192,5 +216,74 @@ describe("sanitizeUnicodeSurrogates", () => {
       const input = "\uD800\uDC00\uD801";
       expect(sanitizeUnicodeSurrogates(input)).toBe("\uD800\uDC00\uFFFD");
     });
+  });
+});
+
+describe("startRerankerService", () => {
+  const requestedExecutionProviders: string[][] = [];
+
+  const sessionStub = {
+    run: async () => ({ logits: { data: new Float32Array([0.5]) } }),
+    release: async () => {},
+  } as unknown as InferenceSession;
+
+  /** The message onnxruntime-node throws when Dawn finds no GPU adapter. */
+  const webGpuAdapterError = new Error(
+    "Failed to get a WebGPU adapter: No supported adapters",
+  );
+
+  function mockSessionCreation(
+    respond: (executionProviders: string[]) => Promise<InferenceSession>,
+  ) {
+    vi.mocked(InferenceSession.create).mockImplementation(((
+      _modelPath: string,
+      options: { executionProviders: string[] },
+    ) => {
+      requestedExecutionProviders.push(options.executionProviders);
+      return respond(options.executionProviders);
+    }) as unknown as typeof InferenceSession.create);
+  }
+
+  beforeEach(() => {
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+  });
+
+  afterEach(async () => {
+    await stopRerankerService();
+    requestedExecutionProviders.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the preferred providers when the session loads", async () => {
+    mockSessionCreation(async () => sessionStub);
+
+    await startRerankerService();
+
+    expect(requestedExecutionProviders).toEqual([["webgpu", "cpu"]]);
+    expect(await getRerankerStatus()).toBe(true);
+  });
+
+  it("retries on CPU when the WebGPU provider fails to initialize", async () => {
+    mockSessionCreation(async (executionProviders) => {
+      if (executionProviders.includes("webgpu")) throw webGpuAdapterError;
+      return sessionStub;
+    });
+
+    await startRerankerService();
+
+    expect(requestedExecutionProviders).toEqual([["webgpu", "cpu"], ["cpu"]]);
+    expect(await getRerankerStatus()).toBe(true);
+  });
+
+  it("stays unready when CPU fails too", async () => {
+    const cpuError = new Error("Protobuf parsing failed");
+    mockSessionCreation(async (executionProviders) => {
+      throw executionProviders.includes("webgpu")
+        ? webGpuAdapterError
+        : cpuError;
+    });
+
+    await expect(startRerankerService()).rejects.toThrow(cpuError);
+    expect(await getRerankerStatus()).toBe(false);
   });
 });

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -34,14 +34,21 @@ const MAX_SEQUENCE_LENGTH = 2048;
 const BATCH_SIZE = 10;
 
 /**
- * ONNX Runtime execution providers, in preference order. WebGPU is roughly 3x
- * faster than CPU here and agrees with it to within float32 rounding, so it is
- * preferred when available; listing `cpu` after it means platforms without a
- * usable GPU provider (Linux arm64, or any host without a GPU) fall back
- * instead of failing to load. `coreml` is deliberately absent: it is slower
- * than CPU for this model's dynamic shapes.
+ * ONNX Runtime execution providers to try first. WebGPU is roughly 3x faster
+ * than CPU here and agrees with it to within float32 rounding, so it is
+ * preferred when available. `coreml` is deliberately absent: it is slower than
+ * CPU for this model's dynamic shapes.
  */
-const EXECUTION_PROVIDERS = ["webgpu", "cpu"];
+const PREFERRED_EXECUTION_PROVIDERS = ["webgpu", "cpu"];
+
+/**
+ * Trailing `cpu` in a provider list is not a fallback chain: ONNX Runtime only
+ * falls back per operator, once a provider is registered. A provider that fails
+ * to initialize at all (no GPU adapter, or no `libvulkan.so.1` for Dawn to
+ * load, as on Hugging Face Spaces) rejects the whole session, so the CPU-only
+ * session has to be a second attempt.
+ */
+const FALLBACK_EXECUTION_PROVIDERS = ["cpu"];
 
 let isReady = false;
 let session: InferenceSession | null = null;
@@ -105,6 +112,19 @@ async function ensureFileExists(hfRepoFile: string) {
   return localPath;
 }
 
+function createSession(modelPath: string, executionProviders: string[]) {
+  printMessage(
+    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${executionProviders.join(", ")})...`,
+  );
+
+  return InferenceSession.create(modelPath, {
+    executionProviders,
+    // Errors only. ONNX Runtime otherwise warns on every startup that it
+    // assigned shape operators to CPU, which is expected and not actionable.
+    logSeverityLevel: 3,
+  });
+}
+
 export async function startRerankerService() {
   printMessage("Preparing model...");
 
@@ -114,21 +134,19 @@ export async function startRerankerService() {
     ensureFileExists(TOKENIZER_CONFIG_HF_FILE),
   ]);
 
-  printMessage(
-    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${EXECUTION_PROVIDERS.join(", ")})...`,
-  );
-
   tokenizer = new Tokenizer(
     JSON.parse(fs.readFileSync(tokenizerPath, "utf8")),
     JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
   );
 
-  session = await InferenceSession.create(modelPath, {
-    executionProviders: EXECUTION_PROVIDERS,
-    // Errors only. ONNX Runtime otherwise warns on every startup that it
-    // assigned shape operators to CPU, which is expected and not actionable.
-    logSeverityLevel: 3,
-  });
+  try {
+    session = await createSession(modelPath, PREFERRED_EXECUTION_PROVIDERS);
+  } catch (error) {
+    printMessage(
+      `Could not load the model with ${PREFERRED_EXECUTION_PROVIDERS.join(", ")}: ${error instanceof Error ? error.message : error}`,
+    );
+    session = await createSession(modelPath, FALLBACK_EXECUTION_PROVIDERS);
+  }
 
   await score("test", ["test document"]);
 


### PR DESCRIPTION
## Description

Currently, the reranker never loads on a host without a usable GPU, and the log from a Hugging Face Space deploy shows it:

```
Loading model (arch: x64, platform: linux, execution providers: webgpu, cpu)...
Warning: Couldn't load Vulkan: libvulkan.so.1: cannot open shared object file: No such file or directory
Failed to start reranker service: Error: ... Failed to get a WebGPU adapter: No supported adapters
Reranker service is not healthy, using unranked results
```

The session was created with `["webgpu", "cpu"]`, and a trailing `cpu` in that list is not a fallback chain: ONNX Runtime only falls back per operator once a provider has been registered. A provider that fails to initialize at all rejects `InferenceSession.create`, and the entries behind it never get a chance. So the reranker stayed unready for the life of the process and every search returned unranked SearXNG results.

This PR creates a second session with `["cpu"]` when the first one fails, logging the reason first. Hosts with a working GPU still load on the first attempt, so nothing changes for them.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## How to test

1. `npm run test` covers the three startup paths with a mocked session (`server/rerankerService.test.ts`). The retry test fails before this change, with the same WebGPU adapter error as the Space.
2. To see it with the real model, hide the Vulkan drivers so Dawn finds no adapter, then run the integration suite:

```sh
VK_DRIVER_FILES=/nonexistent/none.json npx vitest run --config vitest.integration.config.ts
```

Before this change the whole file failed and the 6 tests were skipped. Now the log shows the WebGPU attempt failing, `execution providers: cpu` right after it, and the 6 ranking-quality tests pass.

3. Without the environment variable, the same suite loads on WebGPU as before (verified on Linux x64).

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

## Security, performance, or breaking changes

On a host that falls back, reranking runs at CPU speed (roughly 77ms against 24ms for 30 documents), which is the same speed it had before the ONNX migration. Scores agree to within float32 rounding, so the ordering does not change.
