### PR TITLE
Fix `/status` reporting sessions as zero

### DIFF
--- a/server/verifiedTokens.test.ts
+++ b/server/verifiedTokens.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("verifiedTokens", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("counts each distinct token once regardless of repeat requests", async () => {
+    const { addVerifiedToken, getVerifiedTokensAmount } = await import(
+      "./verifiedTokens"
+    );
+
+    addVerifiedToken("a");
+    addVerifiedToken("a");
+    addVerifiedToken("b");
+
+    expect(getVerifiedTokensAmount()).toBe(2);
+  });
+
+  it("keeps the session count when idle tokens are evicted from the cache", async () => {
+    const { addVerifiedToken, isVerifiedToken, getVerifiedTokensAmount } =
+      await import("./verifiedTokens");
+
+    addVerifiedToken("idle");
+    expect(isVerifiedToken("idle")).toBe(true);
+
+    // Past the idle timeout; the periodic cleanup should evict the entry.
+    vi.advanceTimersByTime(31 * 60_000);
+
+    expect(isVerifiedToken("idle")).toBe(false);
+    // The count stays on a since-restart basis even after eviction.
+    expect(getVerifiedTokensAmount()).toBe(1);
+  });
+
+  it("counts a returning session again after its token was evicted", async () => {
+    const { addVerifiedToken, getVerifiedTokensAmount } = await import(
+      "./verifiedTokens"
+    );
+
+    addVerifiedToken("returning");
+    vi.advanceTimersByTime(31 * 60_000);
+    addVerifiedToken("returning");
+
+    expect(getVerifiedTokensAmount()).toBe(2);
+  });
+
+  it("keeps an actively-used token alive across the idle window", async () => {
+    const { addVerifiedToken, isVerifiedToken } = await import(
+      "./verifiedTokens"
+    );
+
+    addVerifiedToken("active");
+    // Refresh before each cleanup tick so the token is never idle long enough.
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(20 * 60_000);
+      addVerifiedToken("active");
+    }
+
+    expect(isVerifiedToken("active")).toBe(true);
+  });
+});

--- a/server/verifiedTokens.ts
+++ b/server/verifiedTokens.ts
@@ -1,11 +1,24 @@
-/** Set of verified tokens for session management. */
-const verifiedTokens = new Set<string>();
+/** Verified tokens mapped to the time they were last seen, used to skip re-verifying repeat requests. */
+const verifiedTokens = new Map<string, number>();
+
+/** A token idle for longer than this is dropped from the cache, bounding memory; a request after that starts a new session. */
+const SESSION_IDLE_TIMEOUT_MS = 30 * 60_000;
 const CLEANUP_INTERVAL_MS = 60_000;
+
+/**
+ * Distinct sessions seen since the server started. Kept separate from the
+ * cache above so the count survives idle tokens being evicted, staying on the
+ * same "since restart" basis as the search counters it is averaged against.
+ */
+let sessionCount = 0;
 
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 function cleanupVerifiedTokens(): void {
-  verifiedTokens.clear();
+  const now = Date.now();
+  for (const [token, lastSeen] of verifiedTokens) {
+    if (now - lastSeen > SESSION_IDLE_TIMEOUT_MS) verifiedTokens.delete(token);
+  }
 }
 
 function startCleanupTimer(): void {
@@ -19,7 +32,7 @@ function startCleanupTimer(): void {
 startCleanupTimer();
 
 export function getVerifiedTokensAmount() {
-  return verifiedTokens.size;
+  return sessionCount;
 }
 
 export function isVerifiedToken(token: string) {
@@ -27,5 +40,6 @@ export function isVerifiedToken(token: string) {
 }
 
 export function addVerifiedToken(token: string) {
-  return verifiedTokens.add(token);
+  if (!verifiedTokens.has(token)) sessionCount++;
+  verifiedTokens.set(token, Date.now());
 }

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -79,9 +79,7 @@ export async function verifyTokenAndRateLimit(
       void error;
     }
 
-    if (isValidToken) {
-      addVerifiedToken(token);
-    } else {
+    if (!isValidToken) {
       return {
         isAuthorized: false,
         statusCode: 401,
@@ -89,6 +87,9 @@ export async function verifyTokenAndRateLimit(
       };
     }
   }
+
+  // Records a new session or refreshes an active one's last-seen time.
+  addVerifiedToken(token);
 
   const rateLimitKey = request ? getClientIp(request) : token;
 


### PR DESCRIPTION
Fixes the `/status` endpoint always reporting `sessions: 0`.

Currently, the memory-bounding cleanup added in #2157 calls `verifiedTokens.clear()` on the whole set every 60 seconds. That wipes the count every minute, so `getVerifiedTokensAmount()` only returns a non-zero value if a search happens to land in the current 60-second window. Before #2157 the set was never cleared, so `sessions` meant "distinct sessions since restart", which is the basis it shares with `textualSearches`/`graphicalSearches` when computing the per-session averages.

This PR keeps memory bounded without destroying the metric: it evicts idle tokens with a per-token TTL instead of a full wipe, and tracks distinct sessions with a monotonic counter kept separate from the expiring cache, so the count stays on the "since restart" basis.

## What changed

| File | Change |
|---|---|
| `server/verifiedTokens.ts` | `Set` -> `Map<token, lastSeen>`; cleanup evicts only entries idle longer than 30 min; `sessions` now comes from a monotonic `sessionCount` that survives eviction |
| `server/verifyTokenAndRateLimit.ts` | Every authorized request now records/refreshes the token's last-seen time, so an active session keeps its slot and returning after the idle window counts as a new session |
| `server/verifiedTokens.test.ts` | New tests: distinct-token counting, count surviving eviction, returning-after-eviction re-count, and an active token staying alive across the idle window |

## How to test

1. `npx vitest run server/verifiedTokens.test.ts server/verifyTokenAndRateLimit.test.ts` (20 tests pass).
2. Run the app, do a search, then hit `/status`: `sessions` reads 1 and stays there past the 60-second mark (before this change it dropped back to 0).