### PR TITLE
fix: handle internal API stream chunk boundaries

### DIFF
--- a/client/modules/textGenerationWithInternalApi.test.ts
+++ b/client/modules/textGenerationWithInternalApi.test.ts
@@ -50,15 +50,34 @@ function sseChunks(lines: string[]) {
   return [...lines.map((line) => `data: ${line}\n`), "data: [DONE]\n"];
 }
 
-function streamResponse(chunks: string[], status = 200) {
+function streamResponse(chunks: Array<string | Uint8Array>, status = 200) {
   const encoder = new TextEncoder();
   const body = new ReadableStream({
     start(controller) {
-      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      for (const chunk of chunks) {
+        controller.enqueue(
+          typeof chunk === "string" ? encoder.encode(chunk) : chunk,
+        );
+      }
       controller.close();
     },
   });
   return new Response(body, { status });
+}
+
+async function generateChatFromChunks(chunks: Array<string | Uint8Array>) {
+  const { generateChatWithInternalApi } = await import(
+    "./textGenerationWithInternalApi"
+  );
+  mockFetch.mockResolvedValueOnce(streamResponse(chunks));
+
+  const onUpdate = vi.fn();
+  const result = await generateChatWithInternalApi(
+    [{ role: "user", content: "Hi" }],
+    onUpdate,
+  );
+
+  return { onUpdate, result };
 }
 
 describe("textGenerationWithInternalApi", () => {
@@ -144,23 +163,43 @@ describe("textGenerationWithInternalApi", () => {
 
   describe("generateChatWithInternalApi", () => {
     it("streams incremental accumulated text as multiple SSE chunks arrive", async () => {
-      const { generateChatWithInternalApi } = await import(
-        "./textGenerationWithInternalApi"
+      const { onUpdate, result } = await generateChatFromChunks([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+        "data: [DONE]\n",
+      ]);
+
+      expect(result).toBe("Hello world");
+      expect(onUpdate).toHaveBeenNthCalledWith(1, "Hello");
+      expect(onUpdate).toHaveBeenNthCalledWith(2, "Hello world");
+    });
+
+    it("reassembles SSE frames split across arbitrary byte boundaries", async () => {
+      const encodedResponse = new TextEncoder().encode(
+        [
+          'data: {"choices":[{"delta":{"content":"Hello 🌍"}}]}',
+          'data: {"choices":[{"delta":{"content":"!"}}]}',
+        ].join("\n"),
       );
 
-      mockFetch.mockResolvedValueOnce(
-        streamResponse([
-          'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
-          'data: {"choices":[{"delta":{"content":" world"}}]}\n',
-          "data: [DONE]\n",
-        ]),
+      const { onUpdate, result } = await generateChatFromChunks(
+        Array.from({ length: encodedResponse.length }, (_, index) =>
+          encodedResponse.slice(index, index + 1),
+        ),
       );
 
-      const onUpdate = vi.fn();
-      const result = await generateChatWithInternalApi(
-        [{ role: "user", content: "Hi" }],
-        onUpdate,
-      );
+      expect(result).toBe("Hello 🌍!");
+      expect(onUpdate).toHaveBeenNthCalledWith(1, "Hello 🌍");
+      expect(onUpdate).toHaveBeenNthCalledWith(2, "Hello 🌍!");
+    });
+
+    it("skips a malformed data line and continues streaming", async () => {
+      const { onUpdate, result } = await generateChatFromChunks([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+        "data: not-json\n",
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+        "data: [DONE]\n",
+      ]);
 
       expect(result).toBe("Hello world");
       expect(onUpdate).toHaveBeenNthCalledWith(1, "Hello");

--- a/client/modules/textGenerationWithInternalApi.ts
+++ b/client/modules/textGenerationWithInternalApi.ts
@@ -14,6 +14,11 @@ import {
 } from "./textGenerationUtilities";
 import type { ChatMessage } from "./types";
 
+interface InternalApiStreamPayload {
+  error?: unknown;
+  choices?: Array<{ delta?: { content?: unknown } }>;
+}
+
 export async function generateTextWithInternalApi() {
   await canStartResponding();
   updateTextGenerationState("preparingToGenerate");
@@ -80,30 +85,45 @@ async function processStreamResponse(
   const reader = response.body.getReader();
   const decoder = new TextDecoder("utf-8");
   let streamedMessage = "";
+  let bufferedText = "";
+
+  const processLine = (line: string) => {
+    const data = line.replace(/^data: /, "").trim();
+    if (data === "" || data === "[DONE]") return;
+
+    let parsedLine: InternalApiStreamPayload;
+    try {
+      parsedLine = JSON.parse(data) as InternalApiStreamPayload;
+    } catch {
+      return;
+    }
+
+    if (typeof parsedLine?.error === "string") {
+      throw new ChatGenerationError(parsedLine.error);
+    }
+
+    const deltaContent = parsedLine?.choices?.[0]?.delta?.content;
+    if (typeof deltaContent === "string" && deltaContent !== "") {
+      streamedMessage += deltaContent;
+      onChunk(streamedMessage);
+    }
+  };
 
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
 
-    const chunk = decoder.decode(value);
-    const lines = chunk.split("\n");
-    const parsedLines = lines
-      .map((line) => line.replace(/^data: /, "").trim())
-      .filter((line) => line !== "" && line !== "[DONE]")
-      .map((line) => JSON.parse(line));
+    bufferedText += decoder.decode(value, { stream: true });
+    const lines = bufferedText.split("\n");
+    bufferedText = lines.pop() ?? "";
 
-    for (const parsedLine of parsedLines) {
-      if (typeof parsedLine?.error === "string") {
-        throw new ChatGenerationError(parsedLine.error);
-      }
-
-      const deltaContent = parsedLine?.choices?.[0]?.delta?.content;
-      if (deltaContent) {
-        streamedMessage += deltaContent;
-        onChunk(streamedMessage);
-      }
+    for (const line of lines) {
+      processLine(line);
     }
   }
+
+  bufferedText += decoder.decode();
+  processLine(bufferedText);
 
   return streamedMessage;
 }


### PR DESCRIPTION
## Description

Fixes #2177.

The internal inference client previously decoded and parsed each transport
chunk independently. A chunk can end in the middle of either an SSE data line
or a multi-byte UTF-8 character, so a valid streamed response could fail with a
`SyntaxError` and discard the rest of the answer.

The parser now keeps the `TextDecoder` in streaming mode, buffers text between
reads, and parses only complete newline-delimited frames. It also flushes the
last unterminated frame at EOF and skips an isolated malformed data line while
preserving the existing error-frame behavior.

Regression tests feed the response one byte at a time through a multi-byte
character and verify that a malformed line does not prevent later valid
content from streaming.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (refactor, build, chore)

## How to test

1. Run `npm ci`.
2. Run `npm test`.
3. Run `npm run lint`.

The focused regression suite is:

`npx vitest run client/modules/textGenerationWithInternalApi.test.ts`

## Checklist

- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense
