### PR TITLE
fix: consolidate circuit breakers (#2188)

### DIFF
--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -7,6 +7,7 @@ import {
   type MockedFunction,
   vi,
 } from "vitest";
+import { CircuitBreaker } from "./utils/circuitBreaker";
 import {
   describeUnresponsiveEngines,
   fetchSearXNG,
@@ -165,36 +166,30 @@ describe("retry logic", () => {
 });
 
 describe("circuit breaker", () => {
-  let isolatedFetchSearXNG: typeof fetchSearXNG;
-
-  beforeEach(async () => {
-    vi.resetModules();
-    const module = await import("./webSearchService");
-    isolatedFetchSearXNG = module.fetchSearXNG;
-  });
-
   it("opens after exactly 5 non-retriable failures", async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 5 });
     fetchMock.mockResolvedValue(createMockResponse("", false, 503));
 
     for (let i = 0; i < 5; i++) {
-      await isolatedFetchSearXNG("test", "text");
+      await fetchSearXNG("test", "text", 30, breaker);
     }
 
     const callsBeforeBreak = fetchMock.mock.calls.length;
-    await isolatedFetchSearXNG("test", "text");
+    await fetchSearXNG("test", "text", 30, breaker);
 
     expect(fetchMock.mock.calls.length).toBe(callsBeforeBreak);
   });
 
   it("does not open before 5 failures", async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 5 });
     fetchMock.mockResolvedValue(createMockResponse("", false, 503));
 
     for (let i = 0; i < 4; i++) {
-      await isolatedFetchSearXNG("test", "text");
+      await fetchSearXNG("test", "text", 30, breaker);
     }
 
     const callsBefore = fetchMock.mock.calls.length;
-    await isolatedFetchSearXNG("test", "text");
+    await fetchSearXNG("test", "text", 30, breaker);
 
     expect(fetchMock.mock.calls.length).toBe(callsBefore + 1);
   });

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -2,6 +2,7 @@ import { basename } from "node:path";
 import debug from "debug";
 import { convert as convertHtmlToPlainText } from "html-to-text";
 import { strip as stripEmojis } from "node-emoji";
+import { CircuitBreaker } from "./utils/circuitBreaker";
 
 const fileName = basename(import.meta.url);
 const printMessage = debug(fileName);
@@ -11,22 +12,16 @@ const SERVICE_HOST = "127.0.0.1";
 const SERVICE_PORT = 8888;
 const SERVICE_BASE_URL = `http://${SERVICE_HOST}:${SERVICE_PORT}`;
 
-interface CircuitBreakerState {
-  failures: number;
-  lastFailureTime: number;
-  isOpen: boolean;
-}
-
-const circuitBreaker: CircuitBreakerState = {
-  failures: 0,
-  lastFailureTime: 0,
-  isOpen: false,
-};
-
-const CIRCUIT_BREAKER_THRESHOLD = 5;
-const CIRCUIT_BREAKER_TIMEOUT = 60000;
 const MAX_RETRIES = 3;
 const BASE_RETRY_DELAY = 1000;
+
+// successThreshold: 1 preserves the previous breaker's single-success reset:
+// once resetTimeout elapses, one healthy request closes the circuit again.
+const searxngCircuitBreaker = new CircuitBreaker({
+  failureThreshold: 5,
+  resetTimeout: 60_000,
+  successThreshold: 1,
+});
 
 type SearchType = "text" | "images";
 
@@ -121,33 +116,10 @@ export function describeUnresponsiveEngines(
     .join(", ");
 }
 
-function recordFailure() {
-  circuitBreaker.failures++;
-  circuitBreaker.lastFailureTime = Date.now();
-  if (circuitBreaker.failures >= CIRCUIT_BREAKER_THRESHOLD) {
-    circuitBreaker.isOpen = true;
-    printMessage(
-      `Circuit breaker opened after ${circuitBreaker.failures} failures`,
-    );
-  }
-}
-
 async function performSearch(
   query: string,
   searchType: SearchType,
 ): Promise<SearxngSearchResult[]> {
-  if (circuitBreaker.isOpen) {
-    const timeSinceLastFailure = Date.now() - circuitBreaker.lastFailureTime;
-    if (timeSinceLastFailure < CIRCUIT_BREAKER_TIMEOUT) {
-      throw new Error(
-        "Circuit breaker is open - SearXNG service temporarily unavailable",
-      );
-    }
-    circuitBreaker.isOpen = false;
-    circuitBreaker.failures = 0;
-    printMessage("Circuit breaker reset");
-  }
-
   const searchUrl = buildSearchUrl(query, searchType);
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -161,21 +133,14 @@ async function performSearch(
 
     const response = await fetch(searchUrl, {
       headers: { Accept: "application/json" },
-    }).catch((error: unknown) => {
-      recordFailure();
-      throw error;
     });
 
     if (!response.ok) {
       if (response.status === 500 && attempt < MAX_RETRIES) {
         continue;
       }
-      recordFailure();
       throw new Error(`SearXNG request failed with status ${response.status}`);
     }
-
-    circuitBreaker.failures = 0;
-    circuitBreaker.isOpen = false;
 
     const data = (await response.json()) as SearxngSearchResponse;
     const results = Array.isArray(data.results) ? data.results : [];
@@ -192,7 +157,6 @@ async function performSearch(
     return results;
   }
 
-  recordFailure();
   throw new Error(
     `SearXNG request failed with status 500 after ${MAX_RETRIES} retries`,
   );
@@ -202,8 +166,11 @@ async function processSearchResults(
   query: string,
   searchType: SearchType,
   limit: number,
+  breaker: CircuitBreaker,
 ) {
-  const results = await performSearch(query, searchType);
+  const results = await breaker.execute("searxng", () =>
+    performSearch(query, searchType),
+  );
   const deduplicatedResults = deduplicateResults(results);
 
   if (searchType === "text") {
@@ -253,9 +220,10 @@ export async function fetchSearXNG(
   query: string,
   searchType: SearchType,
   limit = 30,
+  breaker: CircuitBreaker = searxngCircuitBreaker,
 ) {
   try {
-    return await processSearchResults(query, searchType, limit);
+    return await processSearchResults(query, searchType, limit, breaker);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     printMessage(`Search failed: ${errorMessage}`);


### PR DESCRIPTION
## Description

Fixes #2188.

Currently, `server/webSearchService.ts` guards SearXNG with a bespoke module-level circuit breaker. Its state lives for the whole process lifetime with no reset hook, so it can't be built fresh in a test. Meanwhile the `CircuitBreaker` class in `server/utils/circuitBreaker.ts` already covers this (per-key, `HALF_OPEN`-aware) and has its own tests, but nothing in production imports it. So the tested code is dead and the live code is untested.

This PR routes SearXNG through the `CircuitBreaker` class and deletes the bespoke one. The breaker is injected into `fetchSearXNG` (`breaker: CircuitBreaker = searxngCircuitBreaker`), so production shares one persistent instance and tests can pass their own fresh one instead of reaching for `vi.resetModules()`.

Behavior is preserved: same `failureThreshold: 5` and `60s` `resetTimeout`, and `successThreshold: 1` keeps the old single-success reset (one healthy request closes the circuit again after the timeout).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (refactor, build, chore)

## How to test

1. Run `npm ci`.
2. Run `npm run test` (or the focused suite: `npx vitest run server/webSearchService.test.ts server/utils/circuitBreaker.test.ts`).
3. Run `npm run lint`.

The circuit-breaker tests now build a `new CircuitBreaker(...)` and pass it into `fetchSearXNG`, so they no longer reload the module to get isolation.

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), with tests added where it made sense

## Security, performance, or breaking changes

`fetchSearXNG` gains an optional fourth parameter (`breaker`) with a default, so existing callers are untouched. No other breaking changes.
