### PR TITLE
Clean up reranker input in `rankSearchResults`

### DIFF
--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -22,7 +22,7 @@ describe("rankSearchResults", () => {
     expect(mockRerank).toHaveBeenCalledWith("test query", []);
   });
 
-  it("should pass lowercased query and documents to rerank", async () => {
+  it("should pass query and title+snippet (cased, no URL) to rerank", async () => {
     mockRerank.mockResolvedValue([
       { index: 0, relevance_score: 0.9 },
       { index: 1, relevance_score: 0.5 },
@@ -33,12 +33,11 @@ describe("rankSearchResults", () => {
       ["Title B", "Content B", "https://b.com"],
     ]);
     expect(mockRerank).toHaveBeenCalledWith(
-      "test query",
-      expect.arrayContaining([
-        expect.stringContaining("title a"),
-        expect.stringContaining("title b"),
-      ]),
+      "Test Query",
+      expect.arrayContaining(["Title A\nContent A", "Title B\nContent B"]),
     );
+    const [, docs] = mockRerank.mock.calls[0];
+    expect(docs.join("\n")).not.toContain("https://");
   });
 
   it("should sort results by score descending when preserveTopResults is false", async () => {
@@ -95,7 +94,7 @@ describe("rankSearchResults", () => {
     expect(docs[0].length).toBeLessThanOrEqual(512);
   });
 
-  it("should replace double quotes with single quotes in snippet", async () => {
+  it("should preserve double quotes in snippet verbatim", async () => {
     mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }] as {
       index: number;
       relevance_score: number;
@@ -105,7 +104,7 @@ describe("rankSearchResults", () => {
       ["Title", 'Content with "quotes"', "https://a.com"],
     ]);
     const docs = mockRerank.mock.calls[0][1] as string[];
-    // The snippet's double quotes are replaced with single quotes
-    expect(docs[0]).toContain("'quotes'");
+    // Double quotes in the snippet are preserved (no Markdown wrapper to escape for)
+    expect(docs[0]).toBe('Title\nContent with "quotes"');
   });
 });

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -7,15 +7,14 @@ export async function rankSearchResults(
   searchResults: [title: string, content: string, url: string][],
   preserveTopResults = false,
 ) {
-  const documents = searchResults.map(([title, snippet, url]) => {
-    const doc =
-      `[${title}](${url} "${snippet.replaceAll('"', "'")}")`.toLocaleLowerCase();
+  const documents = searchResults.map(([title, snippet]) => {
+    const doc = `${title}\n${snippet}`;
     return doc.length > MAX_DOCUMENT_LENGTH
       ? doc.slice(0, MAX_DOCUMENT_LENGTH)
       : doc;
   });
 
-  const results = await rerank(query.toLocaleLowerCase(), documents);
+  const results = await rerank(query, documents);
 
   const scoredResults = results.map(({ index, relevance_score }) => ({
     result: searchResults[index],

--- a/server/rerankerService.integration.test.ts
+++ b/server/rerankerService.integration.test.ts
@@ -166,9 +166,8 @@ const MAX_DOCUMENT_LENGTH = 512;
 
 /** Mirrors the document formatting in rankSearchResults.ts. */
 function buildDocuments(results: SearchResult[]) {
-  return results.map(([title, snippet, url]) => {
-    const doc =
-      `[${title}](${url} "${snippet.replaceAll('"', "'")}")`.toLocaleLowerCase();
+  return results.map(([title, snippet]) => {
+    const doc = `${title}\n${snippet}`;
     return doc.length > MAX_DOCUMENT_LENGTH
       ? doc.slice(0, MAX_DOCUMENT_LENGTH)
       : doc;
@@ -195,7 +194,7 @@ describe("reranker service", () => {
   for (const fixture of fixtures) {
     it(`ranks relevant results first: ${fixture.name}`, async () => {
       const documents = buildDocuments(fixture.results);
-      const scored = await rerank(fixture.query.toLocaleLowerCase(), documents);
+      const scored = await rerank(fixture.query, documents);
 
       expect(scored).toHaveLength(fixture.results.length);
       expect(


### PR DESCRIPTION
Fixes #2193.

## What changed

`server/rankSearchResults.ts` was feeding the reranker Markdown-shaped documents that mixed content with the URL and were lowercased:

```ts
`[${title}](${url} "${snippet.replaceAll('"', "'")}")`.toLocaleLowerCase()
```

Three consequences at scoring time:
1. **Casing signal was thrown away** on both query and doc. `jina-reranker-v1-tiny-en` was trained on cased text; lowercasing pushes every input off its training distribution.
2. **The URL competed with the snippet for the 512-character budget.** A long URL in the middle of the doc could push the snippet — the actual relevant content — past the truncation cut.
3. **The URL itself was scored as content.** The cross-encoder attends over every token; the URL adds nothing but is not free.

## Fix

Feed the reranker just `${title}\n${snippet}` — no URL, no lowercasing, snippet immediately after the title with no interleaved markup. The 512-char cap is preserved (backward-compatible with the `MAX_DOCUMENT_LENGTH` guard); with the URL removed the entire budget is available for title + snippet. Query casing is preserved too, so cased-cased scoring stays inside the reranker's training distribution.

The double-quote-to-single-quote replacement in snippets is dropped as well — it only existed because the previous Markdown link wrapping (`...\"snippet\"...`) would break on inner quotes; the new shape has no such constraint.

## Tests

- `rankSearchResults.test.ts` "lowercased query and documents" case retargeted to assert the new contract (cased passthrough, no URL, `title\nsnippet` shape) and gains a URL-absence assertion.
- "replace double quotes with single quotes" case retargeted to verify quotes are now preserved verbatim.
- All 7 tests in the file pass locally. `biome check` clean on both files.

## Follow-up (out of scope here)

The issue also mentions token-based truncation. Doing that cleanly means exposing the tokenizer from `rerankerService.ts` (currently a lazily-initialised module-level singleton), which is a wider surface change than this drop-in cleanup. Happy to open a follow-up if you'd like — kept this PR small so it's easy to review, revert, and reason about.