### PR TITLE
fix: truncate reranker input by tokens, not characters

### DIFF
--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -66,14 +66,9 @@ On server close, `stopRerankerService()` clears the readiness flag and releases 
 
 ### Document Preparation
 
-Search results are formatted as Markdown-style strings and truncated:
+Each result is formatted as `` `${title}\n${snippet}` ``: the cased title and snippet on either side of a newline, with no URL. The query keeps its original casing too. Unicode surrogates in both are sanitized before tokenization.
 
-```typescript
-const doc = `[${title}](${url} "${snippet}")`.toLocaleLowerCase();
-// Truncated to MAX_DOCUMENT_LENGTH (512 characters)
-```
-
-Both query and documents are lowercased and Unicode surrogates are sanitized before tokenization.
+Documents are sent to the reranker whole. Truncation happens by tokens inside the reranker, not by characters here: `score()` caps each encoded `(query, document)` pair at `MAX_SEQUENCE_LENGTH` tokens, dropping tokens from the end of the document only, so the query and the trailing separator are preserved.
 
 ### Unicode Sanitization
 
@@ -125,6 +120,7 @@ Reranking is applied to both text and image search results. For image results, t
 | HuggingFace Repo | jinaai/jina-reranker-v1-tiny-en |
 | Type | Cross-encoder reranker |
 | Size | 4 layers, 33M parameters |
+| Max sequence length | 8192 tokens (ALiBi); capped at 2048 via `MAX_SEQUENCE_LENGTH` |
 | Storage | `server/models/jinaai/jina-reranker-v1-tiny-en/` |
 
 Despite being an English model, it ranks non-English results (Portuguese, for example) well in practice, which is why it is preferred over larger alternatives.

--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -82,7 +82,7 @@ describe("rankSearchResults", () => {
     expect(result).toEqual([]);
   });
 
-  it("should truncate document strings to MAX_DOCUMENT_LENGTH", async () => {
+  it("should pass full document text to rerank without character truncation", async () => {
     mockRerank.mockResolvedValue([{ index: 0, relevance_score: 0.9 }] as {
       index: number;
       relevance_score: number;
@@ -91,7 +91,10 @@ describe("rankSearchResults", () => {
     const longTitle = "A".repeat(600);
     await rankSearchResults("query", [[longTitle, "short", "https://a.com"]]);
     const docs = mockRerank.mock.calls[0][1] as string[];
-    expect(docs[0].length).toBeLessThanOrEqual(512);
+    // Truncation is now token-based inside the reranker, so the full document
+    // reaches it; nothing is cut by character count upstream.
+    expect(docs[0]).toBe(`${longTitle}\nshort`);
+    expect(docs[0].length).toBeGreaterThan(512);
   });
 
   it("should preserve double quotes in snippet verbatim", async () => {

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -1,18 +1,13 @@
 import { rerank } from "./rerankerService";
 
-const MAX_DOCUMENT_LENGTH = 512;
-
 export async function rankSearchResults(
   query: string,
   searchResults: [title: string, content: string, url: string][],
   preserveTopResults = false,
 ) {
-  const documents = searchResults.map(([title, snippet]) => {
-    const doc = `${title}\n${snippet}`;
-    return doc.length > MAX_DOCUMENT_LENGTH
-      ? doc.slice(0, MAX_DOCUMENT_LENGTH)
-      : doc;
-  });
+  const documents = searchResults.map(
+    ([title, snippet]) => `${title}\n${snippet}`,
+  );
 
   const results = await rerank(query, documents);
 

--- a/server/rerankerService.integration.test.ts
+++ b/server/rerankerService.integration.test.ts
@@ -162,16 +162,9 @@ const fixtures: Fixture[] = [
   },
 ];
 
-const MAX_DOCUMENT_LENGTH = 512;
-
 /** Mirrors the document formatting in rankSearchResults.ts. */
 function buildDocuments(results: SearchResult[]) {
-  return results.map(([title, snippet]) => {
-    const doc = `${title}\n${snippet}`;
-    return doc.length > MAX_DOCUMENT_LENGTH
-      ? doc.slice(0, MAX_DOCUMENT_LENGTH)
-      : doc;
-  });
+  return results.map(([title, snippet]) => `${title}\n${snippet}`);
 }
 
 describe("reranker service", () => {

--- a/server/rerankerService.test.ts
+++ b/server/rerankerService.test.ts
@@ -8,12 +8,13 @@ import {
   sanitizeUnicodeSurrogates,
   startRerankerService,
   stopRerankerService,
+  truncatePairTokens,
 } from "./rerankerService";
 
 vi.mock("@huggingface/tokenizers", () => ({
   Tokenizer: class {
     encode() {
-      return { ids: [1, 2, 3] };
+      return { ids: [1, 2, 3], token_type_ids: [0, 0, 0] };
     }
   },
 }));
@@ -410,5 +411,33 @@ describe("rerank", () => {
     const [query, options] = encodeSpy.mock.calls[0];
     expect(query).toBe("query\ufffd");
     expect((options as { text_pair: string }).text_pair).toBe("doc\ufffd");
+  });
+});
+
+describe("truncatePairTokens", () => {
+  // Sequence layout: [CLS] q q [SEP] | d d d d [SEP]
+  const ids = [101, 11, 12, 102, 21, 22, 23, 24, 102];
+  const tokenTypeIds = [0, 0, 0, 0, 1, 1, 1, 1, 1];
+
+  it("returns the ids unchanged when within budget", () => {
+    expect(truncatePairTokens(ids, tokenTypeIds, 20)).toBe(ids);
+  });
+
+  it("drops document tokens from the end, keeping the query and trailing separator", () => {
+    const out = truncatePairTokens(ids, tokenTypeIds, 6);
+
+    expect(out).toHaveLength(6);
+    expect(out.slice(0, 4)).toEqual([101, 11, 12, 102]); // query segment intact
+    expect(out.at(-1)).toBe(102); // trailing [SEP] preserved
+    expect(out).toEqual([101, 11, 12, 102, 21, 102]); // budget: 6 - 4 - 1 = 1 doc token
+  });
+
+  it("falls back to a plain head slice when the query alone exceeds the budget", () => {
+    const queryHeavyIds = [101, 11, 12, 13, 14, 102, 21, 102];
+    const queryHeavyTypes = [0, 0, 0, 0, 0, 0, 1, 1];
+
+    expect(truncatePairTokens(queryHeavyIds, queryHeavyTypes, 4)).toEqual([
+      101, 11, 12, 13,
+    ]);
   });
 });

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -21,8 +21,10 @@ const PAD_TOKEN_ID = 0;
 /**
  * Sequence-length budget for one (query, document) pair, and the single point
  * where truncation happens now that rankSearchResults sends whole documents.
- * Left at 2048 rather than the tokenizer's declared `model_max_length` of 512,
- * matching the prior intent; see #2193.
+ * jina-reranker-v1-tiny-en is an ALiBi model that handles up to 8192 tokens
+ * (verified: the ONNX graph runs at 8192 without error); the `model_max_length`
+ * of 512 in tokenizer_config.json is a stale BERT default, not the real limit.
+ * 2048 is a deliberate, conservative cap. See #2193.
  */
 const MAX_SEQUENCE_LENGTH = 2048;
 

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -19,8 +19,10 @@ const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
 const PAD_TOKEN_ID = 0;
 
 /**
- * Documents are truncated to 512 characters upstream, so this only guards
- * against pathological tokenization.
+ * Sequence-length budget for one (query, document) pair, and the single point
+ * where truncation happens now that rankSearchResults sends whole documents.
+ * Left at 2048 rather than the tokenizer's declared `model_max_length` of 512,
+ * matching the prior intent; see #2193.
  */
 const MAX_SEQUENCE_LENGTH = 2048;
 
@@ -195,6 +197,36 @@ async function scoreBatch(
 }
 
 /**
+ * Caps an encoded cross-encoder pair at `maxLength` tokens by dropping tokens
+ * from the end of the document only. The sequence is `[CLS] query [SEP]
+ * document [SEP]`, so the query sits at the front and is preserved, and the
+ * trailing separator is kept so the model still receives a well-formed pair.
+ * `tokenTypeIds` mark the query segment (0) apart from the document (1). This
+ * mirrors the tokenizer's `only_second` truncation, which the JS package does
+ * not implement. Falls back to a plain head slice if the query alone already
+ * exceeds the budget.
+ */
+export function truncatePairTokens(
+  ids: number[],
+  tokenTypeIds: number[],
+  maxLength: number,
+): number[] {
+  if (ids.length <= maxLength) {
+    return ids;
+  }
+
+  const querySegmentLength = tokenTypeIds.filter((type) => type === 0).length;
+  const documentBudget = maxLength - querySegmentLength - 1;
+
+  if (documentBudget <= 0) {
+    return ids.slice(0, maxLength);
+  }
+
+  const separator = ids[ids.length - 1];
+  return [...ids.slice(0, querySegmentLength + documentBudget), separator];
+}
+
+/**
  * Returns the cross-encoder's raw relevance logit per document. Deliberately
  * not squashed through sigmoid: the standard-deviation filter in
  * rankSearchResults is calibrated against this scale.
@@ -208,10 +240,11 @@ async function score(query: string, documents: string[]) {
   const loadedTokenizer = tokenizer;
 
   const encodings = documents.map((document) => {
-    const { ids } = loadedTokenizer.encode(query, { text_pair: document });
-    return ids.length > MAX_SEQUENCE_LENGTH
-      ? ids.slice(0, MAX_SEQUENCE_LENGTH)
-      : ids;
+    const { ids, token_type_ids } = loadedTokenizer.encode(query, {
+      text_pair: document,
+      return_token_type_ids: true,
+    });
+    return truncatePairTokens(ids, token_type_ids, MAX_SEQUENCE_LENGTH);
   });
 
   const scores: number[] = [];


### PR DESCRIPTION
## Description

Fixes #2193.

`rankSearchResults` truncated each document to 512 **characters** before handing it to the reranker. Two problems with that:

- Characters are the wrong unit. The cross-encoder thinks in tokens, so a character cap cuts at a place that has nothing to do with the model's real limit.
- 512 characters is well short of the model's budget (2048 tokens), so relevant content was being thrown away for no reason before the reranker ever saw it.

This moves truncation to where it belongs: by tokens, inside `score()`, where the tokenizer already lives.

## What changed

| File | Change |
|---|---|
| `server/rankSearchResults.ts` | Removed the 512-character truncation. Documents now reach the reranker whole. |
| `server/rerankerService.ts` | `score()` now truncates the encoded `(query, document)` pair by tokens. Added `truncatePairTokens`, which drops document tokens only, keeping the query and the trailing `[SEP]` intact (using `token_type_ids` to tell the two segments apart). Updated the stale comment on `MAX_SEQUENCE_LENGTH`. |
| `server/rerankerService.test.ts` | Added unit tests for `truncatePairTokens` (within budget, document trimmed with query + separator preserved, query-heavy fallback). |
| `server/rankSearchResults.test.ts` | Retargeted the old character-truncation test to assert the full document is now passed through. |
| `server/rerankerService.integration.test.ts` | Dropped the mirrored character truncation from `buildDocuments`, so it still matches production. |
| `docs/reranking.md` | Rewrote "Document Preparation" to match reality: token-based document-only truncation, and the current `title\nsnippet` format. That section had also gone stale back at #2256 (still showed the old Markdown+lowercase shape), so this fixes both. Added the model's sequence-length limit to the details table. |

The query already survived the old tail slice (it sits at the front of the sequence), so the real gain here is on the document side: it gets the whole token budget, and truncation now mirrors the tokenizer's `only_second` strategy, which the JS package doesn't implement on its own.

## Why 2048 (not 512)

The `tokenizer_config.json` declares `model_max_length: 512`, which is tempting to treat as the cap. It isn't. `jina-reranker-v1-tiny-en` is JinaBERT with ALiBi, and both the model card ("up to an impressive 8,192 tokens") and a direct check agree: I fed the real ONNX graph sequences from 513 up to 8192 tokens and every one ran and returned finite logits, with no error at 513 (a learned-512-position BERT would throw there). So the 512 in the config is a stale BERT default, not the model's real limit, and capping at 512 would throw away ~7/8 of the model's usable context. 2048 is kept as a conservative budget.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other

## How to test

1. `npm ci`
2. `npm run test`
3. `npx vitest run --config vitest.integration.config.ts` (loads the real model)
4. `npm run lint`

## Checklist
- [x] `npm run lint` passes
- [x] Tests pass (`npm run test`), including the real-model integration test (6/6)

## Security, performance, or breaking changes

None breaking. The public API is unchanged. Documents now reach the tokenizer whole instead of pre-cut to 512 characters; tokenization cost is bounded by the search provider's snippet length and the 2048-token cap still bounds what the model runs on.
