### PR TITLE
fix: clarify browser inference privacy

### DIFF
--- a/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/AISettingsForm.tsx
@@ -72,6 +72,13 @@ export default function AISettingsForm() {
             allowDeselect={false}
           />
 
+          {form.values.inferenceType === "browser" && (
+            <Text size="xs" c="dimmed">
+              Search queries still go through your MiniSearch instance and
+              SearXNG; only the AI answer is generated locally.
+            </Text>
+          )}
+
           {form.values.inferenceType === "openai" && (
             <OpenAISettings
               form={form}

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -52,7 +52,7 @@ addLogEntry(
 );
 
 export const inferenceTypes = [
-  { value: "browser", label: "In the browser (Private)" },
+  { value: "browser", label: "In the browser (local inference)" },
   { value: "openai", label: "Remote server (API)" },
   { value: "horde", label: "AI Horde (Pre-configured)" },
   ...(VITE_INTERNAL_API_ENABLED


### PR DESCRIPTION
## Summary

- relabel browser-based AI as local inference instead of implying the entire search is private
- clarify that search queries still pass through the MiniSearch instance and SearXNG
- show the clarification only when browser inference is selected

Closes #2195

## Validation

- `git diff --check`
- verified the copy and conditional placement against the issue requirements

The full local test suite was not run because dependency installation did not complete in the local environment; the change is limited to static UI copy in two files.