### PR TITLE
docs: add good-first-issue pointers to README and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 First off, thank you for considering contributing to MiniSearch! It's people like you that make MiniSearch such a great tool.
 
+## Your First Contribution
+
+Not sure where to start? [Browse issues labeled "good first issue"](https://github.com/felladrin/MiniSearch/issues?q=label%3A%22good+first+issue%22+state%3Aopen). They are curated for first-time contributors, and you are welcome to ask for help in the issue comments.
+
 ## Quick Start
 
 - **Onboarding**: See [`../docs/quick-start.md`](../docs/quick-start.md) for setup and running the app.
@@ -18,6 +22,7 @@ docker compose exec development-server npm run lint
 ```
 
 This runs:
+
 - Biome (formatting/linting)
 - TypeScript (type checking)
 - knip (dead code detection)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ Yes. Configure the `INTERNAL_OPENAI_COMPATIBLE_API_*` variables from the [Config
 
 ## Contributing
 
-Contributions are welcome. To set up a development environment:
+Contributions are welcome. Looking for where to start? [Browse the good first issues](https://github.com/felladrin/MiniSearch/issues?q=label%3A%22good+first+issue%22+state%3Aopen) — they are curated for first-time contributors.
+
+To set up a development environment:
 
 ```bash
 git clone https://github.com/felladrin/MiniSearch.git


### PR DESCRIPTION
Closes #2198.

**Problem:** The repo has good-first-issues labeled, but nothing in the README or CONTRIBUTING file points first-timers to them. New visitors land on the Contributing section with only setup steps and no cue about what to pick up.

**What changed:**

| File | Change |
| --- | --- |
| `README.md` | Added "Your first contribution" sentence linking to the good-first-issues label filter, placed before setup steps |
| `.github/CONTRIBUTING.md` | Added "Your First Contribution" section at the top, before Quick Start, with the same link and an invitation to ask for help |

**How verified:** Checked locally — both files render correctly and the link resolves to the filtered issues view.