### PR TITLE
fix: validate and clamp server proxy inputs

### DIFF
--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -1,0 +1,92 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./handleTokenVerification", () => ({
+  handleTokenVerification: vi.fn(),
+}));
+
+import { handleTokenVerification } from "./handleTokenVerification";
+import { internalApiEndpointServerHook } from "./internalApiEndpointServerHook";
+
+function createRequest(body: unknown): IncomingMessage {
+  const request = Readable.from([JSON.stringify(body)]) as IncomingMessage;
+  request.url = "/inference?token=abc";
+  request.method = "POST";
+  request.headers = {
+    host: "localhost:3000",
+    "content-type": "application/json",
+  };
+  return request;
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    headersSent: false,
+    writableEnded: false,
+    destroyed: false,
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as ServerResponse & {
+    setHeader: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+}
+
+function getRegisteredHandler() {
+  const use = vi.fn();
+  internalApiEndpointServerHook({
+    middlewares: { use },
+  } as unknown as Parameters<typeof internalApiEndpointServerHook>[0]);
+  return use.mock.calls[0][0] as (
+    request: IncomingMessage,
+    response: ServerResponse,
+    next: () => void,
+  ) => Promise<void>;
+}
+
+describe("internalApiEndpointServerHook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(handleTokenVerification).mockResolvedValue({
+      shouldContinue: true,
+    });
+  });
+
+  it.each([
+    {
+      name: "messages is missing",
+      body: {},
+      expectedPath: "messages",
+    },
+    {
+      name: "messages is empty",
+      body: { messages: [] },
+      expectedPath: "messages",
+    },
+    {
+      name: "a message role is invalid",
+      body: { messages: [{ role: "admin", content: "hello" }] },
+      expectedPath: "messages.0.role",
+    },
+    {
+      name: "message content is not a string",
+      body: { messages: [{ role: "user", content: 42 }] },
+      expectedPath: "messages.0.content",
+    },
+  ])("responds 400 when $name", async ({ body, expectedPath }) => {
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(createRequest(body), response, vi.fn());
+
+    expect(response.statusCode).toBe(400);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "application/json",
+    );
+    const payload = JSON.parse(response.end.mock.calls[0][0]);
+    expect(payload.error).toContain(`Invalid request body: ${expectedPath}`);
+  });
+});

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -1,7 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { type ModelMessage, streamText } from "ai";
+import { streamText } from "ai";
 import type { PreviewServer, ViteDevServer } from "vite";
+import { z } from "zod";
 import {
   listOpenAiCompatibleModels,
   selectRandomModel,
@@ -15,19 +16,19 @@ import {
   safeWriteResponse,
 } from "./utils/streamUtils";
 
-/**
- * Request body interface for chat completion
- */
-interface ChatCompletionRequestBody {
-  /** Array of chat messages */
-  messages: ModelMessage[];
-  /** Sampling temperature */
-  temperature?: number;
-  /** Top-p sampling parameter */
-  top_p?: number;
-  /** Maximum tokens to generate */
-  max_tokens?: number;
-}
+const chatCompletionRequestSchema = z.object({
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["system", "user", "assistant"]),
+        content: z.string(),
+      }),
+    )
+    .min(1),
+  temperature: z.number().optional(),
+  top_p: z.number().optional(),
+  max_tokens: z.number().optional(),
+});
 
 /**
  * Chat completion chunk for streaming responses
@@ -170,18 +171,8 @@ export function internalApiEndpointServerHook<
       );
       if (!shouldContinue) return;
 
-      if (
-        !process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL ||
-        !process.env.INTERNAL_OPENAI_COMPATIBLE_API_KEY
-      ) {
-        sendJsonError(response, 500, {
-          error: "OpenAI API configuration is missing",
-        });
-        return;
-      }
-
       try {
-        let requestBody: ChatCompletionRequestBody;
+        let rawRequestBody: unknown;
         try {
           const maxBodyBytes = 1024 * 1024;
           const chunks: Buffer[] = [];
@@ -205,15 +196,29 @@ export function internalApiEndpointServerHook<
             }
             chunks.push(buf);
           }
-          requestBody = JSON.parse(Buffer.concat(chunks).toString());
+          rawRequestBody = JSON.parse(Buffer.concat(chunks).toString());
         } catch (_error) {
           sendJsonError(response, 400, { error: "Invalid request body" });
           return;
         }
 
-        if (!Array.isArray(requestBody.messages)) {
+        const parsedRequestBody =
+          chatCompletionRequestSchema.safeParse(rawRequestBody);
+        if (!parsedRequestBody.success) {
+          const issue = parsedRequestBody.error.issues[0];
           sendJsonError(response, 400, {
-            error: "Invalid request body: messages is required",
+            error: `Invalid request body: ${issue.path.join(".") || "body"} ${issue.message}`,
+          });
+          return;
+        }
+        const requestBody = parsedRequestBody.data;
+
+        if (
+          !process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL ||
+          !process.env.INTERNAL_OPENAI_COMPATIBLE_API_KEY
+        ) {
+          sendJsonError(response, 500, {
+            error: "OpenAI API configuration is missing",
           });
           return;
         }

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -100,6 +100,26 @@ describe("searchEndpointServerHook", () => {
     expect(fetchSearXNG).not.toHaveBeenCalled();
   });
 
+  it("responds 400 when the query parameter exceeds the maximum length", async () => {
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+    const query = "a".repeat(2001);
+
+    await handler(
+      createRequest(`/search/text?q=${query}&token=abc`),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "Query parameter must not exceed 2000 characters",
+      }),
+    );
+    expect(fetchSearXNG).not.toHaveBeenCalled();
+  });
+
   it("stops processing when token verification fails", async () => {
     vi.mocked(handleTokenVerification).mockResolvedValue({
       shouldContinue: false,
@@ -137,6 +157,19 @@ describe("searchEndpointServerHook", () => {
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify([["Title", "Snippet", "https://example.com"]]),
     );
+  });
+
+  it("clamps the requested result limit to the server maximum", async () => {
+    vi.mocked(fetchSearXNG).mockResolvedValue([]);
+    const handler = getRegisteredHandler();
+
+    await handler(
+      createRequest("/search/text?q=cats&token=abc&limit=1000"),
+      createResponse(),
+      vi.fn(),
+    );
+
+    expect(fetchSearXNG).toHaveBeenCalledWith("cats", "text", 30);
   });
 
   it("reranks results when the reranker is healthy and returns its reordered output", async () => {

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -1,4 +1,5 @@
 import type { PreviewServer, ViteDevServer } from "vite";
+import { z } from "zod";
 import { handleTokenVerification } from "./handleTokenVerification";
 import { rankSearchResults } from "./rankSearchResults";
 import { getRerankerStatus } from "./rerankerService";
@@ -9,6 +10,26 @@ import {
 import { fetchSearXNG } from "./webSearchService";
 
 const THUMBNAIL_TIMEOUT_MS = 1000;
+const DEFAULT_SEARCH_LIMIT = 30;
+const MAX_SEARCH_LIMIT = 30;
+const MAX_QUERY_LENGTH = 2000;
+
+const searchParamsSchema = z.object({
+  query: z
+    .string({ error: "Missing query parameter" })
+    .trim()
+    .min(1, "Missing query parameter")
+    .max(
+      MAX_QUERY_LENGTH,
+      `Query parameter must not exceed ${MAX_QUERY_LENGTH} characters`,
+    ),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .catch(DEFAULT_SEARCH_LIMIT)
+    .transform((limit) => Math.min(limit, MAX_SEARCH_LIMIT)),
+});
 
 type TextResult = [title: string, content: string, url: string];
 type ImageResult = [
@@ -80,17 +101,22 @@ export function searchEndpointServerHook<
     if (!request.url?.startsWith("/search/")) return next();
 
     const url = new URL(request.url, `http://${request.headers.host}`);
-    const query = url.searchParams.get("q");
     const token = url.searchParams.get("token");
-    const limit = Number(url.searchParams.get("limit")) || 30;
+    const parsedParams = searchParamsSchema.safeParse({
+      query: url.searchParams.get("q") ?? undefined,
+      limit: url.searchParams.get("limit") ?? DEFAULT_SEARCH_LIMIT,
+    });
 
-    if (!query) {
+    if (!parsedParams.success) {
       response.statusCode = 400;
       response.setHeader("Content-Type", "application/json");
-      response.end(JSON.stringify({ error: "Missing query parameter" }));
+      response.end(
+        JSON.stringify({ error: parsedParams.error.issues[0].message }),
+      );
       return;
     }
 
+    const { query, limit } = parsedParams.data;
     const { shouldContinue } = await handleTokenVerification(
       token,
       response,


### PR DESCRIPTION
## Summary
- validate and trim search queries, rejecting requests over the existing 2,000-character client limit
- clamp search result limits to 30 while preserving the current default for invalid values
- validate inference message roles and content before provider setup
- add endpoint regression tests for oversized queries, excessive limits, and malformed messages

## Testing
- npm test -- server/searchEndpointServerHook.test.ts server/internalApiEndpointServerHook.test.ts
- npx biome check server/searchEndpointServerHook.ts server/searchEndpointServerHook.test.ts server/internalApiEndpointServerHook.ts server/internalApiEndpointServerHook.test.ts
- npx tsc -p tsconfig.node.json --noEmit

Closes #2187