### PR TITLE
fix: add .ts extensions to all relative imports for Vite native config loader compatibility

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/server/configEndpointServerHook.ts
+++ b/server/configEndpointServerHook.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_INTERNAL_API_NAME,
   DEFAULT_WLLAMA_MODEL_ID,
   type ServerConfig,
-} from "../shared/serverConfig";
+} from "../shared/serverConfig.ts";
 
 /**
  * Vite server hook that serves runtime server config at /api/config.

--- a/server/handleTokenVerification.ts
+++ b/server/handleTokenVerification.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { verifyTokenAndRateLimit } from "./verifyTokenAndRateLimit";
+import { verifyTokenAndRateLimit } from "./verifyTokenAndRateLimit.ts";
 
 /** Handles token verification and sends appropriate error responses if needed. */
 export async function handleTokenVerification(

--- a/server/http-compression.d.ts
+++ b/server/http-compression.d.ts
@@ -1,5 +1,5 @@
 declare module "http-compression" {
-  import { IncomingMessage, ServerResponse } from "http";
+  import { IncomingMessage, ServerResponse } from "node:http";
 
   interface Options {
     gzip?: {

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -6,15 +6,15 @@ import { z } from "zod";
 import {
   listOpenAiCompatibleModels,
   selectRandomModel,
-} from "../shared/openaiModels";
-import { getModelConfig } from "./config/modelConfig";
-import { handleTokenVerification } from "./handleTokenVerification";
+} from "../shared/openaiModels.ts";
+import { getModelConfig } from "./config/modelConfig.ts";
+import { handleTokenVerification } from "./handleTokenVerification.ts";
 import {
   calculateBackoffTime,
   isResponseWritable,
   safeEndResponse,
   safeWriteResponse,
-} from "./utils/streamUtils";
+} from "./utils/streamUtils.ts";
 
 const chatCompletionRequestSchema = z.object({
   messages: z

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -1,4 +1,4 @@
-import { rerank } from "./rerankerService";
+import { rerank } from "./rerankerService.ts";
 
 export async function rankSearchResults(
   query: string,

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { Tokenizer } from "@huggingface/tokenizers";
 import debug from "debug";
 import { InferenceSession, Tensor } from "onnxruntime-node";
-import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository";
+import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository.ts";
 
 const fileName = path.basename(import.meta.url);
 const printMessage = debug(fileName);

--- a/server/rerankerServiceHook.ts
+++ b/server/rerankerServiceHook.ts
@@ -1,6 +1,9 @@
 import type { PreviewServer, ViteDevServer } from "vite";
-import { startRerankerService, stopRerankerService } from "./rerankerService";
-import { startWebSearchService } from "./webSearchService";
+import {
+  startRerankerService,
+  stopRerankerService,
+} from "./rerankerService.ts";
+import { startWebSearchService } from "./webSearchService.ts";
 
 export async function rerankerServiceHook<
   T extends ViteDevServer | PreviewServer,

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -1,13 +1,13 @@
 import type { PreviewServer, ViteDevServer } from "vite";
 import { z } from "zod";
-import { handleTokenVerification } from "./handleTokenVerification";
-import { rankSearchResults } from "./rankSearchResults";
-import { getRerankerStatus } from "./rerankerService";
+import { handleTokenVerification } from "./handleTokenVerification.ts";
+import { rankSearchResults } from "./rankSearchResults.ts";
+import { getRerankerStatus } from "./rerankerService.ts";
 import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
-} from "./searchesSinceLastRestart";
-import { fetchSearXNG } from "./webSearchService";
+} from "./searchesSinceLastRestart.ts";
+import { fetchSearXNG } from "./webSearchService.ts";
 
 const THUMBNAIL_TIMEOUT_MS = 1000;
 const DEFAULT_SEARCH_LIMIT = 30;

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -1,12 +1,12 @@
 import prettyMilliseconds from "pretty-ms";
 import type { PreviewServer, ViteDevServer } from "vite";
-import { getRerankerStatus } from "./rerankerService";
+import { getRerankerStatus } from "./rerankerService.ts";
 import {
   getGraphicalSearchesSinceLastRestart,
   getTextualSearchesSinceLastRestart,
-} from "./searchesSinceLastRestart";
-import { getVerifiedTokensAmount } from "./verifiedTokens";
-import { getWebSearchStatus } from "./webSearchService";
+} from "./searchesSinceLastRestart.ts";
+import { getVerifiedTokensAmount } from "./verifiedTokens.ts";
+import { getWebSearchStatus } from "./webSearchService.ts";
 
 /**
  * Server start time for uptime calculation

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -2,8 +2,8 @@ import type { IncomingMessage } from "node:http";
 import { isIP } from "node:net";
 import { argon2Verify } from "hash-wasm";
 import { RateLimiterMemory } from "rate-limiter-flexible";
-import { getSearchToken } from "./searchToken";
-import { addVerifiedToken, isVerifiedToken } from "./verifiedTokens";
+import { getSearchToken } from "./searchToken.ts";
+import { addVerifiedToken, isVerifiedToken } from "./verifiedTokens.ts";
 
 const rateLimiter = new RateLimiterMemory({
   points: 10,

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -2,7 +2,7 @@ import { basename } from "node:path";
 import debug from "debug";
 import { convert as convertHtmlToPlainText } from "html-to-text";
 import { strip as stripEmojis } from "node-emoji";
-import { CircuitBreaker } from "./utils/circuitBreaker";
+import { CircuitBreaker } from "./utils/circuitBreaker.ts";
 
 const fileName = basename(import.meta.url);
 const printMessage = debug(fileName);

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,6 +5,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true,
     "strict": true
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,16 +6,16 @@ import dotenv from "dotenv";
 import getGitCommitHash from "helper-git-hash";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
-import { cacheServerHook } from "./server/cacheServerHook";
-import { compressionServerHook } from "./server/compressionServerHook";
-import { configEndpointServerHook } from "./server/configEndpointServerHook";
-import { crossOriginServerHook } from "./server/crossOriginServerHook";
-import { internalApiEndpointServerHook } from "./server/internalApiEndpointServerHook";
-import { rerankerServiceHook } from "./server/rerankerServiceHook";
-import { searchEndpointServerHook } from "./server/searchEndpointServerHook";
-import { getSearchToken, regenerateSearchToken } from "./server/searchToken";
-import { statusEndpointServerHook } from "./server/statusEndpointServerHook";
-import { validateAccessKeyServerHook } from "./server/validateAccessKeyServerHook";
+import { cacheServerHook } from "./server/cacheServerHook.ts";
+import { compressionServerHook } from "./server/compressionServerHook.ts";
+import { configEndpointServerHook } from "./server/configEndpointServerHook.ts";
+import { crossOriginServerHook } from "./server/crossOriginServerHook.ts";
+import { internalApiEndpointServerHook } from "./server/internalApiEndpointServerHook.ts";
+import { rerankerServiceHook } from "./server/rerankerServiceHook.ts";
+import { searchEndpointServerHook } from "./server/searchEndpointServerHook.ts";
+import { getSearchToken, regenerateSearchToken } from "./server/searchToken.ts";
+import { statusEndpointServerHook } from "./server/statusEndpointServerHook.ts";
+import { validateAccessKeyServerHook } from "./server/validateAccessKeyServerHook.ts";
 
 dotenv.config({ path: [".env", ".env.example"], quiet: true });
 


### PR DESCRIPTION
## Root Cause

Vite's upcoming native config loader (planned default in next major) requires explicit file extensions on all relative imports. The server codebase was using extensionless imports, triggering warnings during docker compose up.

## Changes

Added `.ts` extensions to all relative imports across 11 files:

| File | Imports Fixed |
|------|---------------|
| `vite.config.ts` | 10 server hook imports |
| `server/internalApiEndpointServerHook.ts` | 3 imports |
| `server/configEndpointServerHook.ts` | 1 import |
| `server/searchEndpointServerHook.ts` | 5 imports |
| `server/statusEndpointServerHook.ts` | 4 imports |
| `server/rerankerServiceHook.ts` | 2 imports |
| `server/rerankerService.ts` | 1 import |
| `server/webSearchService.ts` | 1 import |
| `server/rankSearchResults.ts` | 1 import |
| `server/handleTokenVerification.ts` | 1 import |
| `server/verifyTokenAndRateLimit.ts` | 2 imports |

## Verification

Ran `docker compose up` and confirmed no import extension warnings in logs. Server starts cleanly.