### PR TITLE
Improve Docker health check timing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN git config --global --add safe.directory ${APP_DIR} 2>/dev/null || true; \
   echo "WARNING: no usable git repository in the build context, so the app will report an empty commit hash."; \
   npm run build
 
-HEALTHCHECK --interval=5m CMD curl -f http://localhost:7860/status || exit 1
+HEALTHCHECK --start-period=60s --interval=30s --timeout=10s --retries=3 CMD curl -fsS http://localhost:${PORT}/status || exit 1
 
 ENTRYPOINT [ "/bin/sh", "-c" ]
 


### PR DESCRIPTION
## Description

Adds an explicit startup grace period, timeout, retry count, and faster polling interval to the production container health check. The probe now uses the configured `PORT` value and suppresses output on success while showing errors on failure.

Fixes #2183

## How to test
1. Run `docker build --check .`.
2. Build and start the production image and observe the `/status` health probe.