### PR TITLE
chore: remove dead architectural rule

### DIFF
--- a/scripts/architectural-linter.cjs
+++ b/scripts/architectural-linter.cjs
@@ -9,13 +9,6 @@ const EXTERNAL_API_ALLOWLIST = [
 ];
 
 const VIOLATIONS = {
-  COMPONENT_NOT_SELF_CONTAINED: {
-    message: "Component should be self-contained in its own folder",
-    remediation:
-      "Move component to its own folder with related styles, hooks, and utilities. See docs/project-structure.md for guidelines.",
-    severity: "error",
-  },
-
   CONTEXT_PROVIDER_NESTING: {
     message: "Avoid nested Context providers - use create-pubsub instead",
     remediation:


### PR DESCRIPTION
## Description

Remove the unused `COMPONENT_NOT_SELF_CONTAINED` violation definition. `checkViolations()` never emits this rule, so keeping the configuration suggested enforcement that did not exist.

Fixes #2171

## Type of Change
- [x] Other (chore)

## How to test
1. Run `node scripts/architectural-linter.cjs`.
2. Run `npm run lint`.

## Checklist
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

## Security, performance, or breaking changes

None.
