### PR TITLE
ci: enforce coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: npm run format:check
 
       - name: Run tests
-        run: npm test
+        run: npm run test:coverage


### PR DESCRIPTION
## Description

Run the existing coverage command in CI so the line and function thresholds in `vitest.config.ts` are enforced instead of being informational only.

Fixes #2189

## Type of Change
- [x] Other (CI)

## How to test
1. Run `TZ=UTC npm run test:coverage`.
2. Confirm the 31% line and 24% function thresholds pass.

## Checklist
- [x] `npm run format:check` passes
- [x] Tests pass (`TZ=UTC npm run test:coverage`)

## Security, performance, or breaking changes

None.
