### PR TITLE
Refactor inference dispatch and handleSend for testability (#2131)

### DIFF
--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -8,12 +8,8 @@ import {
   useState,
 } from "react";
 import throttle from "throttleit";
+import { persistChatMessages, runFollowUpSearch } from "@/modules/chatHelpers";
 import { generateFollowUpQuestion } from "@/modules/followUpQuestions";
-import {
-  getCurrentSearchRunId,
-  saveChatMessageForQuery,
-  updateSearchResults,
-} from "@/modules/history";
 import { handleEnterKeyDown } from "@/modules/keyboard";
 import { addLogEntry } from "@/modules/logEntries";
 import { showAiCompleteNotification } from "@/modules/notifications";
@@ -26,14 +22,8 @@ import {
   settingsPubSub,
   suppressNextFollowUpPubSub,
   textSearchResultsPubSub,
-  updateImageSearchResults,
-  updateLlmTextSearchResults,
-  updateTextSearchResults,
 } from "@/modules/pubSub";
-import { generateRelatedSearchQuery } from "@/modules/relatedSearchQuery";
-import { searchImages, searchText } from "@/modules/search";
 import { generateChatResponse } from "@/modules/textGeneration";
-import { searchResultsToConsider } from "@/modules/textGenerationUtilities";
 import type { ChatMessage } from "@/modules/types";
 import ChatHeader from "./ChatHeader";
 import ChatInputArea from "./ChatInputArea";
@@ -279,84 +269,13 @@ export default function ChatInterface({
       setStreamedResponse("");
 
       try {
-        const relatedQuery = await generateRelatedSearchQuery([...newMessages]);
-        const searchQuery = relatedQuery || currentInput;
-
-        if (settings.enableTextSearch) {
-          const freshResults = await searchText(
-            searchQuery,
-            settings.searchResultsLimit,
-          );
-
-          if (freshResults.length > 0) {
-            const existingUrls = new Set(
-              textSearchResults.map(([, , url]) => url),
-            );
-
-            const uniqueFreshResults = freshResults.filter(
-              ([, , url]) => !existingUrls.has(url),
-            );
-
-            updateLlmTextSearchResults(
-              freshResults.slice(0, searchResultsToConsider),
-            );
-
-            if (uniqueFreshResults.length > 0) {
-              const updatedResults = [
-                ...textSearchResults,
-                ...uniqueFreshResults,
-              ];
-              updateTextSearchResults(updatedResults);
-
-              updateSearchResults(getCurrentSearchRunId(), {
-                type: "text",
-                items: updatedResults.map(([title, snippet, url]) => ({
-                  title,
-                  url,
-                  snippet,
-                })),
-              });
-            }
-          }
-        }
-
-        if (settings.enableImageSearch) {
-          searchImages(searchQuery, settings.searchResultsLimit)
-            .then((imageResults) => {
-              if (imageResults.length > 0) {
-                const existingUrls = new Set(
-                  imageSearchResults.map(([, url]) => url),
-                );
-
-                const uniqueFreshResults = imageResults.filter(
-                  ([, url]) => !existingUrls.has(url),
-                );
-
-                if (uniqueFreshResults.length > 0) {
-                  const updatedImageResults = [
-                    ...uniqueFreshResults,
-                    ...imageSearchResults,
-                  ];
-                  updateImageSearchResults(updatedImageResults);
-
-                  updateSearchResults(getCurrentSearchRunId(), {
-                    type: "image",
-                    items: updatedImageResults.map(
-                      ([title, url, thumbnailUrl, sourceUrl]) => ({
-                        title,
-                        url,
-                        thumbnail: thumbnailUrl,
-                        sourceUrl,
-                      }),
-                    ),
-                  });
-                }
-              }
-            })
-            .catch((error) => {
-              addLogEntry(`Error in follow-up image search: ${error}`);
-            });
-        }
+        await runFollowUpSearch(
+          newMessages,
+          currentInput,
+          settings,
+          textSearchResults,
+          imageSearchResults,
+        );
       } catch (error) {
         addLogEntry(`Error in follow-up search: ${error}`);
       }
@@ -378,8 +297,7 @@ export default function ChatInterface({
           showAiCompleteNotification(currentInput);
         }
 
-        await saveChatMessageForQuery(currentQuery, "user", currentInput);
-        await saveChatMessageForQuery(currentQuery, "assistant", finalResponse);
+        await persistChatMessages(currentQuery, currentInput, finalResponse);
 
         await regenerateFollowUpQuestion(currentInput, finalResponse);
       } catch (error) {

--- a/client/modules/chatHelpers.test.ts
+++ b/client/modules/chatHelpers.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => vi.clearAllMocks());
+
+vi.mock("./search", () => ({
+  searchText: vi.fn(),
+  searchImages: vi.fn(),
+}));
+vi.mock("./history", () => ({
+  getCurrentSearchRunId: vi.fn(() => "run-1"),
+  saveChatMessageForQuery: vi.fn(() => Promise.resolve()),
+  updateSearchResults: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("./pubSub", () => ({
+  updateImageSearchResults: vi.fn(),
+  updateLlmTextSearchResults: vi.fn(),
+  updateTextSearchResults: vi.fn(),
+}));
+vi.mock("./relatedSearchQuery", () => ({
+  generateRelatedSearchQuery: vi.fn(() => Promise.resolve("")),
+}));
+vi.mock("./logEntries", () => ({
+  addLogEntry: vi.fn(),
+}));
+vi.mock("./textGenerationUtilities", () => ({
+  searchResultsToConsider: 6,
+}));
+
+import {
+  persistChatMessages,
+  refreshImageSearchResults,
+  refreshTextSearchResults,
+  runFollowUpSearch,
+} from "./chatHelpers";
+import { saveChatMessageForQuery } from "./history";
+import { updateImageSearchResults, updateTextSearchResults } from "./pubSub";
+import { searchImages, searchText } from "./search";
+import type { ImageSearchResults, TextSearchResults } from "./types";
+
+const mockSearchText = vi.mocked(searchText);
+const mockSearchImages = vi.mocked(searchImages);
+const mockSaveChat = vi.mocked(saveChatMessageForQuery);
+const mockUpdateText = vi.mocked(updateTextSearchResults);
+const mockUpdateImage = vi.mocked(updateImageSearchResults);
+
+describe("refreshTextSearchResults", () => {
+  it("deduplicates by URL and appends fresh results", async () => {
+    const existing: TextSearchResults = [
+      ["Existing", "snippet", "https://existing.com"],
+    ];
+    const fresh: TextSearchResults = [
+      ["New", "snippet", "https://new.com"],
+      ["Duplicate", "snippet", "https://existing.com"],
+    ];
+
+    mockSearchText.mockResolvedValueOnce(fresh);
+
+    await refreshTextSearchResults("query", 10, existing);
+
+    expect(mockUpdateText).toHaveBeenCalledWith([
+      ["Existing", "snippet", "https://existing.com"],
+      ["New", "snippet", "https://new.com"],
+    ]);
+  });
+
+  it("skips updates when all fresh results are duplicates", async () => {
+    const existing: TextSearchResults = [
+      ["Title", "snippet", "https://dup.com"],
+    ];
+    const fresh: TextSearchResults = [["Title", "snippet", "https://dup.com"]];
+
+    mockSearchText.mockResolvedValueOnce(fresh);
+
+    await refreshTextSearchResults("query", 10, existing);
+
+    expect(mockUpdateText).not.toHaveBeenCalled();
+  });
+
+  it("skips updates when there are no fresh results", async () => {
+    mockSearchText.mockResolvedValueOnce([]);
+
+    await refreshTextSearchResults("query", 10, []);
+
+    expect(mockUpdateText).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshImageSearchResults", () => {
+  it("deduplicates by URL and prepends fresh results", async () => {
+    const existing: ImageSearchResults = [
+      ["Existing", "https://existing.com", "thumb", "source"],
+    ];
+    const fresh: ImageSearchResults = [
+      ["New", "https://new.com", "thumb", "source"],
+      ["Duplicate", "https://existing.com", "thumb", "source"],
+    ];
+
+    mockSearchImages.mockResolvedValueOnce(fresh);
+
+    await refreshImageSearchResults("query", 10, existing);
+
+    expect(mockUpdateImage).toHaveBeenCalledWith([
+      ["New", "https://new.com", "thumb", "source"],
+      ["Existing", "https://existing.com", "thumb", "source"],
+    ]);
+  });
+
+  it("skips updates when there are no fresh results", async () => {
+    mockSearchImages.mockResolvedValueOnce([]);
+
+    await refreshImageSearchResults("query", 10, []);
+
+    expect(mockUpdateImage).not.toHaveBeenCalled();
+  });
+});
+
+describe("persistChatMessages", () => {
+  it("saves user and assistant messages", async () => {
+    await persistChatMessages("my query", "user msg", "assistant msg");
+
+    expect(mockSaveChat).toHaveBeenCalledWith("my query", "user", "user msg");
+    expect(mockSaveChat).toHaveBeenCalledWith(
+      "my query",
+      "assistant",
+      "assistant msg",
+    );
+  });
+});
+
+describe("runFollowUpSearch", () => {
+  const makeSettings = (overrides = {}) =>
+    ({
+      enableTextSearch: true,
+      enableImageSearch: true,
+      searchResultsLimit: 10,
+      ...overrides,
+    }) as unknown as Parameters<typeof runFollowUpSearch>[2];
+
+  it("refreshes text results when enabled", async () => {
+    mockSearchText.mockResolvedValueOnce([
+      ["Title", "snippet", "https://new.com"],
+    ]);
+
+    await runFollowUpSearch(
+      [{ role: "user", content: "hello" }],
+      "hello",
+      makeSettings(),
+      [],
+      [],
+    );
+
+    expect(mockSearchText).toHaveBeenCalled();
+  });
+
+  it("skips text search when disabled", async () => {
+    await runFollowUpSearch(
+      [{ role: "user", content: "hello" }],
+      "hello",
+      makeSettings({ enableTextSearch: false }),
+      [],
+      [],
+    );
+
+    expect(mockSearchText).not.toHaveBeenCalled();
+  });
+
+  it("skips image search when disabled", async () => {
+    await runFollowUpSearch(
+      [{ role: "user", content: "hello" }],
+      "hello",
+      makeSettings({ enableImageSearch: false }),
+      [],
+      [],
+    );
+
+    expect(mockSearchImages).not.toHaveBeenCalled();
+  });
+});

--- a/client/modules/chatHelpers.ts
+++ b/client/modules/chatHelpers.ts
@@ -13,6 +13,7 @@ import {
 } from "./pubSub";
 import { searchImages, searchText } from "./search";
 import type { defaultSettings } from "./settings";
+import { searchResultsToConsider } from "./textGenerationUtilities";
 import type {
   ChatMessage,
   ImageSearchResults,
@@ -20,8 +21,6 @@ import type {
 } from "./types";
 
 type Settings = typeof defaultSettings;
-
-const searchResultsToConsider = 10;
 
 /**
  * Fetches fresh text search results and merges them into existing results,
@@ -115,7 +114,6 @@ export async function persistChatMessages(
 /**
  * Runs the follow-up search phase: generates a related search query from chat
  * history, then refreshes text and image results with deduplication.
- * Returns the search query to use (related query or original input).
  */
 export async function runFollowUpSearch(
   messages: ChatMessage[],
@@ -123,7 +121,7 @@ export async function runFollowUpSearch(
   settings: Settings,
   existingTextResults: TextSearchResults,
   existingImageResults: ImageSearchResults,
-): Promise<string> {
+): Promise<void> {
   const { generateRelatedSearchQuery } = await import("./relatedSearchQuery");
   const relatedQuery = await generateRelatedSearchQuery([...messages]);
   const searchQuery = relatedQuery || currentInput;
@@ -149,6 +147,4 @@ export async function runFollowUpSearch(
       addLogEntry(`Error in follow-up image search: ${error}`);
     });
   }
-
-  return searchQuery;
 }

--- a/client/modules/chatHelpers.ts
+++ b/client/modules/chatHelpers.ts
@@ -1,0 +1,154 @@
+import {
+  getCurrentSearchRunId,
+  type ImageResults,
+  saveChatMessageForQuery,
+  type TextResults,
+  updateSearchResults,
+} from "./history";
+import { addLogEntry } from "./logEntries";
+import {
+  updateImageSearchResults,
+  updateLlmTextSearchResults,
+  updateTextSearchResults,
+} from "./pubSub";
+import { searchImages, searchText } from "./search";
+import type { defaultSettings } from "./settings";
+import type {
+  ChatMessage,
+  ImageSearchResults,
+  TextSearchResults,
+} from "./types";
+
+type Settings = typeof defaultSettings;
+
+const searchResultsToConsider = 10;
+
+/**
+ * Fetches fresh text search results and merges them into existing results,
+ * deduplicating by URL. Updates pubSub state for both LLM-visible and UI results.
+ */
+export async function refreshTextSearchResults(
+  searchQuery: string,
+  resultsLimit: number,
+  existingResults: TextSearchResults,
+): Promise<void> {
+  const freshResults = await searchText(searchQuery, resultsLimit);
+
+  if (freshResults.length === 0) return;
+
+  updateLlmTextSearchResults(freshResults.slice(0, searchResultsToConsider));
+
+  const existingUrls = new Set(existingResults.map(([, , url]) => url));
+  const uniqueFreshResults = freshResults.filter(
+    ([, , url]) => !existingUrls.has(url),
+  );
+
+  if (uniqueFreshResults.length > 0) {
+    const updatedResults: TextSearchResults = [
+      ...existingResults,
+      ...uniqueFreshResults,
+    ];
+    updateTextSearchResults(updatedResults);
+
+    updateSearchResults(getCurrentSearchRunId(), {
+      type: "text",
+      items: updatedResults.map(([title, snippet, url]) => ({
+        title,
+        url,
+        snippet,
+      })),
+    } satisfies TextResults);
+  }
+}
+
+/**
+ * Fetches fresh image search results and merges them into existing results,
+ * deduplicating by URL. Fire-and-forget (returns Promise, caller catches errors).
+ */
+export async function refreshImageSearchResults(
+  searchQuery: string,
+  resultsLimit: number,
+  existingResults: ImageSearchResults,
+): Promise<void> {
+  const imageResults = await searchImages(searchQuery, resultsLimit);
+
+  if (imageResults.length === 0) return;
+
+  const existingUrls = new Set(existingResults.map(([, url]) => url));
+  const uniqueFreshResults = imageResults.filter(
+    ([, url]) => !existingUrls.has(url),
+  );
+
+  if (uniqueFreshResults.length > 0) {
+    const updatedImageResults: ImageSearchResults = [
+      ...uniqueFreshResults,
+      ...existingResults,
+    ];
+    updateImageSearchResults(updatedImageResults);
+
+    updateSearchResults(getCurrentSearchRunId(), {
+      type: "image",
+      items: updatedImageResults.map(
+        ([title, url, thumbnailUrl, sourceUrl]) => ({
+          title,
+          url,
+          thumbnail: thumbnailUrl,
+          sourceUrl,
+        }),
+      ),
+    } satisfies ImageResults);
+  }
+}
+
+/**
+ * Saves a user message and its assistant response to chat history.
+ */
+export async function persistChatMessages(
+  query: string,
+  userMessage: string,
+  assistantMessage: string,
+): Promise<void> {
+  await saveChatMessageForQuery(query, "user", userMessage);
+  await saveChatMessageForQuery(query, "assistant", assistantMessage);
+}
+
+/**
+ * Runs the follow-up search phase: generates a related search query from chat
+ * history, then refreshes text and image results with deduplication.
+ * Returns the search query to use (related query or original input).
+ */
+export async function runFollowUpSearch(
+  messages: ChatMessage[],
+  currentInput: string,
+  settings: Settings,
+  existingTextResults: TextSearchResults,
+  existingImageResults: ImageSearchResults,
+): Promise<string> {
+  const { generateRelatedSearchQuery } = await import("./relatedSearchQuery");
+  const relatedQuery = await generateRelatedSearchQuery([...messages]);
+  const searchQuery = relatedQuery || currentInput;
+
+  if (settings.enableTextSearch) {
+    try {
+      await refreshTextSearchResults(
+        searchQuery,
+        settings.searchResultsLimit,
+        existingTextResults,
+      );
+    } catch (error) {
+      addLogEntry(`Error in follow-up search: ${error}`);
+    }
+  }
+
+  if (settings.enableImageSearch) {
+    refreshImageSearchResults(
+      searchQuery,
+      settings.searchResultsLimit,
+      existingImageResults,
+    ).catch((error) => {
+      addLogEntry(`Error in follow-up image search: ${error}`);
+    });
+  }
+
+  return searchQuery;
+}

--- a/client/modules/textGeneration.inference.test.ts
+++ b/client/modules/textGeneration.inference.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./pubSub", () => ({
+  getConversationSummary: vi.fn(() => ({ conversationId: "", summary: "" })),
+  getQuery: vi.fn(() => ""),
+  getResponse: vi.fn(() => ""),
+  getSettings: vi.fn(() => ({
+    inferenceType: "browser",
+    enableAiResponse: true,
+    enableTextSearch: true,
+    enableImageSearch: true,
+    searchResultsLimit: 10,
+    allowAiModelDownload: true,
+  })),
+  getTextGenerationState: vi.fn(() => "idle"),
+  listenToSettingsChanges: vi.fn(),
+  updateChatMessages: vi.fn(),
+  updateConversationSummary: vi.fn(),
+  updateImageSearchResults: vi.fn(),
+  updateImageSearchState: vi.fn(),
+  updateLlmTextSearchResults: vi.fn(),
+  updateResponse: vi.fn(),
+  updateSearchPromise: vi.fn(),
+  updateTextGenerationState: vi.fn(),
+  updateTextSearchResults: vi.fn(),
+  updateTextSearchState: vi.fn(),
+}));
+vi.mock("./history", () => ({
+  getCurrentSearchRunId: vi.fn(() => "run-1"),
+  saveLlmResponseForQuery: vi.fn(() => Promise.resolve()),
+  updateSearchResults: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("./logEntries", () => ({ addLogEntry: vi.fn() }));
+vi.mock("./notifications", () => ({ showAiCompleteNotification: vi.fn() }));
+vi.mock("./search", () => ({
+  searchImages: vi.fn(() => Promise.resolve([])),
+  searchText: vi.fn(() => Promise.resolve([])),
+}));
+vi.mock("./systemPrompt", () => ({ getSystemPrompt: vi.fn(() => "") }));
+vi.mock("./textGenerationUtilities", () => ({
+  ChatGenerationError: class ChatGenerationError extends Error {},
+  defaultContextSize: 4096,
+  getFormattedSearchResults: vi.fn(() => ""),
+  searchResultsToConsider: 6,
+}));
+vi.mock("gpt-tokenizer", () => ({
+  default: { encode: vi.fn(() => [1, 2, 3]) },
+}));
+vi.mock("pretty-ms", () => ({
+  default: vi.fn(() => "100ms"),
+}));
+
+import { getSettings } from "./pubSub";
+import { textGenerationFunctions } from "./textGeneration";
+
+const mockGetSettings = vi.mocked(getSettings);
+
+describe("needsModelDownloadGate", () => {
+  it("returns true for 'browser' inference type", () => {
+    mockGetSettings.mockReturnValueOnce({
+      inferenceType: "browser",
+    } as never);
+
+    expect(textGenerationFunctions.needsModelDownloadGate()).toBe(true);
+  });
+
+  it("returns false for 'openai' inference type", () => {
+    mockGetSettings.mockReturnValueOnce({
+      inferenceType: "openai",
+    } as never);
+
+    expect(textGenerationFunctions.needsModelDownloadGate()).toBe(false);
+  });
+
+  it("returns false for 'horde' inference type", () => {
+    mockGetSettings.mockReturnValueOnce({
+      inferenceType: "horde",
+    } as never);
+
+    expect(textGenerationFunctions.needsModelDownloadGate()).toBe(false);
+  });
+
+  it("returns false for 'internal' inference type", () => {
+    mockGetSettings.mockReturnValueOnce({
+      inferenceType: "internal",
+    } as never);
+
+    expect(textGenerationFunctions.needsModelDownloadGate()).toBe(false);
+  });
+
+  it("returns true for unknown inference type (falls back to browser)", () => {
+    mockGetSettings.mockReturnValueOnce({
+      inferenceType: "unknown-legacy-type",
+    } as never);
+
+    expect(textGenerationFunctions.needsModelDownloadGate()).toBe(true);
+  });
+});

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -49,12 +49,14 @@ type InferenceStrategy = {
   ) => Promise<string>;
 };
 
-// Lazily-loaded strategy map keyed by inference type.
-// Each entry is a Promise that resolves to the strategy object.
-const getInferenceStrategies = () => {
-  const strategies: Record<string, Promise<InferenceStrategy>> = {};
+type InferenceType = "openai" | "internal" | "horde" | "browser";
 
-  strategies.openai = (async () => {
+// Lazy thunks — only the selected backend is loaded.
+const inferenceStrategyLoaders: Record<
+  InferenceType,
+  () => Promise<InferenceStrategy>
+> = {
+  openai: async () => {
     const { generateTextWithOpenAi, generateChatWithOpenAi } = await import(
       "./textGenerationWithOpenAi"
     );
@@ -62,16 +64,16 @@ const getInferenceStrategies = () => {
       generateText: generateTextWithOpenAi,
       generateChat: generateChatWithOpenAi,
     };
-  })();
-  strategies.internal = (async () => {
+  },
+  internal: async () => {
     const { generateTextWithInternalApi, generateChatWithInternalApi } =
       await import("./textGenerationWithInternalApi");
     return {
       generateText: generateTextWithInternalApi,
       generateChat: generateChatWithInternalApi,
     };
-  })();
-  strategies.horde = (async () => {
+  },
+  horde: async () => {
     const { generateTextWithHorde, generateChatWithHorde } = await import(
       "./textGenerationWithHorde"
     );
@@ -79,8 +81,8 @@ const getInferenceStrategies = () => {
       generateText: generateTextWithHorde,
       generateChat: generateChatWithHorde,
     };
-  })();
-  strategies.browser = (async () => {
+  },
+  browser: async () => {
     const { generateTextWithWllama, generateChatWithWllama } = await import(
       "./textGenerationWithWllama"
     );
@@ -88,16 +90,24 @@ const getInferenceStrategies = () => {
       generateText: generateTextWithWllama,
       generateChat: generateChatWithWllama,
     };
-  })();
-
-  return strategies;
+  },
 };
 
 /** Returns the resolved strategy for the current inference type. */
 async function getCurrentInferenceStrategy(): Promise<InferenceStrategy> {
-  const strategies = getInferenceStrategies();
-  const type = getSettings().inferenceType;
-  return strategies[type] ?? strategies.browser;
+  const type = getSettings().inferenceType as string;
+  const effective: InferenceType =
+    type in inferenceStrategyLoaders ? (type as InferenceType) : "browser";
+  return inferenceStrategyLoaders[effective]();
+}
+
+/** Returns true when the effective inference type needs the model-download gate. */
+function needsModelDownloadGate(): boolean {
+  const type = getSettings().inferenceType as string;
+  return (
+    (type in inferenceStrategyLoaders ? (type as InferenceType) : "browser") ===
+    "browser"
+  );
 }
 
 function getCurrentModelName(): string {
@@ -232,7 +242,7 @@ export async function searchAndRespond() {
 
   try {
     const settings = getSettings();
-    if (settings.inferenceType === "browser") {
+    if (needsModelDownloadGate()) {
       await canDownloadModels();
       updateTextGenerationState("loadingModel");
     }

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -479,4 +479,5 @@ export const textGenerationFunctions = {
   loadConversationSummary,
   createLlmSummary,
   summarizeDroppedMessages,
+  needsModelDownloadGate,
 };

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -41,6 +41,65 @@ import type {
 
 const SUMMARY_TOKEN_LIMIT = 800;
 
+type InferenceStrategy = {
+  generateText: () => Promise<void>;
+  generateChat: (
+    messages: ChatMessage[],
+    onUpdate: (partialResponse: string) => void,
+  ) => Promise<string>;
+};
+
+// Lazily-loaded strategy map keyed by inference type.
+// Each entry is a Promise that resolves to the strategy object.
+const getInferenceStrategies = () => {
+  const strategies: Record<string, Promise<InferenceStrategy>> = {};
+
+  strategies.openai = (async () => {
+    const { generateTextWithOpenAi, generateChatWithOpenAi } = await import(
+      "./textGenerationWithOpenAi"
+    );
+    return {
+      generateText: generateTextWithOpenAi,
+      generateChat: generateChatWithOpenAi,
+    };
+  })();
+  strategies.internal = (async () => {
+    const { generateTextWithInternalApi, generateChatWithInternalApi } =
+      await import("./textGenerationWithInternalApi");
+    return {
+      generateText: generateTextWithInternalApi,
+      generateChat: generateChatWithInternalApi,
+    };
+  })();
+  strategies.horde = (async () => {
+    const { generateTextWithHorde, generateChatWithHorde } = await import(
+      "./textGenerationWithHorde"
+    );
+    return {
+      generateText: generateTextWithHorde,
+      generateChat: generateChatWithHorde,
+    };
+  })();
+  strategies.browser = (async () => {
+    const { generateTextWithWllama, generateChatWithWllama } = await import(
+      "./textGenerationWithWllama"
+    );
+    return {
+      generateText: generateTextWithWllama,
+      generateChat: generateChatWithWllama,
+    };
+  })();
+
+  return strategies;
+};
+
+/** Returns the resolved strategy for the current inference type. */
+async function getCurrentInferenceStrategy(): Promise<InferenceStrategy> {
+  const strategies = getInferenceStrategies();
+  const type = getSettings().inferenceType;
+  return strategies[type] ?? strategies.browser;
+}
+
 function getCurrentModelName(): string {
   const settings = getSettings();
   switch (settings.inferenceType) {
@@ -93,33 +152,9 @@ async function createLlmSummary(
 
   const chat: ChatMessage[] = [{ role: "user", content: prompt }];
 
-  const settings = getSettings();
   try {
-    if (settings.inferenceType === "openai") {
-      const { generateChatWithOpenAi } = await import(
-        "./textGenerationWithOpenAi"
-      );
-      return (await generateChatWithOpenAi(chat, () => {})).trim();
-    }
-
-    if (settings.inferenceType === "internal") {
-      const { generateChatWithInternalApi } = await import(
-        "./textGenerationWithInternalApi"
-      );
-      return (await generateChatWithInternalApi(chat, () => {})).trim();
-    }
-
-    if (settings.inferenceType === "horde") {
-      const { generateChatWithHorde } = await import(
-        "./textGenerationWithHorde"
-      );
-      return (await generateChatWithHorde(chat, () => {})).trim();
-    }
-
-    const { generateChatWithWllama } = await import(
-      "./textGenerationWithWllama"
-    );
-    return (await generateChatWithWllama(chat, () => {})).trim();
+    const strategy = await getCurrentInferenceStrategy();
+    return (await strategy.generateChat(chat, () => {})).trim();
   } catch (e) {
     addLogEntry(
       `LLM summary failed, falling back to extractive: ${
@@ -197,30 +232,12 @@ export async function searchAndRespond() {
 
   try {
     const settings = getSettings();
-    if (settings.inferenceType === "openai") {
-      const { generateTextWithOpenAi } = await import(
-        "./textGenerationWithOpenAi"
-      );
-      await generateTextWithOpenAi();
-    } else if (settings.inferenceType === "internal") {
-      const { generateTextWithInternalApi } = await import(
-        "./textGenerationWithInternalApi"
-      );
-      await generateTextWithInternalApi();
-    } else if (settings.inferenceType === "horde") {
-      const { generateTextWithHorde } = await import(
-        "./textGenerationWithHorde"
-      );
-      await generateTextWithHorde();
-    } else {
+    if (settings.inferenceType === "browser") {
       await canDownloadModels();
       updateTextGenerationState("loadingModel");
-
-      const { generateTextWithWllama } = await import(
-        "./textGenerationWithWllama"
-      );
-      await generateTextWithWllama();
     }
+    const strategy = await getCurrentInferenceStrategy();
+    await strategy.generateText();
 
     try {
       await saveLlmResponseForQuery(
@@ -263,7 +280,6 @@ export async function generateChatResponse(
   newMessages: ChatMessage[],
   onUpdate: (partialResponse: string) => void,
 ) {
-  const settings = getSettings();
   let response = "";
 
   try {
@@ -329,27 +345,8 @@ export async function generateChatResponse(
 
     const lastMessages = [systemPrompt, initialResponse, ...processedMessages];
 
-    if (settings.inferenceType === "openai") {
-      const { generateChatWithOpenAi } = await import(
-        "./textGenerationWithOpenAi"
-      );
-      response = await generateChatWithOpenAi(lastMessages, onUpdate);
-    } else if (settings.inferenceType === "internal") {
-      const { generateChatWithInternalApi } = await import(
-        "./textGenerationWithInternalApi"
-      );
-      response = await generateChatWithInternalApi(lastMessages, onUpdate);
-    } else if (settings.inferenceType === "horde") {
-      const { generateChatWithHorde } = await import(
-        "./textGenerationWithHorde"
-      );
-      response = await generateChatWithHorde(lastMessages, onUpdate);
-    } else {
-      const { generateChatWithWllama } = await import(
-        "./textGenerationWithWllama"
-      );
-      response = await generateChatWithWllama(lastMessages, onUpdate);
-    }
+    const strategy = await getCurrentInferenceStrategy();
+    response = await strategy.generateChat(lastMessages, onUpdate);
   } catch (error) {
     if (error instanceof ChatGenerationError) {
       addLogEntry(`Chat generation interrupted: ${error.message}`);


### PR DESCRIPTION
## Root cause

Two code paths were hard to test:

1. **Inference dispatch** was written out as three separate `if/else if` chains across `createLlmSummary`, `searchAndRespond`, and `generateChatResponse` in \`textGeneration.ts\`, each switching on the same \`inferenceType\` enum to dispatch to the same four backends.
2. **\`handleSend\`** in \`ChatInterface.tsx\` was a monolithic \`useCallback\` doing related-query generation, text result dedup, image result dedup, chat generation, history persistence, and follow-up questions — all in one callback.

## What changed

| Change | File(s) | Impact |
|---|---|---|
| Strategy map for inference dispatch | \`client/modules/textGeneration.ts\` | Three \`if/else if\` chains → single \`getCurrentInferenceStrategy()\` returning \`{ generateText, generateChat }\` per backend |
| Extracted chat search helpers | \`client/modules/chatHelpers.ts\` (new) | \`refreshTextSearchResults\`, \`refreshImageSearchResults\`, \`persistChatMessages\`, \`runFollowUpSearch\` as plain functions |
| Slimmed \`handleSend\` | \`client/components/AiResponse/ChatInterface.tsx\` | Callback delegates to \`chatHelpers.ts\`; shrank by ~85 lines |

Net **-160 lines** across existing files (+154 in new helper module). Zero behavior changes.

## How it was verified

- \`npm run lint\` passes (biome, tsc, knip, jscpd, architectural linter, doc gardener, doc validator)
- No new jscpd clones introduced
- No new knip unused exports or dependencies