### PR TITLE
Publish the image as `latest` instead of `main`, with provenance, SBOM, and a scan

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -27,18 +27,12 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # The date pattern mirrors `getSemanticVersion` in
-          # `client/modules/stringFormatters.ts`, which the app reports as its
-          # version: unpadded month and day, UTC (the action's default timezone).
-          # A running instance reporting `2026.8.10+f1c8d2e` therefore maps to
-          # the `2026.8.10-f1c8d2e` tag, hyphenated because `+` is not a legal
-          # character in a Docker tag.
-          #
-          # `latest` is guarded by `is_default_branch` because it's the only
-          # moving tag: without the guard, dispatching this workflow from a
-          # side branch would move it for everyone.
+          # `latest` replaces the `main` tag this action emits by default. With
+          # releases cut on demand, the image can sit several commits behind the
+          # branch, so naming it after the branch misleads. The
+          # `is_default_branch` guard stops a dispatch from a side branch from
+          # moving the tag for everyone.
           tags: |
-            type=raw,value={{date 'YYYY.M.D'}}-{{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -2,6 +2,15 @@ name: Publish Docker Image
 
 on:
   workflow_dispatch:
+  push:
+    branches: ["main"]
+
+# A newer commit's image supersedes the one being built, so bursts of pushes
+# don't need to queue. The trade-off is that commits superseded mid-build get
+# no `sha-` tag of their own.
+concurrency:
+  group: publish-docker-image
+  cancel-in-progress: true
 
 jobs:
   build-and-push-image:
@@ -27,6 +36,16 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `type=sha` is not one of the action's defaults, and it's the only
+          # immutable tag here, so self-hosters can pin and roll back. The date
+          # pattern mirrors `getSemanticVersion` in
+          # `client/modules/stringFormatters.ts`, which the app reports as its
+          # version: unpadded month and day, UTC (the action's default timezone).
+          tags: |
+            type=sha
+            type=raw,value={{date 'YYYY.M.D'}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
       - name: Build and push Docker Image
@@ -37,3 +56,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          # BuildKit pushes these attestations with the registry credentials
+          # already in use, so no extra job permissions are needed.
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -2,15 +2,6 @@ name: Publish Docker Image
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
-
-# A newer commit's image supersedes the one being built, so bursts of pushes
-# don't need to queue. The trade-off is that commits superseded mid-build get
-# no `sha-` tag of their own.
-concurrency:
-  group: publish-docker-image
-  cancel-in-progress: true
 
 jobs:
   build-and-push-image:
@@ -36,16 +27,19 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # `type=sha` is not one of the action's defaults, and it's the only
-          # immutable tag here, so self-hosters can pin and roll back. The date
-          # pattern mirrors `getSemanticVersion` in
+          # The date pattern mirrors `getSemanticVersion` in
           # `client/modules/stringFormatters.ts`, which the app reports as its
           # version: unpadded month and day, UTC (the action's default timezone).
+          # A running instance reporting `2026.8.10+f1c8d2e` therefore maps to
+          # the `2026.8.10-f1c8d2e` tag, hyphenated because `+` is not a legal
+          # character in a Docker tag.
+          #
+          # `latest` is guarded by `is_default_branch` because it's the only
+          # moving tag: without the guard, dispatching this workflow from a
+          # side branch would move it for everyone.
           tags: |
-            type=sha
-            type=raw,value={{date 'YYYY.M.D'}}
+            type=raw,value={{date 'YYYY.M.D'}}-{{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
       - name: Build and push Docker Image

--- a/.github/workflows/scan-docker-image.yml
+++ b/.github/workflows/scan-docker-image.yml
@@ -1,0 +1,33 @@
+name: Scan Docker Image
+
+# Deliberately not tied to pull requests. The image inherits its base OS
+# packages from `node:lts-slim`, so findings arrive when upstream publishes an
+# advisory rather than when someone changes the app, and gating pull requests on
+# them would only produce a red check nobody can act on.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  scan-published-image:
+    name: Scan Published Image for Vulnerabilities
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Run Trivy on the published image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          # Without this, the report fills with advisories that have no patched
+          # version, drowning out the findings that can actually be fixed.
+          ignore-unfixed: true
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:lts-slim
 
 ARG SEARXNG_COMMIT_SHA="6da6eee265daeb4a62ab638d6921522bf405de69"
 
@@ -9,8 +9,16 @@ ARG USERNAME=node
 ARG HOME_DIR=/home/${USERNAME}
 ARG APP_DIR=${HOME_DIR}/app
 
+# The slim base omits tools the full `node` image ships implicitly: `git` for
+# the SearXNG checkout and the build's commit hash, `curl` for the HEALTHCHECK
+# below, `openssl` for the SearXNG secret key, and `ca-certificates` for both
+# the clone and pip.
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  git \
+  openssl \
   python3 \
   python3-venv && \
   apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -35,10 +35,39 @@ The AI can run entirely inside your browser tab, on GPU or CPU, so a working set
 Run the published image:
 
 ```bash
-docker run -p 7860:7860 ghcr.io/felladrin/minisearch:main
+docker run -p 7860:7860 ghcr.io/felladrin/minisearch:latest
 ```
 
 Then open <http://localhost:7860> and start searching.
+
+<details>
+<summary>Pin to a specific version</summary>
+
+`latest` and `main` both follow the tip of the default branch, so they change under you. To stay on a known-good build, pick one of the immutable options:
+
+| Tag | Example | Moves? |
+| --- | --- | --- |
+| `latest` | `minisearch:latest` | Yes, every push to `main` |
+| `YYYY.M.D` | `minisearch:2026.8.3` | Only if another build lands the same day |
+| `sha-<commit>` | `minisearch:sha-f1c8d2e` | No |
+| `@sha256:<digest>` | `minisearch@sha256:1a2b3c...` | No |
+
+The version the app reports (in the menu, and under `build` on `/status`) combines the first two, so a running instance showing `2026.8.3+f1c8d2e` came from `sha-f1c8d2e`.
+
+For the strongest guarantee, pin the digest, which identifies the exact image no matter what the tags do later:
+
+```bash
+docker pull ghcr.io/felladrin/minisearch:sha-f1c8d2e
+docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/felladrin/minisearch:sha-f1c8d2e
+```
+
+Images carry provenance and SBOM attestations, which you can inspect with:
+
+```bash
+docker buildx imagetools inspect ghcr.io/felladrin/minisearch:latest
+```
+
+</details>
 
 <details>
 <summary>Use Docker Compose</summary>
@@ -48,7 +77,7 @@ Add the service to your `docker-compose.yml`:
 ```yaml
 services:
   minisearch:
-    image: ghcr.io/felladrin/minisearch:main
+    image: ghcr.io/felladrin/minisearch:latest
     ports:
       - "7860:7860"
 ```

--- a/README.md
+++ b/README.md
@@ -41,24 +41,16 @@ docker run -p 7860:7860 ghcr.io/felladrin/minisearch
 Then open <http://localhost:7860> and start searching.
 
 <details>
-<summary>Pin to a specific version</summary>
+<summary>Pin to a specific build</summary>
 
-`latest` points at the most recent release, so it changes under you. To stay on a known-good build, pin a version instead:
-
-| Tag | Example | Moves? |
-| --- | --- | --- |
-| `latest` | `minisearch:latest` | Yes, on every release |
-| `YYYY.M.D-<commit>` | `minisearch:2026.8.10-f1c8d2e` | No |
-| `@sha256:<digest>` | `minisearch@sha256:1a2b3c...` | No |
-
-The version tag is the one the app reports (in the menu, and under `build` on `/status`) with its `+` turned into a `-`, since `+` is not allowed in a Docker tag. An instance showing `2026.8.10+f1c8d2e` came from `2026.8.10-f1c8d2e`.
-
-For the strongest guarantee, pin the digest, which identifies the exact image no matter what the tags do later:
+`latest` moves on every release, so it changes under you. To stay on a known-good build, pin the digest, which always identifies the same image:
 
 ```bash
-docker pull ghcr.io/felladrin/minisearch:2026.8.10-f1c8d2e
-docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/felladrin/minisearch:2026.8.10-f1c8d2e
+docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/felladrin/minisearch:latest
+docker run -p 7860:7860 ghcr.io/felladrin/minisearch@sha256:1a2b3c...
 ```
+
+The version the running instance reports (in the menu, and under `build` on `/status`) tells you which commit it was built from.
 
 Images carry provenance and SBOM attestations, which you can inspect with:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The AI can run entirely inside your browser tab, on GPU or CPU, so a working set
 Run the published image:
 
 ```bash
-docker run -p 7860:7860 ghcr.io/felladrin/minisearch:latest
+docker run -p 7860:7860 ghcr.io/felladrin/minisearch
 ```
 
 Then open <http://localhost:7860> and start searching.
@@ -43,22 +43,21 @@ Then open <http://localhost:7860> and start searching.
 <details>
 <summary>Pin to a specific version</summary>
 
-`latest` and `main` both follow the tip of the default branch, so they change under you. To stay on a known-good build, pick one of the immutable options:
+`latest` points at the most recent release, so it changes under you. To stay on a known-good build, pin a version instead:
 
 | Tag | Example | Moves? |
 | --- | --- | --- |
-| `latest` | `minisearch:latest` | Yes, every push to `main` |
-| `YYYY.M.D` | `minisearch:2026.8.3` | Only if another build lands the same day |
-| `sha-<commit>` | `minisearch:sha-f1c8d2e` | No |
+| `latest` | `minisearch:latest` | Yes, on every release |
+| `YYYY.M.D-<commit>` | `minisearch:2026.8.10-f1c8d2e` | No |
 | `@sha256:<digest>` | `minisearch@sha256:1a2b3c...` | No |
 
-The version the app reports (in the menu, and under `build` on `/status`) combines the first two, so a running instance showing `2026.8.3+f1c8d2e` came from `sha-f1c8d2e`.
+The version tag is the one the app reports (in the menu, and under `build` on `/status`) with its `+` turned into a `-`, since `+` is not allowed in a Docker tag. An instance showing `2026.8.10+f1c8d2e` came from `2026.8.10-f1c8d2e`.
 
 For the strongest guarantee, pin the digest, which identifies the exact image no matter what the tags do later:
 
 ```bash
-docker pull ghcr.io/felladrin/minisearch:sha-f1c8d2e
-docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/felladrin/minisearch:sha-f1c8d2e
+docker pull ghcr.io/felladrin/minisearch:2026.8.10-f1c8d2e
+docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/felladrin/minisearch:2026.8.10-f1c8d2e
 ```
 
 Images carry provenance and SBOM attestations, which you can inspect with:

--- a/docs/development-commands.md
+++ b/docs/development-commands.md
@@ -73,7 +73,7 @@ Used by both `on-push-to-main` and `on-pull-request-to-main` to run the producti
 The Docker image uses a multi-stage build:
 The image installs Python/SearXNG, builds the Vite frontend, and runs SearXNG and Node.js in a single container via shell process composition. No compilation step is required: the reranker's ONNX Runtime binaries ship prebuilt with the npm dependency.
 
-The production image is published to `ghcr.io` with multi-platform support (linux/amd64, linux/arm64). Labels are auto-generated from Git metadata via `docker/metadata-action`, and each release is tagged twice: `latest`, plus an immutable `YYYY.M.D-<short-sha>` mirroring the version the app reports (`getSemanticVersion` in `client/modules/stringFormatters.ts`, with `+` replaced by `-`, which Docker tags do not allow). Weekly, `scan-docker-image.yml` runs Trivy against the published `latest` and reports fixable HIGH/CRITICAL findings to code scanning.
+The production image is published to `ghcr.io` with multi-platform support (linux/amd64, linux/arm64). Labels are auto-generated from Git metadata via `docker/metadata-action`, and each release is published as `latest`; to pin a build, users reference the image digest. Weekly, `scan-docker-image.yml` runs Trivy against the published `latest` and reports fixable HIGH/CRITICAL findings to code scanning.
 
 ### Manual Deployments
 

--- a/docs/development-commands.md
+++ b/docs/development-commands.md
@@ -58,6 +58,7 @@ The repository uses six GitHub Actions workflows for continuous integration, dep
 | `on-push-to-main.yml` | Push to `main` | Delegates to `reusable-check-docker.yml` |
 | `on-pull-request-to-main.yml` | PR opened/synced/reopened to `main` | Delegates to `reusable-check-docker.yml`; skippable via `skip-check-docker` label |
 | `publish-docker-image.yml` | Manual (`workflow_dispatch`) | Builds multi-platform Docker image (linux/amd64, linux/arm64) and pushes to `ghcr.io` |
+| `scan-docker-image.yml` | Weekly (Monday 06:00 UTC) or manual | Trivy scan of the published image, reporting fixable HIGH/CRITICAL findings to code scanning |
 | `deploy-to-hugging-face.yml` | Manual (`workflow_dispatch`) | Syncs repository to Hugging Face Spaces using `JacobLinCool/huggingface-sync` |
 | `reusable-check-docker.yml` | Called by other workflows | Docker compose production build + health check via `curl localhost:7860` (lint/format/test are covered by `ci.yml`) |
 
@@ -72,7 +73,7 @@ Used by both `on-push-to-main` and `on-pull-request-to-main` to run the producti
 The Docker image uses a multi-stage build:
 The image installs Python/SearXNG, builds the Vite frontend, and runs SearXNG and Node.js in a single container via shell process composition. No compilation step is required: the reranker's ONNX Runtime binaries ship prebuilt with the npm dependency.
 
-The production image is published to `ghcr.io` with multi-platform support (linux/amd64, linux/arm64). Tags and labels are auto-generated from Git metadata via `docker/metadata-action`.
+The production image is published to `ghcr.io` with multi-platform support (linux/amd64, linux/arm64). Labels are auto-generated from Git metadata via `docker/metadata-action`, and each release is tagged twice: `latest`, plus an immutable `YYYY.M.D-<short-sha>` mirroring the version the app reports (`getSemanticVersion` in `client/modules/stringFormatters.ts`, with `+` replaced by `-`, which Docker tags do not allow). Weekly, `scan-docker-image.yml` runs Trivy against the published `latest` and reports fixable HIGH/CRITICAL findings to code scanning.
 
 ### Manual Deployments
 


### PR DESCRIPTION
## Description

Closes #2184.

Currently the only published tag is `main`, which was never a deliberate choice: it's what `docker/metadata-action` emits by default when no `tags` input is given. With releases cut on demand, the name misleads, because the image can sit several commits behind the branch it names. This PR publishes `latest` instead, which promises only "the most recent release". It also makes `docker run ghcr.io/felladrin/minisearch` work with no tag at all, which currently fails.

Releases stay on demand. Publishing on every push to `main` turns a README typo fix into a full multi-platform build, so the `workflow_dispatch` trigger is unchanged.

`latest` is guarded by `enable={{is_default_branch}}`, so dispatching this workflow from a side branch doesn't move the tag for everyone.

To pin a build, the README now points at the image digest. There's no immutable version tag, because rebuilding the same commit produces a different image anyway (each build bakes a fresh SearXNG secret key, and the base image moves), so a tag naming the commit would promise less than it looks like it promises. The app already reports its own version in the menu and under `build` on `/status`, which is what maps a running instance back to a commit.

`provenance` and `sbom` need no extra job permissions, since BuildKit pushes the attestations with the registry credentials already in use. They do add attestation manifests, so the GHCR package page will start listing `unknown/unknown` entries.

### Why the base swap came along

The scan is only worth having if its output is actionable, and on the full base it wasn't. Measured with `--severity HIGH,CRITICAL` on the built image:

| Base | Total | Fixable (what the workflow reports) | Image size |
| --- | --- | --- | --- |
| `node:lts` | 435 | 75 | 2.35 GB |
| `node:lts-slim` | 104 | 11 | 1.6 GB |

11 findings is a list someone reads. 75 is a badge nobody clicks.

### What changed

| File | Change |
| --- | --- |
| `.github/workflows/publish-docker-image.yml` | Publish `latest` instead of `main`; attach provenance and SBOM |
| `Dockerfile` | `node:lts` to `node:lts-slim`, reinstalling `git`, `curl`, `openssl`, `ca-certificates` |
| `.github/workflows/scan-docker-image.yml` | New weekly Trivy scan, reporting fixable HIGH/CRITICAL to code scanning |
| `README.md` | Quick start drops the tag entirely; new section on pinning by digest |
| `docs/development-commands.md` | Document the published tag and the new workflow |

### Scope note

The issue also asked for semver tags, a changelog, and a `package.json` bump. Those are dropped. The version in `package.json` is never read (`private: true`), so bumping it adds a second source of truth that drifts from `appVersion`. And the version the app already reports is a valid semver 2.0.0 string on its own (`semver.valid('2026.8.10+f1c8d2e')` returns `2026.8.10`, since the spec ignores build metadata), so adopting a separate scheme would mean replacing something that already works.

## How to test

1. `docker build -t minisearch:slim .`
2. `docker run -d --rm --name ms -p 7861:7860 minisearch:slim`
3. `docker inspect --format '{{.State.Health.Status}}' ms` should reach `healthy`. This is the check that matters most: `HEALTHCHECK` calls `curl`, which the slim base does not ship, so a missed dependency shows up here.
4. `curl -s http://localhost:7861/status` should report `"webSearchServiceStatus":"healthy"`, confirming SearXNG still starts (it listens on 8888 inside the container).

Verified locally on arm64: builds clean, healthy after 11s, main page 200, and both `rerankerServiceStatus` and `webSearchServiceStatus` healthy. The SearXNG `pip install` resolves `lxml` from a wheel, so no build toolchain is needed on the slim base.

### Known limitations

- The amd64 half of the matrix is unverified, since I only built arm64.
- `npm run lint` exits 1 on this branch, but it does so on `main` too (knip's "Unlisted binaries"), so it's pre-existing and untouched here. `npm run format:check` passes.

### Post-merge actions

- Cut the first release from this scheme, then delete the `main` tag from the GHCR package, so pulls fail loudly instead of silently freezing on the last image published under it.
