### PR TITLE
Add 2s fetch timeout to `getWebSearchStatus()`

### DIFF
--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -95,6 +95,27 @@ describe("WebSearchService", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("returns false when health endpoint hangs and the request times out", async () => {
+    vi.useFakeTimers();
+    try {
+      (global.fetch as MockedFunction<typeof fetch>).mockImplementation(
+        (_input: string | Request | URL, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new Error("Aborted")),
+            );
+          }),
+      );
+
+      const promise = getWebSearchStatus();
+      await vi.advanceTimersByTimeAsync(2000);
+      const status = await promise;
+      expect(status).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("should return empty array on fetchSearXNG error", async () => {
     (global.fetch as MockedFunction<typeof fetch>).mockRejectedValue(
       new Error("Network failure"),

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -74,7 +74,9 @@ export async function startWebSearchService() {
 
 export async function getWebSearchStatus() {
   try {
-    const response = await fetch(`${SERVICE_BASE_URL}/healthz`);
+    const response = await fetch(`${SERVICE_BASE_URL}/healthz`, {
+      signal: AbortSignal.timeout(2000),
+    });
     const responseText = await response.text();
     return responseText.trim() === "OK";
   } catch {


### PR DESCRIPTION
Closes #2287

## Root cause

`getWebSearchStatus()` in `server/webSearchService.ts` called `fetch("http://127.0.0.1:8888/healthz")` with no timeout. If SearXNG accepts the TCP connection but never responds, the fetch blocks indefinitely and the `/status` handler never returns.

## What changed

| File | Change |
|------|--------|
| `server/webSearchService.ts` | Wrap the `/healthz` fetch in `AbortSignal.timeout(2000)` so the health check aborts after 2s |
| `server/webSearchService.test.ts` | Add a test simulating a hanging health endpoint, asserting `getWebSearchStatus()` returns `false` once the abort fires |

## How it was verified

- `npx vitest run server/webSearchService.test.ts` → 3 files, 37 tests passed (includes the new hang-and-timeout test)
- LSP diagnostics clean on both edited files