### PR TITLE
Honor a configurable port in the reusable Docker health check

### DIFF
--- a/.github/workflows/reusable-check-docker.yml
+++ b/.github/workflows/reusable-check-docker.yml
@@ -1,16 +1,22 @@
 on:
   workflow_call:
+    inputs:
+      port:
+        type: string
+        default: "7860"
 jobs:
   check-docker-container:
     name: Check Docker Container
     runs-on: ubuntu-latest
+    env:
+      PORT: ${{ inputs.port }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v7
       - run: docker compose -f docker-compose.production.yml up -d
       - name: Check if main page is available
-        run: until curl -s -o /dev/null -w "%{http_code}" localhost:"${PORT:-7860}" | grep 200; do sleep 1; done
+        run: until curl -s -o /dev/null -w "%{http_code}" localhost:"$PORT" | grep 200; do sleep 1; done
         timeout-minutes: 1
 
       - uses: actions/setup-node@v7
@@ -24,7 +30,9 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Playwright e2e smoke
-        run: PLAYWRIGHT_BASE_URL="http://127.0.0.1:${PORT:-7860}" npm run test:e2e
+        run: npm run test:e2e
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:${{ inputs.port }}
 
       - name: Upload Playwright report
         if: ${{ failure() }}

--- a/.github/workflows/reusable-check-docker.yml
+++ b/.github/workflows/reusable-check-docker.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v7
       - run: docker compose -f docker-compose.production.yml up -d
       - name: Check if main page is available
-        run: until curl -s -o /dev/null -w "%{http_code}" localhost:7860 | grep 200; do sleep 1; done
+        run: until curl -s -o /dev/null -w "%{http_code}" localhost:"${PORT:-7860}" | grep 200; do sleep 1; done
         timeout-minutes: 1
 
       - uses: actions/setup-node@v7
@@ -24,9 +24,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Playwright e2e smoke
-        run: npm run test:e2e
-        env:
-          PLAYWRIGHT_BASE_URL: http://127.0.0.1:7860
+        run: PLAYWRIGHT_BASE_URL="http://127.0.0.1:${PORT:-7860}" npm run test:e2e
 
       - name: Upload Playwright report
         if: ${{ failure() }}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,7 +5,7 @@ services:
       - PORT=${PORT:-7860}
       - BASIC_SSL=${BASIC_SSL:-false}
     ports:
-      - "${PORT:-7860}:7860"
+      - "${PORT:-7860}:${PORT:-7860}"
     build:
       dockerfile: Dockerfile
       context: .


### PR DESCRIPTION
Currently, the reusable Docker workflow hardcodes `7860` in both the readiness curl and the `PLAYWRIGHT_BASE_URL`, and the compose production `ports` mapping publishes to container port `7860` while the app actually binds `PORT`. So a non-default port silently breaks both sides: the health check polls a port nothing answers on and never sees the container ready, and the published mapping points at a dead container port. This PR does 2 things: the reusable workflow now takes a `port` input (default `"7860"`) exposed as a job-level `PORT`, so `docker compose up`, the readiness curl, and the Playwright base URL all agree on the same port; and the compose `ports` mapping forwards the host port to the container's real port (`${PORT:-7860}:${PORT:-7860}`). With no input passed the behavior is identical to before (`7860:7860`), so this is purely a robustness fix. #2276 already fixed the same hardcode in the `Dockerfile` healthcheck; this closes the CI side.

- Fixes #2286.

Note: a job-level `env:` is needed rather than a per-step one, because `docker compose up -d` reads `PORT` from the environment too. And caller-side `env:` doesn't cross the `workflow_call` boundary, which is why the port arrives as a declared input.

## How to test

1. With `PORT` unset, run `docker compose -f docker-compose.production.yml up -d` and check that `curl localhost:7860/status` returns 200.
2. Run it again with `PORT=9000 docker compose -f docker-compose.production.yml up -d` and check that `curl localhost:9000/status` returns 200 (this failed before the fix, since the old mapping pointed at container port 7860).
3. Confirm the `check-docker` workflow passes on this branch, which covers the default-port path end-to-end.

Note: I couldn't run the Docker build locally in this session, so step 3 is what verified the container path (`check-docker / Check Docker Container` passed in 2m48s). Step 2 still needs a local run to confirm the override case.