### PR TITLE
Add Hadolint to CI lint pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,10 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-      - name: Install hadolint
+      - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
-          version: latest
-
-      - name: Lint Dockerfile
-        run: hadolint Dockerfile
 
       - name: Check formatting
         run: npm run format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Lint Dockerfile
+        run: hadolint Dockerfile
+
       - name: Check formatting
         run: npm run format:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Install hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          version: latest
+
       - name: Lint Dockerfile
         run: hadolint Dockerfile
 

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+# Hadolint configuration for MiniSearch
+# Suppress rules that are not applicable to our Dockerfile
+
+ignored:
+  - DL3064
+  - DL3008
+  - SC2046
+  - DL3025


### PR DESCRIPTION
## Problem

The repo lint gate runs Biome, TypeScript, knip, jscpd, and custom scripts — but none of them validate Dockerfiles. Dockerfile changes bypass all automated checks.

## Fix

Add [Hadolint](https://github.com/hadolint/hadolint) to the CI pipeline with a `.hadolint.yaml` config that suppresses rules not applicable to our Dockerfile:

| Rule | Reason for suppression |
|------|------------------------|
| DL3064 | `ARG USERNAME=node` — not sensitive data |
| DL3008 | Pinning apt package versions is impractical for this use case |
| SC2046 | Intentional shell expansion for random key generation |
| DL3025 | CMD uses shell form to run multiple background processes |

## Files changed

- `.hadolint.yaml` — new config file
- `.github/workflows/ci.yml` — add `hadolint` action step

Fixes #2285
