### PR TITLE
Replace the reranker with a multilingual cross-encoder

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -34,7 +34,7 @@ Instead of a heavy state management library like Redux, MiniSearch uses a minima
 
 ### Reranker
 
-A secondary search stage that takes initial results from SearXNG and re-orders them based on relevance to the query using a cross-encoder model (`jina-reranker-v1-tiny-en`) running in-process via ONNX Runtime.
+A secondary search stage that takes initial results from SearXNG and re-orders them based on relevance to the query using a multilingual cross-encoder model (`mmarco-mMiniLMv2-L12-H384-v1`) running in-process via ONNX Runtime.
 
 - **Implementation**: Loads the model's ONNX export with `onnxruntime-node`; no child process
 - **Health Check**: Polls `/health` endpoint via `getRerankerStatus`

--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -18,7 +18,7 @@ The reranking subsystem consists of three components:
 
 The `rerankerServiceHook` starts the reranker during server initialization:
 
-1. Downloads the model and tokenizer from HuggingFace if not present (`jinaai/jina-reranker-v1-tiny-en`)
+1. Downloads the model and tokenizer from HuggingFace if not present (`cross-encoder/mmarco-mMiniLMv2-L12-H384-v1`)
 2. Creates an ONNX Runtime inference session
 3. Performs a warmup inference (`query: "test"`, `documents: ["test document"]`) to ensure the graph is initialized
 4. Sets `isReady = true`
@@ -29,30 +29,30 @@ There is no child process, port, or health endpoint: inference runs inside the N
 
 `downloadFileFromHuggingFaceRepository` compares each cached file against the size the Hub reports, so a file downloaded only in part is replaced instead of being loaded. Without that check a truncated model made every later startup fail with `Protobuf parsing failed`, and only deleting `server/models/` by hand recovered.
 
-Downloads land on a sibling `.part-<pid>` path and are renamed once the whole body is on disk, which keeps an interrupted write from being visible where the next startup would trust it. Files are also checked individually, so a missing tokenizer is fetched on its own while the 130MB model stays cached.
+Downloads land on a sibling `.part-<pid>` path and are renamed once the whole body is on disk, which keeps an interrupted write from being visible where the next startup would trust it. Files are also checked individually, so a missing tokenizer is fetched on its own while the 119MB model stays cached.
 
 The size check costs one metadata request per file at startup (roughly 600ms for the three of them). When the Hub is unreachable the cached files are used as they are, so an offline server still starts with a warm cache.
 
 ### Execution Providers
 
-The session is created with `["webgpu", "cpu"]`, with no configuration to set. WebGPU is roughly 3x faster than CPU (24ms against 77ms for 30 documents) and agrees with it to within float32 rounding (1e-6, identical ordering), so it is preferred where it works.
+The session is created with `["cpu"]`, with no configuration to set, and there is no second attempt to fall back from.
 
-When that session fails to be created, the reason is logged and a second session is created with `["cpu"]`. The retry is what makes hosts without a GPU work: a trailing `cpu` in the provider list is not a fallback chain, because ONNX Runtime only falls back per operator once a provider has been registered. A provider that fails to initialize at all rejects `InferenceSession.create` outright, and the entries behind it never get a chance. On Hugging Face Spaces, for instance, Dawn cannot find `libvulkan.so.1`, WebGPU then reports `No supported adapters`, and before the retry existed that left the reranker permanently unready with every search falling back to unranked results. The providers of each attempt are logged.
-
-Note that ONNX Runtime's WebGPU provider here is native, part of the `onnxruntime-node` binary. It is not the browser API, so it needs neither a browser nor Deno.
+The model ships as a dynamically quantized graph, and the WebGPU provider has no kernels for its integer matmuls. It registers happily and then hands every one of them back to the CPU, paying a round trip each time: 812ms against 172ms of the same work, with scores drifting by as much as 1.15 and reordering results. GPU acceleration is therefore not on the table for this model, which also removes the reason the two-attempt session logic existed.
 
 | Provider | Availability in the Node binding | Notes |
 |----------|----------------------------------|-------|
-| `cpu` | Everywhere | Fallback, retried as its own session |
-| `webgpu` | Windows, Linux x64, macOS | Preferred; experimental in ONNX Runtime, and needs a real GPU adapter plus a Vulkan loader on Linux |
+| `cpu` | Everywhere | The only provider used |
+| `webgpu` | Windows, Linux x64, macOS | Not used: no integer-matmul kernels, so a quantized graph runs ~4.7x slower than on CPU and its scores drift |
 | `cuda` | Linux x64 (CUDA v12) | Not used: the binaries are not bundled, and would need `npm install onnxruntime-node --onnxruntime-node-install=cuda12` |
 | `coreml` | macOS | Not used: slower than CPU for this model's dynamic shapes |
 
-There is no GPU provider for Linux arm64, so those hosts always run on CPU.
+### One Document per Call
 
-### Batching
+Documents are scored one at a time rather than in batches, which is what keeps a score a property of its own `(query, document)` pair.
 
-Documents are scored in batches of 10. `onnxruntime-node` wraps a synchronous native call, so scoring all 30 results at once would block the event loop for the full duration. Batching yields between calls, capping the stall at roughly 27ms rather than 78ms, at the cost of about 4% more wall time. Scores are identical either way, because padding is per batch but the attention mask excludes it.
+Dynamic quantization computes each activation tensor's scale from that tensor's own range at runtime. Padding rows out to a shared width puts the pad positions inside that range, and while the attention mask keeps them out of attention it cannot keep them out of the scale, so the quantization of the real tokens shifts. Batches of 10 moved logits by up to 1.29 at ordinary snippet lengths and reordered 2 of 10 fixtures depending only on which documents shared a batch. The fp32 export of the same model shows a difference of exactly zero, so this is a property of quantization and not of the graph.
+
+Scoring one pair at a time removes the padding, and with it the coupling. It also suits the reason batching was introduced in the first place: `onnxruntime-node` wraps a synchronous native call, and one pair holds the event loop for about 13ms instead of the 50ms a batch of 10 takes. The cost is throughput, roughly 12% more wall time for 30 documents on two threads and up to 47% more where there are cores to spare.
 
 ### Shutdown
 
@@ -69,6 +69,8 @@ On server close, `stopRerankerService()` clears the readiness flag and releases 
 Each result is formatted as `` `${title}\n${snippet}` ``: the cased title and snippet on either side of a newline, with no URL. The query keeps its original casing too. Unicode surrogates in both are sanitized before tokenization.
 
 Documents are sent to the reranker whole. Truncation happens by tokens inside the reranker, not by characters here: `score()` caps each encoded `(query, document)` pair at `MAX_SEQUENCE_LENGTH` tokens, dropping tokens from the end of the document only, so the query and the trailing separator are preserved.
+
+`MAX_SEQUENCE_LENGTH` is 512 because the model has 514 learned position embeddings and XLM-RoBERTa reserves two of them. It is a limit, not a preference: a 513-token pair fails outright with `indices element out of data bounds` at the position-embedding gather. Web snippets land around 33-63 tokens per pair, so truncation is rare in practice.
 
 ### Unicode Sanitization
 
@@ -115,23 +117,31 @@ Reranking is applied to both text and image search results. For image results, t
 
 | Property | Value |
 |----------|-------|
-| Model | jina-reranker-v1-tiny-en |
-| Format | ONNX (fp32) |
-| HuggingFace Repo | jinaai/jina-reranker-v1-tiny-en |
-| Type | Cross-encoder reranker |
-| Size | 4 layers, 33M parameters |
-| Max sequence length | 8192 tokens (ALiBi); capped at 2048 via `MAX_SEQUENCE_LENGTH` |
-| Storage | `server/models/jinaai/jina-reranker-v1-tiny-en/` |
+| Model | mmarco-mMiniLMv2-L12-H384-v1 |
+| Format | ONNX, dynamically quantized (`onnx/model_quint8_avx2.onnx`, 119MB) |
+| HuggingFace Repo | cross-encoder/mmarco-mMiniLMv2-L12-H384-v1 |
+| Type | Cross-encoder reranker (XLM-RoBERTa, one relevance logit) |
+| Size | 12 layers, 118M parameters, of which 96M are the 250k-token vocabulary |
+| Max sequence length | 512 tokens, the model's own limit, enforced via `MAX_SEQUENCE_LENGTH` |
+| Storage | `server/models/cross-encoder/mmarco-mMiniLMv2-L12-H384-v1/` |
 
-Despite being an English model, it ranks non-English results (Portuguese, for example) well in practice, which is why it is preferred over larger alternatives.
+It is trained on mMARCO, the machine-translated multilingual MS MARCO, and is genuinely multilingual: a 250k-token sentencepiece vocabulary shared across languages, which is also where most of the parameter count goes.
 
-Quantized variants are deliberately not used. The `q8` export measurably degrades ranking quality on this 33M-parameter model, and the `fp16` export fails to load in `onnxruntime-node`.
+The model it replaced, `jina-reranker-v1-tiny-en`, was chosen on the belief that an English model ranked other languages well enough. Measured against 240 MIRACL queries across English, Spanish, French, German, Russian and Japanese, it scored 0.4636 nDCG@10, below the 0.4963 of the un-reranked first-stage order: on non-English content it was not adding ranking signal. This model scores 0.7992 on the same set. Part of the mechanism is the tokenizer, since an English WordPiece vocabulary spends 2.17x as many tokens on Russian and about 1.4x on Spanish, German and Japanese, so the English model paid more compute to see worse-fragmented subwords.
+
+### Choosing the Quantized Export
+
+The repository ships one build per CPU kernel family from the same weights: `qint8_arm64`, `qint8_avx512`, `qint8_avx512_vnni` and `quint8_avx2`. `quint8_avx2` is the one used, because unsigned activations sidestep the signed-int8 saturation that x64 without VNNI otherwise has to work around, and it measured no slower than the arm64 build when run on arm64. The `qint8_arm64` and `qint8_avx512` builds are bit-identical in output and score 0.8039, marginally above `quint8_avx2`, but that margin is inside the noise of a 240-query set and does not buy predictable behaviour on hosts whose instruction set cannot be known in advance.
+
+Quantization costs nothing measurable here: 0.7992 against 0.7973 nDCG@10 for the fp32 export, for a quarter of the download and half the latency. That is a different conclusion from the one that held for the previous 33M-parameter model, where the `q8` export did measurably degrade ranking; the loss does not carry over to a model with 12 layers and a large embedding table.
+
+The `O4` (fp16) export loads without complaint but is slower than fp32 on CPU, so it is not used either.
 
 ## Testing
 
 `server/rerankerService.test.ts` runs in the default suite and covers Unicode sanitization plus the execution-provider fallback, with the ONNX Runtime session, the tokenizer, and the model download all mocked.
 
-`server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality against English and Portuguese fixtures. It downloads ~130MB, so it is excluded from the default suite:
+`server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality against English and Portuguese fixtures. It downloads ~136MB, the model plus a 17MB sentencepiece tokenizer, so it is excluded from the default suite:
 
 ```sh
 npx vitest run --config vitest.integration.config.ts
@@ -142,7 +152,6 @@ npx vitest run --config vitest.integration.config.ts
 | Scenario | Behavior |
 |----------|----------|
 | Reranker not ready | Falls back to unranked SearXNG results |
-| GPU provider unavailable | Logged, then the session is created again with `["cpu"]` |
 | Model fails to load | Logged by the hook; reranker stays unready and search returns unranked results |
 | Cached file of the wrong size | Logged, then downloaded again before the session is created |
 | Download shorter than the reported size | Throws before anything is written, so the cache keeps no partial file |

--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -139,7 +139,7 @@ The `O4` (fp16) export loads without complaint but is slower than fp32 on CPU, s
 
 ## Testing
 
-`server/rerankerService.test.ts` runs in the default suite and covers Unicode sanitization plus the execution-provider fallback, with the ONNX Runtime session, the tokenizer, and the model download all mocked.
+`server/rerankerService.test.ts` runs in the default suite and covers Unicode sanitization, token truncation, and that every document is sent as its own unpadded row, with the ONNX Runtime session, the tokenizer, and the model download all mocked.
 
 `server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality against English and Portuguese fixtures. It downloads ~136MB, the model plus a 17MB sentencepiece tokenizer, so it is excluded from the default suite:
 

--- a/server/rerankerService.integration.test.ts
+++ b/server/rerankerService.integration.test.ts
@@ -2,8 +2,8 @@
 
 /**
  * Exercises the real reranker model end to end, including the multilingual
- * behaviour that motivated picking jina-reranker-v1-tiny-en. Downloads ~130MB
- * on first run, so it is excluded from the default suite:
+ * behaviour that motivated picking mmarco-mMiniLMv2-L12-H384-v1. Downloads
+ * ~136MB on first run, so it is excluded from the default suite:
  *
  *   npx vitest run --config vitest.integration.config.ts
  */
@@ -200,9 +200,9 @@ describe("reranker service", () => {
         .map(({ index }) => index);
 
       // Every relevant result must outrank every irrelevant one. The model
-      // clears this with a score gap of at least 0.99 between the two groups,
-      // so it is not sensitive to the ~1e-6 difference between the CPU and
-      // WebGPU execution providers.
+      // clears this with a score gap of at least 5.7 between the two groups, so
+      // the assertion is about ranking behaviour and not about a threshold the
+      // model happens to sit on.
       const topIndices = ordered
         .slice(0, fixture.relevant.length)
         .sort((a, b) => a - b);

--- a/server/rerankerService.test.ts
+++ b/server/rerankerService.test.ts
@@ -14,7 +14,7 @@ import {
 vi.mock("@huggingface/tokenizers", () => ({
   Tokenizer: class {
     encode() {
-      return { ids: [1, 2, 3], token_type_ids: [0, 0, 0] };
+      return { ids: [1, 2, 3] };
     }
   },
 }));
@@ -239,20 +239,13 @@ describe("startRerankerService", () => {
     release: async () => {},
   } as unknown as InferenceSession;
 
-  /** The message onnxruntime-node throws when Dawn finds no GPU adapter. */
-  const webGpuAdapterError = new Error(
-    "Failed to get a WebGPU adapter: No supported adapters",
-  );
-
-  function mockSessionCreation(
-    respond: (executionProviders: string[]) => Promise<InferenceSession>,
-  ) {
+  function mockSessionCreation(respond: () => Promise<InferenceSession>) {
     vi.mocked(InferenceSession.create).mockImplementation(((
       _modelPath: string,
       options: { executionProviders: string[] },
     ) => {
       requestedExecutionProviders.push(options.executionProviders);
-      return respond(options.executionProviders);
+      return respond();
     }) as unknown as typeof InferenceSession.create);
   }
 
@@ -266,36 +259,26 @@ describe("startRerankerService", () => {
     vi.restoreAllMocks();
   });
 
-  it("keeps the preferred providers when the session loads", async () => {
+  // No GPU provider is requested: the quantized graph has no integer-matmul
+  // kernels there and falls back operator by operator, which is slower than
+  // running on CPU outright.
+  it("creates a single CPU session and reports ready", async () => {
     mockSessionCreation(async () => sessionStub);
 
     await startRerankerService();
 
-    expect(requestedExecutionProviders).toEqual([["webgpu", "cpu"]]);
+    expect(requestedExecutionProviders).toEqual([["cpu"]]);
     expect(await getRerankerStatus()).toBe(true);
   });
 
-  it("retries on CPU when the WebGPU provider fails to initialize", async () => {
-    mockSessionCreation(async (executionProviders) => {
-      if (executionProviders.includes("webgpu")) throw webGpuAdapterError;
-      return sessionStub;
+  it("stays unready when the session cannot be created", async () => {
+    const loadError = new Error("Protobuf parsing failed");
+    mockSessionCreation(async () => {
+      throw loadError;
     });
 
-    await startRerankerService();
-
-    expect(requestedExecutionProviders).toEqual([["webgpu", "cpu"], ["cpu"]]);
-    expect(await getRerankerStatus()).toBe(true);
-  });
-
-  it("stays unready when CPU fails too", async () => {
-    const cpuError = new Error("Protobuf parsing failed");
-    mockSessionCreation(async (executionProviders) => {
-      throw executionProviders.includes("webgpu")
-        ? webGpuAdapterError
-        : cpuError;
-    });
-
-    await expect(startRerankerService()).rejects.toThrow(cpuError);
+    await expect(startRerankerService()).rejects.toThrow(loadError);
+    expect(requestedExecutionProviders).toEqual([["cpu"]]);
     expect(await getRerankerStatus()).toBe(false);
   });
 });
@@ -347,9 +330,11 @@ describe("rerank", () => {
   it("maps each score to its document index and preserves input order", async () => {
     // Non-monotonic scores: the result must stay in input order, not be
     // sorted by relevance (sorting/filtering lives in rankSearchResults).
-    runMock.mockResolvedValueOnce({
-      logits: { data: new Float32Array([0.5, 0.3, 0.8]) },
-    });
+    for (const score of [0.5, 0.3, 0.8]) {
+      runMock.mockResolvedValueOnce({
+        logits: { data: new Float32Array([score]) },
+      });
+    }
 
     const result = await rerank("query", ["A", "B", "C"]);
 
@@ -360,45 +345,39 @@ describe("rerank", () => {
     ]);
   });
 
-  it("splits documents into batches of BATCH_SIZE and concatenates in order", async () => {
-    // Give every document a unique score equal to its global position, so a
-    // dropped, duplicated, or reordered batch would break the assertions.
+  it("scores one document per model call and concatenates in order", async () => {
+    // Give every document a unique score equal to its position, so a dropped,
+    // duplicated, or reordered call would break the assertions.
     let nextScore = 0;
-    runMock.mockImplementation(
-      async (inputs: { input_ids: { dims: number[] } }) => {
-        const batchSize = inputs.input_ids.dims[0];
-        const data = new Float32Array(batchSize);
-        for (let i = 0; i < batchSize; i++) data[i] = nextScore++;
-        return { logits: { data } };
-      },
-    );
+    runMock.mockImplementation(async () => ({
+      logits: { data: new Float32Array([nextScore++]) },
+    }));
 
     const documents = Array.from({ length: 25 }, (_, i) => `doc ${i}`);
     const result = await rerank("query", documents);
 
-    expect(runMock).toHaveBeenCalledTimes(3); // 10 + 10 + 5
+    expect(runMock).toHaveBeenCalledTimes(25);
     expect(result).toHaveLength(25);
-    // Spot-check both sides of every batch boundary.
     expect(result[0]).toEqual({ index: 0, relevance_score: 0 });
-    expect(result[9]).toEqual({ index: 9, relevance_score: 9 });
-    expect(result[10]).toEqual({ index: 10, relevance_score: 10 });
     expect(result[24]).toEqual({ index: 24, relevance_score: 24 });
   });
 
-  it("makes exactly one model call per full batch when the count is a multiple of BATCH_SIZE", async () => {
-    runMock.mockImplementation(
-      async (inputs: { input_ids: { dims: number[] } }) => ({
-        logits: {
-          data: new Float32Array(inputs.input_ids.dims[0]).fill(0.5),
-        },
-      }),
-    );
+  // The scores of a dynamically quantized graph depend on the whole tensor's
+  // range, so a padded row would let one document's score shift another's.
+  it("sends one unpadded row per call, with every position attended to", async () => {
+    await rerank("query", ["A", "B"]);
 
-    const documents = Array.from({ length: 20 }, (_, i) => `doc ${i}`);
-    const result = await rerank("query", documents);
-
-    expect(runMock).toHaveBeenCalledTimes(2); // 10 + 10, no trailing empty batch
-    expect(result).toHaveLength(20);
+    expect(runMock).toHaveBeenCalledTimes(2);
+    for (const [inputs] of runMock.mock.calls) {
+      const { input_ids, attention_mask } = inputs as {
+        input_ids: { dims: number[]; data: BigInt64Array };
+        attention_mask: { dims: number[]; data: BigInt64Array };
+      };
+      expect(input_ids.dims).toEqual([1, 3]);
+      expect(Array.from(input_ids.data)).toEqual([1n, 2n, 3n]);
+      expect(attention_mask.dims).toEqual([1, 3]);
+      expect(Array.from(attention_mask.data)).toEqual([1n, 1n, 1n]);
+    }
   });
 
   it("sanitizes unpaired surrogates in the query and documents before tokenizing", async () => {
@@ -415,29 +394,29 @@ describe("rerank", () => {
 });
 
 describe("truncatePairTokens", () => {
-  // Sequence layout: [CLS] q q [SEP] | d d d d [SEP]
-  const ids = [101, 11, 12, 102, 21, 22, 23, 24, 102];
-  const tokenTypeIds = [0, 0, 0, 0, 1, 1, 1, 1, 1];
+  // Sequence layout: <s> q q </s> </s> | d d d d </s>
+  const ids = [0, 11, 12, 2, 2, 21, 22, 23, 24, 2];
 
   it("returns the ids unchanged when within budget", () => {
-    expect(truncatePairTokens(ids, tokenTypeIds, 20)).toBe(ids);
+    expect(truncatePairTokens(ids, 20)).toBe(ids);
   });
 
   it("drops document tokens from the end, keeping the query and trailing separator", () => {
-    const out = truncatePairTokens(ids, tokenTypeIds, 6);
+    const out = truncatePairTokens(ids, 7);
 
-    expect(out).toHaveLength(6);
-    expect(out.slice(0, 4)).toEqual([101, 11, 12, 102]); // query segment intact
-    expect(out.at(-1)).toBe(102); // trailing [SEP] preserved
-    expect(out).toEqual([101, 11, 12, 102, 21, 102]); // budget: 6 - 4 - 1 = 1 doc token
+    expect(out).toHaveLength(7);
+    expect(out.slice(0, 5)).toEqual([0, 11, 12, 2, 2]); // query segment intact
+    expect(out.at(-1)).toBe(2); // trailing separator preserved
+    expect(out).toEqual([0, 11, 12, 2, 2, 21, 2]);
   });
 
-  it("falls back to a plain head slice when the query alone exceeds the budget", () => {
-    const queryHeavyIds = [101, 11, 12, 13, 14, 102, 21, 102];
-    const queryHeavyTypes = [0, 0, 0, 0, 0, 0, 1, 1];
+  it("keeps a well-formed pair even when the query alone exceeds the budget", () => {
+    expect(truncatePairTokens(ids, 3)).toEqual([0, 11, 2]);
+  });
 
-    expect(truncatePairTokens(queryHeavyIds, queryHeavyTypes, 4)).toEqual([
-      101, 11, 12, 13,
-    ]);
+  it("never exceeds the position-embedding limit the model was built with", () => {
+    const overLong = Array.from({ length: 900 }, (_, index) => index);
+
+    expect(truncatePairTokens(overLong, 512)).toHaveLength(512);
   });
 });

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -10,49 +10,39 @@ const fileName = path.basename(import.meta.url);
 const printMessage = debug(fileName);
 printMessage.enabled = true;
 
-const MODEL_HF_REPO = "jinaai/jina-reranker-v1-tiny-en";
-const MODEL_HF_FILE = "onnx/model.onnx";
+const MODEL_HF_REPO = "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1";
+
+/**
+ * The dynamically quantized export. The repository ships one build per CPU
+ * kernel family (`qint8_arm64`, `qint8_avx512`, `qint8_avx512_vnni`,
+ * `quint8_avx2`) from the same weights; this one is the portable choice, because
+ * unsigned activations sidestep the signed-int8 saturation that x64 without VNNI
+ * has to work around, and it measured no slower than the arm64 build on arm64.
+ * Quantization costs nothing measurable: 0.7992 against 0.7973 nDCG@10 for fp32
+ * on 240 MIRACL queries, for a quarter of the download and half the latency.
+ */
+const MODEL_HF_FILE = "onnx/model_quint8_avx2.onnx";
+
 const TOKENIZER_HF_FILE = "tokenizer.json";
 const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
 
-/** From the model's config.json. */
-const PAD_TOKEN_ID = 0;
+/**
+ * Hard ceiling rather than a tuning knob: the model has 514 learned position
+ * embeddings, two of which XLM-RoBERTa reserves, so a 513-token pair fails
+ * outright with `indices element out of data bounds` at the position-embedding
+ * gather. Still more generous than what shipped before #2260, which cut
+ * documents to 512 characters upstream.
+ */
+const MAX_SEQUENCE_LENGTH = 512;
 
 /**
- * Sequence-length budget for one (query, document) pair, and the single point
- * where truncation happens now that rankSearchResults sends whole documents.
- * jina-reranker-v1-tiny-en is an ALiBi model that handles up to 8192 tokens
- * (verified: the ONNX graph runs at 8192 without error); the `model_max_length`
- * of 512 in tokenizer_config.json is a stale BERT default, not the real limit.
- * 2048 is a deliberate, conservative cap. See #2193.
+ * Only `cpu`. A dynamically quantized graph is the wrong shape for the WebGPU
+ * provider, which has no kernels for the integer matmuls and shuttles every one
+ * of them back to the CPU: 812ms against 172ms for the same work, with scores
+ * drifting by up to 1.15 and reordering results. `coreml` is out for the same
+ * reason it was before, being slower than CPU on dynamic shapes.
  */
-const MAX_SEQUENCE_LENGTH = 2048;
-
-/**
- * onnxruntime-node wraps a synchronous native call, so a single large batch
- * blocks the event loop for its whole duration. Scoring in batches yields
- * between them, capping the stall at ~27ms instead of ~78ms for 30 results,
- * for about 4% more wall time. Scores are unaffected: padding is per batch but
- * the attention mask makes the result identical either way.
- */
-const BATCH_SIZE = 10;
-
-/**
- * ONNX Runtime execution providers to try first. WebGPU is roughly 3x faster
- * than CPU here and agrees with it to within float32 rounding, so it is
- * preferred when available. `coreml` is deliberately absent: it is slower than
- * CPU for this model's dynamic shapes.
- */
-const PREFERRED_EXECUTION_PROVIDERS = ["webgpu", "cpu"];
-
-/**
- * Trailing `cpu` in a provider list is not a fallback chain: ONNX Runtime only
- * falls back per operator, once a provider is registered. A provider that fails
- * to initialize at all (no GPU adapter, or no `libvulkan.so.1` for Dawn to
- * load, as on Hugging Face Spaces) rejects the whole session, so the CPU-only
- * session has to be a second attempt.
- */
-const FALLBACK_EXECUTION_PROVIDERS = ["cpu"];
+const EXECUTION_PROVIDERS = ["cpu"];
 
 let isReady = false;
 let session: InferenceSession | null = null;
@@ -116,13 +106,13 @@ async function ensureFileExists(hfRepoFile: string) {
   return localPath;
 }
 
-function createSession(modelPath: string, executionProviders: string[]) {
+function createSession(modelPath: string) {
   printMessage(
-    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${executionProviders.join(", ")})...`,
+    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${EXECUTION_PROVIDERS.join(", ")})...`,
   );
 
   return InferenceSession.create(modelPath, {
-    executionProviders,
+    executionProviders: EXECUTION_PROVIDERS,
     // Errors only. ONNX Runtime otherwise warns on every startup that it
     // assigned shape operators to CPU, which is expected and not actionable.
     logSeverityLevel: 3,
@@ -143,14 +133,7 @@ export async function startRerankerService() {
     JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
   );
 
-  try {
-    session = await createSession(modelPath, PREFERRED_EXECUTION_PROVIDERS);
-  } catch (error) {
-    printMessage(
-      `Could not load the model with ${PREFERRED_EXECUTION_PROVIDERS.join(", ")}: ${error instanceof Error ? error.message : error}`,
-    );
-    session = await createSession(modelPath, FALLBACK_EXECUTION_PROVIDERS);
-  }
+  session = await createSession(modelPath);
 
   await score("test", ["test document"]);
 
@@ -170,62 +153,49 @@ export async function getRerankerStatus() {
   return isReady;
 }
 
-async function scoreBatch(
+/**
+ * Scores one pair on its own. Documents are deliberately not batched: this graph
+ * quantizes activations dynamically, deriving the scale from each tensor's own
+ * range, and padding rows out to a shared width puts the pad positions inside
+ * that range even though the attention mask excludes them from attention. A
+ * document's score then depends on which documents happen to sit beside it,
+ * which moved logits by up to 1.29 and reordered 2 of 10 fixtures. One pair per
+ * call has no padding to begin with, and it also holds the event loop for 13ms
+ * at a time instead of 50ms, for about 12% more wall time on two threads.
+ */
+async function scoreDocument(
   activeSession: InferenceSession,
-  encodings: number[][],
-) {
-  const paddedLength = Math.max(...encodings.map(({ length }) => length));
-  const inputIds = new BigInt64Array(encodings.length * paddedLength);
-  const attentionMask = new BigInt64Array(encodings.length * paddedLength);
-
-  encodings.forEach((ids, row) => {
-    const offset = row * paddedLength;
-    for (let column = 0; column < paddedLength; column += 1) {
-      const isPadding = column >= ids.length;
-      inputIds[offset + column] = BigInt(
-        isPadding ? PAD_TOKEN_ID : ids[column],
-      );
-      attentionMask[offset + column] = isPadding ? 0n : 1n;
-    }
-  });
-
-  const dimensions = [encodings.length, paddedLength];
+  ids: number[],
+): Promise<number> {
+  const dimensions = [1, ids.length];
   const { logits } = await activeSession.run({
-    input_ids: new Tensor("int64", inputIds, dimensions),
-    attention_mask: new Tensor("int64", attentionMask, dimensions),
+    input_ids: new Tensor("int64", BigInt64Array.from(ids, BigInt), dimensions),
+    attention_mask: new Tensor(
+      "int64",
+      new BigInt64Array(ids.length).fill(1n),
+      dimensions,
+    ),
   });
 
-  return Array.from(logits.data as Float32Array, Number);
+  return Number((logits.data as Float32Array)[0]);
 }
 
 /**
  * Caps an encoded cross-encoder pair at `maxLength` tokens by dropping tokens
- * from the end of the document only. The sequence is `[CLS] query [SEP]
- * document [SEP]`, so the query sits at the front and is preserved, and the
- * trailing separator is kept so the model still receives a well-formed pair.
- * `tokenTypeIds` mark the query segment (0) apart from the document (1). This
- * mirrors the tokenizer's `only_second` truncation, which the JS package does
- * not implement. Falls back to a plain head slice if the query alone already
- * exceeds the budget.
+ * from the end, which is where the document is: the sequence is `<s> query </s>
+ * </s> document </s>`, so the query sits at the front and survives. The final
+ * separator is carried over to the new end so the model still receives a
+ * well-formed pair. This mirrors the tokenizer's `only_second` truncation, which
+ * the JS package does not implement. The query segment is not read off
+ * `token_type_ids`, because XLM-RoBERTa has a `type_vocab_size` of 1 and emits
+ * zeros for the whole sequence.
  */
-export function truncatePairTokens(
-  ids: number[],
-  tokenTypeIds: number[],
-  maxLength: number,
-): number[] {
+export function truncatePairTokens(ids: number[], maxLength: number): number[] {
   if (ids.length <= maxLength) {
     return ids;
   }
 
-  const querySegmentLength = tokenTypeIds.filter((type) => type === 0).length;
-  const documentBudget = maxLength - querySegmentLength - 1;
-
-  if (documentBudget <= 0) {
-    return ids.slice(0, maxLength);
-  }
-
-  const separator = ids[ids.length - 1];
-  return [...ids.slice(0, querySegmentLength + documentBudget), separator];
+  return [...ids.slice(0, maxLength - 1), ids[ids.length - 1]];
 }
 
 /**
@@ -241,22 +211,15 @@ async function score(query: string, documents: string[]) {
   const activeSession = session;
   const loadedTokenizer = tokenizer;
 
-  const encodings = documents.map((document) => {
-    const { ids, token_type_ids } = loadedTokenizer.encode(query, {
-      text_pair: document,
-      return_token_type_ids: true,
-    });
-    return truncatePairTokens(ids, token_type_ids, MAX_SEQUENCE_LENGTH);
-  });
-
   const scores: number[] = [];
 
-  for (let offset = 0; offset < encodings.length; offset += BATCH_SIZE) {
+  for (const document of documents) {
+    const { ids } = loadedTokenizer.encode(query, { text_pair: document });
     scores.push(
-      ...(await scoreBatch(
+      await scoreDocument(
         activeSession,
-        encodings.slice(offset, offset + BATCH_SIZE),
-      )),
+        truncatePairTokens(ids, MAX_SEQUENCE_LENGTH),
+      ),
     );
   }
 

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -35,15 +35,6 @@ const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
  */
 const MAX_SEQUENCE_LENGTH = 512;
 
-/**
- * Only `cpu`. A dynamically quantized graph is the wrong shape for the WebGPU
- * provider, which has no kernels for the integer matmuls and shuttles every one
- * of them back to the CPU: 812ms against 172ms for the same work, with scores
- * drifting by up to 1.15 and reordering results. `coreml` is out for the same
- * reason it was before, being slower than CPU on dynamic shapes.
- */
-const EXECUTION_PROVIDERS = ["cpu"];
-
 let isReady = false;
 let session: InferenceSession | null = null;
 let tokenizer: Tokenizer | null = null;
@@ -106,13 +97,22 @@ async function ensureFileExists(hfRepoFile: string) {
   return localPath;
 }
 
+/**
+ * Runs on the CPU, with nothing to configure. A dynamically quantized graph is
+ * the wrong shape for the WebGPU provider, which has no kernels for the integer
+ * matmuls and shuttles every one of them back to the CPU: 812ms against 172ms
+ * for the same work, with scores drifting by up to 1.15 and reordering results.
+ * `coreml` is out for the same reason it was before, being slower than CPU on
+ * dynamic shapes. The architecture is logged because it selects the quantized
+ * kernel, which is the part that varies between hosts.
+ */
 function createSession(modelPath: string) {
   printMessage(
-    `Loading model (arch: ${process.arch}, platform: ${process.platform}, execution providers: ${EXECUTION_PROVIDERS.join(", ")})...`,
+    `Loading model on CPU (arch: ${process.arch}, platform: ${process.platform})...`,
   );
 
   return InferenceSession.create(modelPath, {
-    executionProviders: EXECUTION_PROVIDERS,
+    executionProviders: ["cpu"],
     // Errors only. ONNX Runtime otherwise warns on every startup that it
     // assigned shape operators to CPU, which is expected and not actionable.
     logSeverityLevel: 3,


### PR DESCRIPTION
## Description

Replaces `jina-reranker-v1-tiny-en` with the int8 export of [cross-encoder/mmarco-mMiniLMv2-L12-H384-v1](https://huggingface.co/cross-encoder/mmarco-mMiniLMv2-L12-H384-v1).

Currently the reranker is an English model, and the docs say it "ranks non-English results (Portuguese, for example) well in practice". Measured, it doesn't: on 240 queries from [mteb/MIRACLReranking](https://huggingface.co/datasets/mteb/MIRACLReranking) across English, Spanish, French, German, Russian and Japanese, it scores 0.4636 nDCG@10 while the un-reranked SearXNG-style first-stage order scores 0.4963. On non-English content it was not adding ranking signal, and part of the mechanism is the tokenizer: an English WordPiece vocabulary spends 2.17x as many tokens on Russian and about 1.4x on Spanish, German and Japanese, so it paid more compute to see worse-fragmented subwords.

| | nDCG@10 (240 MIRACL queries) | ms per 30 docs (10 cores / 2 threads) | Download |
|---|---|---|---|
| First-stage order, no reranking | 0.4963 | - | - |
| jina-reranker-v1-tiny-en fp32 (before) | 0.4636 | 104 / 224 | 132MB |
| mmarco-mMiniLMv2-L12-H384-v1 int8 (after) | **0.7992** | 137 / 202 | 119MB + 17MB tokenizer |

Per language, nDCG@10 goes 0.774 => 0.743 (en), 0.498 => 0.842 (es), 0.351 => 0.777 (fr), 0.370 => 0.774 (de), 0.387 => 0.819 (ru), 0.402 => 0.840 (ja). English regresses slightly; every other language roughly doubles.

### Why the int8 export

The fp32 export of the same model is 471MB and twice the latency for 0.7973 nDCG@10, so quantization costs nothing measurable here. That is the opposite of what `docs/reranking.md` said about the previous model, where the `q8` export did degrade ranking; the loss doesn't carry over to a model with 12 layers and a large embedding table, so I've replaced that claim rather than just deleting it.

Of the four per-kernel builds in the repository, this PR uses `model_quint8_avx2.onnx`. Unsigned activations sidestep the signed-int8 saturation that x64 without VNNI has to work around, and it measured no slower than the arm64 build when run on arm64. `qint8_arm64` and `qint8_avx512` are bit-identical in output and score 0.8039, marginally higher, but that margin is inside the noise of a 240-query set and doesn't buy predictable behavior on hosts whose instruction set we can't know in advance.

Since the file has "avx2" in the name, I checked it on both architectures rather than assuming. Loading it and scoring the same pair gives 7.698 / -9.777 on arm64 macOS and 7.290 / -9.622 on x64 Linux (`node:22-slim`): the same ordering, with the relevant document about 17 above the irrelevant one on both. So the logits do shift by around 0.4 between kernel paths, which is worth knowing, but it is nowhere near the gaps the ranking depends on.

### Documents are now scored one at a time

Dynamic quantization takes each activation tensor's scale from that tensor's own range at runtime. Padding rows out to a shared width puts the pad positions inside that range, and while the attention mask keeps them out of attention it cannot keep them out of the scale, so the quantization of the real tokens shifts. In batches of 10 that moved logits by up to 1.29 at ordinary snippet lengths (33-63 tokens) and reordered 2 of 10 fixtures depending only on which documents shared a batch. The fp32 export of the same model shows a difference of exactly zero, so this is a property of quantization and not of the graph.

Scoring one pair at a time removes the padding and the coupling with it. It also suits the reason batching was added in the first place: the event-loop stall drops to about 13ms instead of the 50ms a batch of 10 takes. The cost is throughput, roughly 12% more wall time for 30 documents on two threads and up to 47% more where there are cores to spare.

### The session is now CPU-only

The WebGPU provider has no kernels for the integer matmuls in a quantized graph. It registers happily and then hands every one of them back to the CPU, paying a round trip each time: 812ms against 172ms for the same work, with scores drifting by up to 1.15 and reordering results. So `["webgpu", "cpu"]` is out, and with it the two-attempt session logic, which existed only to survive a GPU provider failing to initialize.

Since `["cpu"]` is the only thing ever passed, the provider constant went with it: the rationale now lives on `createSession`, and the startup log says "Loading model on CPU" plus the architecture, which is the part that actually varies between hosts (it selects the quantized kernel).

If keeping GPU acceleration matters more than the download size, the fp32 export is the trade: 471MB and 213ms per 30 documents on CPU, at 0.7973 nDCG@10.

### Smaller changes that follow from the model

- `MAX_SEQUENCE_LENGTH` drops from 2048 to 512. That is the model's own limit, not a preference: it has 514 learned position embeddings and XLM-RoBERTa reserves two, so a 513-token pair fails outright with `indices element out of data bounds` at the position-embedding gather. Still more generous than what shipped before #2260, which cut documents to 512 characters upstream.
- `truncatePairTokens` no longer takes `token_type_ids`. XLM-RoBERTa has a `type_vocab_size` of 1 and emits zeros for the whole sequence, so there is no query segment to read off it. The function is now a two-argument slice, and it produces the same output the old one did for every case except a query that fills the budget on its own, where it now keeps the trailing separator.
- `PAD_TOKEN_ID` is gone, since nothing pads anymore.
- `PREFERRED_EXECUTION_PROVIDERS` and `FALLBACK_EXECUTION_PROVIDERS` are gone too, with no constant replacing them. There was never an environment variable for provider selection, so there's nothing to remove on that side.

### Known limitations

- English loses a little, 0.774 => 0.743 nDCG@10.
- Latency measurements are from arm64 (Apple Silicon, 10 cores). The 2-thread column approximates a small host's core count but not the x64 instruction set, so the numbers on Hugging Face Spaces will differ. The x64 run above proves the file loads and ranks correctly there, but it ran under emulation, so it says nothing about x64 speed.
- `check-docker` passes, though that doesn't verify much here: the Playwright smoke test passes whether or not results come back, and it never asserts that the reranker became ready. What it does confirm is that the swap doesn't break container startup.
- The score filter in `rankSearchResults.ts` is documented as calibrated against the reranker's raw logit scale, and this model separates relevant from irrelevant by gaps of 5.7-11.2 where the old one used 0.98-2.59. I checked the filter rather than retuning it: across the 240 queries it keeps a median 18 of 30 results and retains 98.3% of the relevant ones, with the percentage fallback triggering once. It looks healthy on the new scale, so this PR leaves `kStandardDeviationFactor` alone.

## How to test

1. `npm test` (349 tests, includes the rewritten `server/rerankerService.test.ts`).
2. `npx vitest run --config vitest.integration.config.ts`. This downloads ~136MB on first run and asserts that every relevant result outranks every irrelevant one on the four existing fixtures. All four pass, at score gaps of 5.7-11.2.
3. `npm run lint`.
4. `npm run dev`, then search for something non-English (`configurar nginx como proxy reverso`, `cómo revertir el último commit en git`) and check the ordering. First startup downloads the model, so give it a moment before the first search.

This branch is rebased on top of [#2313](https://github.com/felladrin/MiniSearch/pull/2313), which unblocked the `Lint Dockerfile` step. Before that, the step short-circuited the job and CI never reached `Check formatting` or `Run tests` on any PR.

The reranking measurements come from a harness outside the repository: 240 MIRACL queries with a 30-candidate window per query, plus 10 web-snippet fixtures whose first four are copied verbatim from the integration test, so the harness could be checked against labels that were already in the repo before comparing models. Happy to push that harness somewhere if it's worth keeping.
