### PR TITLE
Fix CI: ignore hadolint DL3066 for the named user in the Dockerfile

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -6,3 +6,5 @@ ignored:
   - DL3008
   - SC2046
   - DL3025
+  # We run as the named `node` user that the base image already provides, by design.
+  - DL3066


### PR DESCRIPTION
## Description

Currently, CI is red on `main`, and it blocks every open PR from going green. The `Lint Dockerfile` step fails with `Dockerfile:43 DL3066 info: Non-numeric user-id may not be resolvable by host system`, pointing at `USER ${USERNAME}`.

This PR adds `DL3066` to the ignore list in `.hadolint.yaml`. The image runs as the named `node` user that the `node` base image already provides, so the non-numeric user-id resolves inside the container. That's by design, not something to fix in the Dockerfile.

### Root cause

[#2311](https://github.com/felladrin/MiniSearch/pull/2311) bumped `hadolint/hadolint-action` to v3.4.0, which pins `hadolint:v2.15.0-debian`. That version reports DL3066 where the previous one did not. The action's default `failure-threshold` is `info`, so an info-level finding is enough to fail the job. [#2310](https://github.com/felladrin/MiniSearch/pull/2310), the commit right before it, has a green run, which confirms the bump is what changed.

The step also short-circuits the rest of the job: `Check formatting` and `Run tests` are skipped when the Dockerfile lint fails, so no PR gets its tests run in CI until this lands.

### Why the ignore, and not a higher threshold

Raising `failure-threshold` above `info` would also fix the red build, but it would stop info-level findings from blocking anything else, for a single rule we disagree with. The ignore entry is narrower.

By the way, this rule looks like it was short-lived upstream: hadolint 2.15.1 no longer reports DL3066 on this Dockerfile, only 2.15.0 does. So a future action bump may make the entry unnecessary. It's harmless to keep either way, and I'd rather not wait on a release we don't control.

## How to test

1. Check out the branch and run hadolint with the exact image the action pins:

```bash
docker run --rm -i -v "$PWD/.hadolint.yaml":/.hadolint.yaml ghcr.io/hadolint/hadolint:v2.15.0-debian hadolint --config /.hadolint.yaml --failure-threshold info - < Dockerfile
```

It exits `0`. On `main` the same command reports DL3066 and exits `1`.

2. Confirm the ignore list is still narrow (other rules keep firing at the same threshold):

```bash
printf 'FROM node:lts\nRUN cd /tmp\n' | docker run --rm -i -v "$PWD/.hadolint.yaml":/.hadolint.yaml ghcr.io/hadolint/hadolint:v2.15.0-debian hadolint --config /.hadolint.yaml --failure-threshold info -
```

It reports DL3003 and SC2164, and exits `1`.

3. Run the two steps that were being skipped: `npm run format:check` passes (172 files, no fixes applied), and `npm run test:coverage` passes (40 test files, 349 tests).

Note: `npm run lint` exits `1` on my machine, on `main` too, from a knip "Unlisted binaries: playwright" report. It's a local environment difference, not from this change; the `Run lint` step passed in CI on the failing run.
