### PR TITLE
Hold back npm packages published in the last three days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps = true
+min-release-age = 3


### PR DESCRIPTION
Adds `min-release-age = 3` to `.npmrc`, so `npm install` will not resolve a package version that went public less than three days ago. Most compromised releases are caught within hours of publication, so a short delay filters that class out before it ever reaches the lockfile.

This complements Renovate rather than replacing it. Renovate's window applies to the version it proposes in a PR; this one also covers the transitive packages the resolver pulls in underneath, and it applies the same rule on my machine and inside Docker builds.

`npm ci` is deliberately unaffected: it installs exactly what `package-lock.json` pins and skips the filter. Every install path in this repo is `npm ci` (`.github/workflows/ci.yml`, `.github/workflows/reusable-check-docker.yml` and the `Dockerfile`), so CI and image builds behave exactly as before.

## How to test

1. Run `npm ci`. It completes as usual, because the window does not apply to lockfile installs.
2. Run `npm install <package>@latest` for something published in the last day or two. npm resolves an older version, or errors with `ETARGET` when no older version exists.
3. If a package ever needs to bypass the window, add it to `min-release-age-exclude`.
