### PR TITLE
Scale the default CPU thread count with the machine

### DIFF
--- a/client/modules/settings.test.ts
+++ b/client/modules/settings.test.ts
@@ -3,6 +3,7 @@ import type { ServerConfig } from "./config";
 import {
   applyServerConfig,
   defaultSettings,
+  getDefaultCpuThreads,
   getInferenceTypes,
 } from "./settings";
 
@@ -22,6 +23,34 @@ describe("Settings Module", () => {
     expect(defaultSettings.enableImageSearch).toBe(true);
     expect(defaultSettings.searchResultsLimit).toBe(15);
     expect(defaultSettings.inferenceType).toBeDefined();
+  });
+
+  describe("getDefaultCpuThreads", () => {
+    it("should always leave at least one thread on tiny machines", () => {
+      expect(getDefaultCpuThreads(1)).toBe(1);
+      expect(getDefaultCpuThreads(2)).toBe(1);
+    });
+
+    it("should scale with the machine instead of using a fixed ceiling", () => {
+      expect(getDefaultCpuThreads(4)).toBe(2);
+      expect(getDefaultCpuThreads(8)).toBe(4);
+      expect(getDefaultCpuThreads(16)).toBe(8);
+      expect(getDefaultCpuThreads(32)).toBe(16);
+      expect(getDefaultCpuThreads(128)).toBe(64);
+    });
+
+    it("should round down on an odd processor count", () => {
+      expect(getDefaultCpuThreads(3)).toBe(1);
+      expect(getDefaultCpuThreads(9)).toBe(4);
+    });
+
+    it("should never oversubscribe the logical processors", () => {
+      for (const cores of [1, 2, 3, 4, 8, 12, 16, 24, 32, 64, 256]) {
+        expect(getDefaultCpuThreads(cores)).toBeLessThanOrEqual(
+          Math.max(1, Math.floor(cores / 2)),
+        );
+      }
+    });
   });
 
   it("should include core inference types", () => {

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -17,6 +17,18 @@ export const hasStoredUserSettings =
   localStorage.getItem(SETTINGS_STORAGE_KEY) !== null;
 
 /**
+ * `navigator.hardwareConcurrency` reports logical processors, so half of it
+ * approximates the physical core count on the SMT CPUs most users have.
+ * wllama's throughput peaks there and degrades past it: on a 16-core/32-thread
+ * machine, 30 threads generated 3.5x slower than 16 and used 39% more memory.
+ */
+export function getDefaultCpuThreads(
+  hardwareConcurrency: number = navigator.hardwareConcurrency ?? 1,
+): number {
+  return Math.max(1, Math.floor(hardwareConcurrency / 2));
+}
+
+/**
  * Default application settings configuration.
  * Runtime server config is merged in via `applyServerConfig()` after
  * /api/config is fetched.
@@ -26,7 +38,7 @@ export const defaultSettings = {
   enableAiResponse: false,
   enableImageSearch: true,
   wllamaModelId: DEFAULT_WLLAMA_MODEL_ID,
-  cpuThreads: Math.max(1, (navigator.hardwareConcurrency ?? 1) - 2),
+  cpuThreads: getDefaultCpuThreads(),
   searchResultsLimit: 15,
   systemPrompt: `Answer using the search results below as your primary source, supplemented by your own knowledge when needed. Write your response in the same language as the query.
 


### PR DESCRIPTION
## Description

Currently, `cpuThreads` defaults to `hardwareConcurrency - 2`, which oversubscribes on anything but a small machine. `navigator.hardwareConcurrency` reports logical processors, so half of it approximates the physical core count on the SMT CPUs most users have, and that is where wllama's throughput peaks.

Measured on a 16-core/32-thread box, in Chromium, with SmolLM2-135M Q4_K_M, a 660-token prompt and the WASM CPU backend (`n_gpu_layers: 0`), reading wllama's own `timings` and peak RSS across the browser process tree:

| threads | prompt tok/s | generation tok/s | peak RSS |
| ------- | ------------ | ---------------- | -------- |
| 6 | 59.8 | 34.9 | 999 MB |
| 14 | 81.4 | 47.5 | 1008 MB |
| 16 | 68.3 | 57.5 | 1106 MB |
| 22 | 67.7 | 34.0 | 1073 MB |
| 30 | 53.7 | 16.5 | 1535 MB |

The peak sits at 16, the physical core count. At 30 threads (what this machine gets today) generation is about 3.5x slower and peak memory is ~39% higher. In a separate run where `n_threads` matched `hardwareConcurrency` exactly, leaving no core for the main thread, it degraded much further, to 0.43 tok/s.

The default now scales with the machine rather than using a fixed number, so it lands on the physical core count at any size:

| logical processors | before | after |
| ------------------ | ------ | ----- |
| 2 | 1 | 1 |
| 4 | 2 | 2 |
| 8 | 6 | 4 |
| 16 | 14 | 8 |
| 32 | 30 | 16 |

The setting stays user-editable, so anyone who wants more threads can still raise it. The input description already warned that "a value that is too high may cause the app to hang"; this stops the default from being that value.

The thread count now lives in `getDefaultCpuThreads()` so it can be tested without stubbing `navigator`.

## How to test

1. Run `npx vitest run client/modules/settings.test.ts`. The new `getDefaultCpuThreads` tests cover the scaling, the rounding on an odd processor count, and the "never oversubscribe" invariant.
2. Clear the `settings` key from localStorage, reload, and open Menu => AI Settings. "CPU threads to use" should read half your logical processor count (the value `navigator.hardwareConcurrency` reports in the console).

Note: the benchmark numbers come from a standalone Playwright harness rather than from this repository, so they are not reproducible from a script here. The regression is measurable in the app by setting `cpuThreads` to `hardwareConcurrency - 2` and then to half, on a machine with many cores, and comparing generation speed.

Only the measurements at 16 and 30 threads were repeated; the other rows are single runs, and the machine was not fully idle.
