### PR TITLE
fix: reduce result animation delay

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -1,9 +1,17 @@
 import { MantineProvider } from "@mantine/core";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ImageSearchResult } from "@/modules/types";
+import {
+  resetReducedMotionPreference,
+  setReducedMotionPreference,
+} from "../testUtils";
 import ImageResultsList from "./ImageResultsList";
+
+afterEach(() => {
+  resetReducedMotionPreference();
+});
 
 const imageResults: ImageSearchResult[] = [
   [
@@ -19,6 +27,16 @@ const imageResults: ImageSearchResult[] = [
     "https://source.example.com/second",
   ],
 ];
+
+const manyImageResults: ImageSearchResult[] = Array.from(
+  { length: 6 },
+  (_, index) => [
+    `Image ${index + 1}`,
+    `https://example.com/${index + 1}`,
+    `https://example.com/${index + 1}.jpg`,
+    `https://source.example.com/${index + 1}`,
+  ],
+);
 
 function renderImageResultsList() {
   return render(
@@ -62,5 +80,37 @@ describe("ImageResultsList", () => {
     expect(
       dialog.querySelector(".yarl__slide_current img")?.getAttribute("alt"),
     ).toBe("Second image");
+  });
+
+  it("does not leave later results waiting behind a long stagger", async () => {
+    render(
+      <MantineProvider>
+        <ImageResultsList imageResults={manyImageResults} />
+      </MantineProvider>,
+    );
+
+    await screen.findByRole("button", {
+      name: "Open image preview: Image 6",
+    });
+  });
+
+  it("skips the animation when reduced motion is preferred", async () => {
+    setReducedMotionPreference(true);
+
+    render(
+      <MantineProvider>
+        <ImageResultsList imageResults={manyImageResults} />
+      </MantineProvider>,
+    );
+
+    const imageButton = await screen.findByRole("button", {
+      name: "Open image preview: Image 6",
+    });
+    const slideStyle = imageButton
+      .closest('[role="group"]')
+      ?.getAttribute("style");
+
+    expect(slideStyle ?? "").not.toContain("transition-property");
+    expect(slideStyle ?? "").not.toContain("transition-duration");
   });
 });

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -8,6 +8,7 @@ import {
   Transition,
   UnstyledButton,
 } from "@mantine/core";
+import { useReducedMotion } from "@mantine/hooks";
 import { useEffect, useState } from "react";
 import type { ImageSearchResult } from "@/modules/types";
 import "@mantine/carousel/styles.css";
@@ -30,6 +31,7 @@ export default function ImageResultsList({
 }: {
   imageResults: ImageSearchResult[];
 }) {
+  const shouldReduceMotion = useReducedMotion();
   const [state, setState] = useState<ImageResultsState>({
     isLightboxOpen: false,
     lightboxIndex: 0,
@@ -74,8 +76,8 @@ export default function ImageResultsList({
             mounted={state.canStartTransition}
             transition="fade"
             timingFunction="ease"
-            enterDelay={index * 250}
-            duration={1500}
+            enterDelay={shouldReduceMotion ? 0 : Math.min(index, 5) * 40}
+            duration={shouldReduceMotion ? 0 : 250}
           >
             {(styles) => (
               <Carousel.Slide style={styles}>

--- a/client/components/Search/Results/Textual/SearchResultsList.test.tsx
+++ b/client/components/Search/Results/Textual/SearchResultsList.test.tsx
@@ -1,13 +1,30 @@
 import { MantineProvider } from "@mantine/core";
 import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach } from "vitest";
 import type { TextSearchResult } from "@/modules/types";
+import {
+  resetReducedMotionPreference,
+  setReducedMotionPreference,
+} from "../testUtils";
 import SearchResultsList from "./SearchResultsList";
+
+afterEach(() => {
+  resetReducedMotionPreference();
+});
 
 describe("SearchResultsList", () => {
   const mockResults: TextSearchResult[] = [
     ["First Title", "First snippet text", "https://example.com/first"],
     ["Second Title", "Second snippet text", "https://example.com/second"],
   ];
+  const manyResults: TextSearchResult[] = Array.from(
+    { length: 6 },
+    (_, index) => [
+      `Result ${index + 1}`,
+      `Snippet ${index + 1}`,
+      `https://example.com/result-${index + 1}`,
+    ],
+  );
 
   it("renders a list of results after transition", async () => {
     render(
@@ -41,6 +58,41 @@ describe("SearchResultsList", () => {
       },
       { timeout: 2000 },
     );
+  });
+
+  it("does not leave later results waiting behind a long stagger", async () => {
+    render(
+      <MantineProvider>
+        <SearchResultsList searchResults={manyResults} />
+      </MantineProvider>,
+    );
+
+    await waitFor(
+      () => expect(screen.getByText("Result 6")).toBeInTheDocument(),
+      {
+        timeout: 1000,
+      },
+    );
+  });
+
+  it("skips the animation when reduced motion is preferred", async () => {
+    setReducedMotionPreference(true);
+
+    render(
+      <MantineProvider>
+        <SearchResultsList searchResults={manyResults} />
+      </MantineProvider>,
+    );
+
+    const resultTitle = await waitFor(() => screen.getByText("Result 6"), {
+      timeout: 1000,
+    });
+    const resultStyle = resultTitle
+      .closest(".mantine-Stack-root")
+      ?.getAttribute("style");
+
+    expect(resultStyle ?? "").not.toContain("transition-property");
+    expect(resultStyle ?? "").not.toContain("transition-duration");
   });
 
   it("renders links with correct href", async () => {

--- a/client/components/Search/Results/Textual/SearchResultsList.tsx
+++ b/client/components/Search/Results/Textual/SearchResultsList.tsx
@@ -8,7 +8,7 @@ import {
   Transition,
   UnstyledButton,
 } from "@mantine/core";
-import { useMediaQuery } from "@mantine/hooks";
+import { useMediaQuery, useReducedMotion } from "@mantine/hooks";
 import { useEffect, useState } from "react";
 import { addLogEntry } from "@/modules/logEntries";
 import { getHostname } from "@/modules/stringFormatters";
@@ -22,6 +22,7 @@ export default function SearchResultsList({
   const shouldDisplayDomainBelowTitle = useMediaQuery(
     `(max-width: ${em(720)})`,
   );
+  const shouldReduceMotion = useReducedMotion();
   const [canStartTransition, setCanStartTransition] = useState(false);
 
   useEffect(() => {
@@ -36,8 +37,8 @@ export default function SearchResultsList({
           mounted={canStartTransition}
           transition="fade"
           timingFunction="ease"
-          enterDelay={index * 200}
-          duration={750}
+          enterDelay={shouldReduceMotion ? 0 : Math.min(index, 5) * 40}
+          duration={shouldReduceMotion ? 0 : 250}
         >
           {(styles) => (
             <Stack gap={16} style={styles}>

--- a/client/components/Search/Results/testUtils.ts
+++ b/client/components/Search/Results/testUtils.ts
@@ -1,0 +1,25 @@
+import { vi } from "vitest";
+
+function mockReducedMotionPreference(matches: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation(
+    (query) =>
+      ({
+        matches: matches && query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as MediaQueryList,
+  );
+}
+
+export function setReducedMotionPreference(matches: boolean) {
+  mockReducedMotionPreference(matches);
+}
+
+export function resetReducedMotionPreference() {
+  mockReducedMotionPreference(false);
+}

--- a/client/components/Search/Results/testUtils.ts
+++ b/client/components/Search/Results/testUtils.ts
@@ -16,10 +16,16 @@ function mockReducedMotionPreference(matches: boolean) {
   );
 }
 
+/**
+ * Set the reduced-motion media query result for component tests.
+ */
 export function setReducedMotionPreference(matches: boolean) {
   mockReducedMotionPreference(matches);
 }
 
+/**
+ * Restore the default reduced-motion media query result for component tests.
+ */
 export function resetReducedMotionPreference() {
   mockReducedMotionPreference(false);
 }


### PR DESCRIPTION
## Description  Closes #2185.  Search and image results no longer make later items wait behind a long staggered fade-in. The transition now caps the stagger at five 40 ms steps and uses a 250 ms fade, so the result list finishes entering within roughly 450 ms instead of several seconds. Both result lists also respect `prefers-reduced-motion` by disabling the transition delay and duration.  ## How to test  - `node node_modules/vitest/vitest.mjs run` — 40 files, 357 tests passed. - `node node_modules/@biomejs/biome/bin/biome check client/components/Search/Results/Graphical/ImageResultsList.tsx client/components/Search/Results/Graphical/ImageResultsList.test.tsx client/components/Search/Results/Textual/SearchResultsList.tsx client/components/Search/Results/Textual/SearchResultsList.test.tsx client/components/Search/Results/testUtils.ts` — passed. - `node node_modules/typescript/bin/tsc --noEmit` — passed. - `node node_modules/vite/bin/vite.js build` — passed.  The repository's npm-based pre-commit and lint scripts could not run locally because `npm` is not available in the shell. The direct checks above were run with the bundled Node runtime. The full repository TypeScript check still reports existing `debug` declaration errors in three server files, and the architectural linter still reports existing server-side external API findings; neither is in the changed files.  ## Screenshots  Not applicable; this change affects transition timing and reduced-motion behavior. 

## AI assistance

AI assistance was used for repository research, implementation, and test drafting. The diff and validation results are documented here for maintainer review.