### PR TITLE
Harden the result animation tests against silent no-ops

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -3,14 +3,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ImageSearchResult } from "@/modules/types";
-import {
-  resetReducedMotionPreference,
-  setReducedMotionPreference,
-} from "../testUtils";
+import { setReducedMotionPreference } from "../testUtils";
 import ImageResultsList from "./ImageResultsList";
 
 afterEach(() => {
-  resetReducedMotionPreference();
+  setReducedMotionPreference(false);
 });
 
 const imageResults: ImageSearchResult[] = [
@@ -28,8 +25,10 @@ const imageResults: ImageSearchResult[] = [
   ],
 ];
 
+// Mirrors the default `searchResultsLimit`, so a reintroduced per-index
+// stagger pushes the last thumbnail far past the timeouts asserted below.
 const manyImageResults: ImageSearchResult[] = Array.from(
-  { length: 6 },
+  { length: 15 },
   (_, index) => [
     `Image ${index + 1}`,
     `https://example.com/${index + 1}`,
@@ -37,6 +36,7 @@ const manyImageResults: ImageSearchResult[] = Array.from(
     `https://source.example.com/${index + 1}`,
   ],
 );
+const lastImageButtonName = "Open image preview: Image 15";
 
 function renderImageResultsList() {
   return render(
@@ -89,9 +89,7 @@ describe("ImageResultsList", () => {
       </MantineProvider>,
     );
 
-    await screen.findByRole("button", {
-      name: "Open image preview: Image 6",
-    });
+    await screen.findByRole("button", { name: lastImageButtonName });
   });
 
   it("skips the animation when reduced motion is preferred", async () => {
@@ -104,13 +102,11 @@ describe("ImageResultsList", () => {
     );
 
     const imageButton = await screen.findByRole("button", {
-      name: "Open image preview: Image 6",
+      name: lastImageButtonName,
     });
-    const slideStyle = imageButton
-      .closest('[role="group"]')
-      ?.getAttribute("style");
+    const slide = imageButton.closest('[role="group"]');
 
-    expect(slideStyle ?? "").not.toContain("transition-property");
-    expect(slideStyle ?? "").not.toContain("transition-duration");
+    expect(slide).toBeInTheDocument();
+    expect(slide?.getAttribute("style") ?? "").not.toContain("transition");
   });
 });

--- a/client/components/Search/Results/Textual/SearchResultsList.test.tsx
+++ b/client/components/Search/Results/Textual/SearchResultsList.test.tsx
@@ -2,14 +2,11 @@ import { MantineProvider } from "@mantine/core";
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach } from "vitest";
 import type { TextSearchResult } from "@/modules/types";
-import {
-  resetReducedMotionPreference,
-  setReducedMotionPreference,
-} from "../testUtils";
+import { setReducedMotionPreference } from "../testUtils";
 import SearchResultsList from "./SearchResultsList";
 
 afterEach(() => {
-  resetReducedMotionPreference();
+  setReducedMotionPreference(false);
 });
 
 describe("SearchResultsList", () => {
@@ -17,14 +14,17 @@ describe("SearchResultsList", () => {
     ["First Title", "First snippet text", "https://example.com/first"],
     ["Second Title", "Second snippet text", "https://example.com/second"],
   ];
+  // Mirrors the default `searchResultsLimit`, so a reintroduced per-index
+  // stagger pushes the last result far past the timeouts asserted below.
   const manyResults: TextSearchResult[] = Array.from(
-    { length: 6 },
+    { length: 15 },
     (_, index) => [
       `Result ${index + 1}`,
       `Snippet ${index + 1}`,
       `https://example.com/result-${index + 1}`,
     ],
   );
+  const lastResultTitle = "Result 15";
 
   it("renders a list of results after transition", async () => {
     render(
@@ -68,7 +68,7 @@ describe("SearchResultsList", () => {
     );
 
     await waitFor(
-      () => expect(screen.getByText("Result 6")).toBeInTheDocument(),
+      () => expect(screen.getByText(lastResultTitle)).toBeInTheDocument(),
       {
         timeout: 1000,
       },
@@ -84,15 +84,15 @@ describe("SearchResultsList", () => {
       </MantineProvider>,
     );
 
-    const resultTitle = await waitFor(() => screen.getByText("Result 6"), {
+    const resultTitle = await waitFor(() => screen.getByText(lastResultTitle), {
       timeout: 1000,
     });
-    const resultStyle = resultTitle
-      .closest(".mantine-Stack-root")
-      ?.getAttribute("style");
+    const resultStack = resultTitle.closest(".mantine-Stack-root");
 
-    expect(resultStyle ?? "").not.toContain("transition-property");
-    expect(resultStyle ?? "").not.toContain("transition-duration");
+    expect(resultStack).toBeInTheDocument();
+    expect(resultStack?.getAttribute("style") ?? "").not.toContain(
+      "transition",
+    );
   });
 
   it("renders links with correct href", async () => {

--- a/client/components/Search/Results/testUtils.ts
+++ b/client/components/Search/Results/testUtils.ts
@@ -1,6 +1,11 @@
 import { vi } from "vitest";
 
-function mockReducedMotionPreference(matches: boolean) {
+/**
+ * Overrides the global `matchMedia` mock from `setupTests.ts`. Only
+ * `(prefers-reduced-motion: reduce)` reports a match, so the other media
+ * queries the result components rely on keep returning false.
+ */
+export function setReducedMotionPreference(matches: boolean) {
   vi.mocked(window.matchMedia).mockImplementation(
     (query) =>
       ({
@@ -14,18 +19,4 @@ function mockReducedMotionPreference(matches: boolean) {
         dispatchEvent: vi.fn(),
       }) as MediaQueryList,
   );
-}
-
-/**
- * Set the reduced-motion media query result for component tests.
- */
-export function setReducedMotionPreference(matches: boolean) {
-  mockReducedMotionPreference(matches);
-}
-
-/**
- * Restore the default reduced-motion media query result for component tests.
- */
-export function resetReducedMotionPreference() {
-  mockReducedMotionPreference(false);
 }


### PR DESCRIPTION
Hardens the reduced-motion and stagger tests added in #2324. They pass today, but two of them can stop testing anything without ever failing.

The reduced-motion tests read the transition styles through `closest(...)?.getAttribute("style")` and compare with `?? ""`. If the selector stops matching (a Mantine class rename, or `Carousel.Slide` no longer carrying `role="group"`), `closest` returns null, the `?? ""` turns that into an empty string, and both assertions pass. I checked it on `main`: renaming the selectors to `.mantine-Stack-root-renamed` and `[role="grouped"]` leaves all 15 tests green. So both tests now assert the wrapper was found before reading its style, and a single `not.toContain("transition")` replaces the two narrower checks.

The stagger tests used 6 results, which put the old timing's last item at exactly 1000ms against a 1000ms timeout. They now use 15 (the default `searchResultsLimit`), so the old timing would need 2800ms for the text list and 3500ms for the carousel.

By the way, `testUtils.ts` had two exported wrappers plus a private function for what is a single call, so `setReducedMotionPreference` is now the only export and `afterEach` calls it with `false`.

## How to test

1. `npm test` (357 tests pass).
2. `npm run lint` (exits 0). The architectural linter wants a TSDoc block in any file with exports, so the doc comment in `testUtils.ts` stays, now describing what the mock actually overrides instead of restating the function name.
3. To confirm the tests still catch the original slow-stagger bug, put the old timing back and re-run them:

```
git checkout 6b89c13^ -- client/components/Search/Results/Textual/SearchResultsList.tsx client/components/Search/Results/Graphical/ImageResultsList.tsx
npx vitest run client/components/Search/Results
```

Four tests fail, each giving up after ~1010ms.
