### PR TITLE
Add failure-injection and graceful-degradation tests

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -35,6 +35,7 @@ This is your navigation hub. Start here, follow the links, and return when you n
 
 ### Development
 - **`docs/development-commands.md`** - Docker, npm, and testing commands
+- **`docs/failure-injection.md`** - Graceful-degradation test matrix
 - **`docs/coding-conventions.md`** - Style guide and patterns
 - **`docs/pull-requests.md`** - PR process and merge philosophy
 - **`docs/core-technologies.md`** - Technology stack and dependencies

--- a/client/modules/textGeneration.degradation.test.ts
+++ b/client/modules/textGeneration.degradation.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  const state = {
+    query: "",
+    response: "",
+    textGenerationState: "idle",
+    textSearchState: "idle",
+    textSearchResults: [] as unknown[],
+    searchPromise: Promise.resolve({}) as Promise<unknown>,
+    settings: {
+      inferenceType: "internal",
+      enableAiResponse: false,
+      enableTextSearch: true,
+      enableImageSearch: false,
+      enableNotificationOnAiComplete: false,
+      allowAiModelDownload: true,
+      searchResultsLimit: 10,
+    },
+  };
+
+  return {
+    state,
+    stateTransitions: [] as string[],
+    /** Lets a test drive a mid-stream interruption from a response update. */
+    onResponseUpdate: { current: (_value: string) => {} },
+  };
+});
+
+vi.mock("./pubSub", () => ({
+  getConversationSummary: () => ({ conversationId: "", summary: "" }),
+  getQuery: () => harness.state.query,
+  getResponse: () => harness.state.response,
+  getSettings: () => harness.state.settings,
+  getTextGenerationState: () => harness.state.textGenerationState,
+  listenToSettingsChanges: vi.fn(),
+  updateChatMessages: vi.fn(),
+  updateConversationSummary: vi.fn(),
+  updateImageSearchResults: vi.fn(),
+  updateImageSearchState: vi.fn(),
+  updateLlmTextSearchResults: vi.fn(),
+  updateResponse: (value: string) => {
+    harness.state.response = value;
+    harness.onResponseUpdate.current(value);
+  },
+  updateSearchPromise: (promise: Promise<unknown>) => {
+    harness.state.searchPromise = promise;
+  },
+  updateTextGenerationState: (value: string) => {
+    harness.state.textGenerationState = value;
+    harness.stateTransitions.push(value);
+  },
+  updateTextSearchResults: (results: unknown[]) => {
+    harness.state.textSearchResults = results;
+  },
+  updateTextSearchState: (value: string) => {
+    harness.state.textSearchState = value;
+  },
+}));
+
+vi.mock("./history", () => ({
+  getCurrentSearchRunId: vi.fn(() => "run-1"),
+  saveLlmResponseForQuery: vi.fn(() => Promise.resolve()),
+  updateSearchResults: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("./logEntries", () => ({ addLogEntry: vi.fn() }));
+
+vi.mock("./notifications", () => ({ showAiCompleteNotification: vi.fn() }));
+
+vi.mock("./search", () => ({
+  searchImages: vi.fn(() => Promise.resolve([])),
+  searchText: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("./searchTokenHash", () => ({
+  getSearchTokenHash: vi.fn().mockResolvedValue("mock-token"),
+}));
+
+vi.mock("./systemPrompt", () => ({
+  getSystemPrompt: vi.fn(() => "system prompt"),
+}));
+
+vi.mock("./textGenerationUtilities", () => ({
+  ChatGenerationError: class ChatGenerationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "ChatGenerationError";
+    }
+  },
+  canStartResponding: vi.fn().mockResolvedValue(undefined),
+  defaultContextSize: 4096,
+  getDefaultChatCompletionCreateParamsStreaming: vi.fn(() => ({
+    max_tokens: 1000,
+  })),
+  getFormattedSearchResults: vi.fn(() => "None."),
+  searchResultsToConsider: 6,
+}));
+
+vi.mock("gpt-tokenizer", () => ({
+  default: { encode: vi.fn(() => [1, 2, 3]) },
+}));
+
+import { saveLlmResponseForQuery } from "./history";
+import { searchText } from "./search";
+import { searchAndRespond } from "./textGeneration";
+import type { TextSearchResults } from "./types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function sseStream(frames: string[]) {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(encoder.encode(frame));
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+function contentFrame(content: string) {
+  return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n`;
+}
+
+describe("search degradation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.state.query = "which programming language should beginners learn";
+    harness.state.response = "";
+    harness.state.textGenerationState = "idle";
+    harness.state.textSearchState = "idle";
+    harness.state.textSearchResults = [];
+    harness.state.settings.enableAiResponse = false;
+    harness.state.settings.enableTextSearch = true;
+    harness.stateTransitions.length = 0;
+    harness.onResponseUpdate.current = () => {};
+  });
+
+  it("falls back to a keyword-only query when the first search comes back empty", async () => {
+    const fallbackResults: TextSearchResults = [
+      ["Beginner languages", "A snippet", "https://example.com"],
+    ];
+    vi.mocked(searchText)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(fallbackResults);
+
+    await searchAndRespond();
+    await harness.state.searchPromise;
+
+    expect(searchText).toHaveBeenCalledTimes(2);
+    const [firstQuery] = vi.mocked(searchText).mock.calls[0];
+    const [fallbackQuery] = vi.mocked(searchText).mock.calls[1];
+    expect(firstQuery).toBe(harness.state.query);
+    expect(fallbackQuery).not.toBe(harness.state.query);
+    expect(fallbackQuery.split(" ").length).toBeLessThan(
+      harness.state.query.split(" ").length,
+    );
+    expect(harness.state.textSearchResults).toEqual(fallbackResults);
+    expect(harness.state.textSearchState).toBe("completed");
+  });
+
+  it("reports the text search as failed when the keyword fallback is also empty", async () => {
+    vi.mocked(searchText).mockResolvedValue([]);
+
+    await searchAndRespond();
+    await harness.state.searchPromise;
+
+    expect(searchText).toHaveBeenCalledTimes(2);
+    expect(harness.state.textSearchResults).toEqual([]);
+    expect(harness.state.textSearchState).toBe("failed");
+  });
+});
+
+describe("inference degradation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.state.query = "test query";
+    harness.state.response = "";
+    harness.state.textGenerationState = "idle";
+    harness.state.settings.enableAiResponse = true;
+    harness.state.settings.enableTextSearch = false;
+    harness.stateTransitions.length = 0;
+    harness.onResponseUpdate.current = () => {};
+  });
+
+  it("ends in a failed state when /inference answers 503", async () => {
+    mockFetch.mockResolvedValue(new Response(null, { status: 503 }));
+
+    await searchAndRespond();
+
+    expect(harness.state.textGenerationState).toBe("failed");
+    expect(harness.stateTransitions).not.toContain("completed");
+    expect(harness.state.response).toBe("");
+    expect(saveLlmResponseForQuery).not.toHaveBeenCalled();
+  });
+
+  it("keeps the partial answer when the stream is aborted mid-generation", async () => {
+    mockFetch.mockResolvedValue(
+      sseStream([
+        contentFrame("Partial "),
+        contentFrame("answer"),
+        contentFrame(" that never arrives"),
+        "data: [DONE]\n",
+      ]),
+    );
+    harness.onResponseUpdate.current = (value: string) => {
+      if (value === "Partial answer") {
+        harness.state.textGenerationState = "interrupted";
+      }
+    };
+
+    await searchAndRespond();
+
+    expect(harness.state.response).toBe("Partial answer");
+    expect(harness.state.textGenerationState).toBe("interrupted");
+    expect(harness.stateTransitions).not.toContain("failed");
+    expect(harness.stateTransitions).not.toContain("completed");
+  });
+});

--- a/docs/development-commands.md
+++ b/docs/development-commands.md
@@ -19,6 +19,8 @@
 - **`docker compose exec development-server npm run test:watch`**: Run tests in watch mode
 - **`docker compose exec development-server npm run test:coverage`**: Run tests with coverage report
 
+Failure-injection cases (dependency down, empty results, aborted stream) are catalogued in `docs/failure-injection.md`.
+
 ### Coverage Reports for AI Analysis
 
 After running `test:coverage`, AI agents can analyze these JSON files:

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -1,0 +1,63 @@
+# Failure Injection & Graceful Degradation
+
+The suite exercises happy paths in the modules' own test files. This page maps
+the complementary set: what MiniSearch does when a dependency misbehaves. Every
+row is a Vitest case with the failure injected through a mocked `fetch`, a mocked
+upstream stream, or an injected circuit breaker, so no external service is
+needed.
+
+## Degradation Matrix
+
+| Failure injected | Expected degradation | Where it is pinned |
+|---|---|---|
+| SearXNG answers 500 once, then recovers | Retried with exponential backoff, results returned | `server/webSearchService.test.ts` › retry logic |
+| SearXNG answers 500 on every attempt | Retry cycle exhausts (4 requests) and costs a single circuit-breaker failure | `server/webSearchService.test.ts` › graceful degradation |
+| SearXNG fails five cycles in a row | Circuit opens; further searches short-circuit without calling the upstream | `server/webSearchService.test.ts` › graceful degradation |
+| SearXNG recovers after the reset timeout | One healthy response closes the circuit again | `server/webSearchService.test.ts` › graceful degradation |
+| SearXNG answers 200 with a non-JSON body | Empty result set, no throw | `server/webSearchService.test.ts` › graceful degradation |
+| SearXNG returns results that are all unusable | Empty result set, no throw | `server/webSearchService.test.ts` › graceful degradation |
+| Provider down vs. genuinely zero results | Both yield `[]` (indistinguishable downstream, see Known Limitations) | `server/webSearchService.test.ts` › graceful degradation |
+| Reranker is not ready | Results served in SearXNG order, HTTP 200 | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Reranking throws mid-request | Results served in SearXNG order, HTTP 200 | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Reranker is not ready on an image search | Images still served with thumbnails | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Reranking throws on an image search | Images still served with thumbnails | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Reranker returns a URL absent from the result set | That image is dropped | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Thumbnail host never answers | Request aborted after the timeout, image dropped | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |
+| Keyword fallback also returns nothing | Text search state becomes `failed` | `client/modules/textGeneration.degradation.test.ts` |
+| `/inference` upstream is not configured | HTTP 500 with a JSON error, no stream opened | `server/internalApiEndpointServerHook.test.ts` › environment configuration |
+| `/inference` cannot list upstream models | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Upstream model fails but another one is available | Retried on the next model, answer still streams | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Upstream model fails on every attempt | SSE error frame, so the client stops waiting | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Upstream stream ends without a finish part | `Stream ended unexpectedly` error frame | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Upstream fails after content was already sent | No retry, the partial answer stands | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Client disconnects mid-stream | Writes stop at the first unwritable check | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| `/inference` answers 503 | Generation state becomes `failed`, nothing persisted | `client/modules/textGeneration.degradation.test.ts` |
+| Generation interrupted mid-stream | Partial answer preserved, state stays `interrupted` | `client/modules/textGeneration.degradation.test.ts` |
+
+## Known Limitations
+
+`fetchSearXNG` catches every failure and returns `[]`, so "the provider is down"
+and "there are no results for this query" reach the client as the same response.
+The matrix pins that behavior rather than hiding it: changing it means changing
+the endpoint contract, and the test is where that decision becomes visible.
+
+## Adding a Row
+
+Keep each case next to the module it covers, reusing that file's mocks and
+harness: a `describe("graceful degradation")` block where the file has no
+failure-shaped block yet, the existing one where it does (the `/inference` rows
+live under `streaming path`), or a sibling `*.degradation.test.ts` when the case
+needs a harness of its own (the client rows drive `searchAndRespond` through a
+fake pubSub store). A row earns
+its place when it fails for the right reason: mutate the degradation branch in
+the module (delete the `catch`, the fallback, or the interrupt check) and confirm
+the case goes red before committing it.
+
+## Related Topics
+
+- **Development Commands**: `docs/development-commands.md` - Running the suite
+- **Reranking**: `docs/reranking.md` - Reranker lifecycle and readiness
+- **AI Integration**: `docs/ai-integration.md` - Inference backends
+- **Overview**: `docs/overview.md` - Search and inference data flow

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -3,7 +3,7 @@
 The suite exercises happy paths in the modules' own test files. This page maps
 the complementary set: what MiniSearch does when a dependency misbehaves. Every
 row is a Vitest case with the failure injected through a mocked `fetch`, a mocked
-upstream stream, or an injected circuit breaker, so no external service is
+module boundary, or an injected circuit breaker, so no external service is
 needed.
 
 ## Degradation Matrix
@@ -26,13 +26,13 @@ needed.
 | Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |
 | Keyword fallback also returns nothing | Text search state becomes `failed` | `client/modules/textGeneration.degradation.test.ts` |
-| `/inference` upstream is not configured | HTTP 500 with a JSON error, no stream opened | `server/internalApiEndpointServerHook.test.ts` › environment configuration |
+| `/inference` upstream is not configured | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › environment configuration |
 | `/inference` cannot list upstream models | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream model fails but another one is available | Retried on the next model, answer still streams | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream model fails on every attempt | SSE error frame, so the client stops waiting | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream stream ends without a finish part | `Stream ended unexpectedly` error frame | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream fails after content was already sent | No retry, the partial answer stands | `server/internalApiEndpointServerHook.test.ts` › streaming path |
-| Client disconnects mid-stream | Writes stop at the first unwritable check | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Response is already unwritable when streaming would start | No headers set, the upstream is never called | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | `/inference` answers 503 | Generation state becomes `failed`, nothing persisted | `client/modules/textGeneration.degradation.test.ts` |
 | Generation interrupted mid-stream | Partial answer preserved, state stays `interrupted` | `client/modules/textGeneration.degradation.test.ts` |
 
@@ -48,9 +48,9 @@ the endpoint contract, and the test is where that decision becomes visible.
 Keep each case next to the module it covers, reusing that file's mocks and
 harness: a `describe("graceful degradation")` block where the file has no
 failure-shaped block yet, the existing one where it does (the `/inference` rows
-live under `streaming path`), or a sibling `*.degradation.test.ts` when the case
-needs a harness of its own (the client rows drive `searchAndRespond` through a
-fake pubSub store). A row earns
+live under `environment configuration` and `streaming path`), or a sibling
+`*.degradation.test.ts` when the case needs a harness of its own (the client
+rows drive `searchAndRespond` through a fake pubSub store). A row earns
 its place when it fails for the right reason: mutate the degradation branch in
 the module (delete the `catch`, the fallback, or the interrupt check) and confirm
 the case goes red before committing it.

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./handleTokenVerification", () => ({
   handleTokenVerification: vi.fn(),
@@ -68,6 +68,9 @@ function getRegisteredHandler() {
 describe("searchEndpointServerHook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks keeps implementations, and one degradation case installs a
+    // fetch that only settles on abort.
+    mockFetch.mockReset();
     vi.mocked(handleTokenVerification).mockResolvedValue({
       shouldContinue: true,
     });
@@ -268,6 +271,193 @@ describe("searchEndpointServerHook", () => {
 
     const [body] = response.end.mock.calls[0];
     expect(JSON.parse(body)).toEqual([]);
+  });
+
+  describe("graceful degradation", () => {
+    const searxngResults: [string, string, string][] = [
+      ["A", "snippet a", "https://a.com"],
+      ["B", "snippet b", "https://b.com"],
+    ];
+    const imageResult: [string, string, string, string] = [
+      "Cat picture",
+      "https://example.com/cat.jpg",
+      "https://thumb.example.com/cat.jpg",
+      "https://example.com/cat",
+    ];
+    const thumbnailDataUrl = `data:image/jpeg;base64,${Buffer.from([1, 2, 3]).toString("base64")}`;
+
+    function respondWithThumbnail() {
+      mockFetch.mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+    }
+
+    beforeEach(() => {
+      // The degradation paths log on purpose; keep the test output readable.
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("returns unranked results when the reranker is down", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue(searxngResults);
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/text?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(rankSearchResults).not.toHaveBeenCalled();
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith(JSON.stringify(searxngResults));
+    });
+
+    it("returns unranked results when reranking throws mid-request", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue(searxngResults);
+      vi.mocked(getRerankerStatus).mockResolvedValue(true);
+      vi.mocked(rankSearchResults).mockRejectedValue(
+        new Error("Reranker model is not loaded"),
+      );
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/text?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith(JSON.stringify(searxngResults));
+    });
+
+    it("still serves image results when the reranker is down", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+      respondWithThumbnail();
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(rankSearchResults).not.toHaveBeenCalled();
+      expect(response.statusCode).toBe(200);
+      const [body] = response.end.mock.calls[0];
+      expect(JSON.parse(body)).toEqual([
+        [imageResult[0], imageResult[1], thumbnailDataUrl, imageResult[3]],
+      ]);
+    });
+
+    it("still serves image results when reranking throws mid-request", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(true);
+      vi.mocked(rankSearchResults).mockRejectedValue(
+        new Error("Reranker model is not loaded"),
+      );
+      respondWithThumbnail();
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      const [body] = response.end.mock.calls[0];
+      expect(JSON.parse(body)).toEqual([
+        [imageResult[0], imageResult[1], thumbnailDataUrl, imageResult[3]],
+      ]);
+    });
+
+    it("drops an image the reranker returns under an unknown URL", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(true);
+      vi.mocked(rankSearchResults).mockResolvedValue([
+        ["Cat picture", "", "https://example.com/not-in-the-result-set.jpg"],
+      ]);
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith("[]");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("drops an image whose thumbnail host never answers", async () => {
+      // Matches THUMBNAIL_TIMEOUT_MS in searchEndpointServerHook.ts.
+      const thumbnailTimeoutMs = 1000;
+      vi.useFakeTimers();
+      try {
+        vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+        vi.mocked(getRerankerStatus).mockResolvedValue(false);
+        mockFetch.mockImplementation(
+          (_url: string, init?: RequestInit) =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(new Error("The operation was aborted")),
+              );
+            }),
+        );
+
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const handled = handler(
+          createRequest("/search/images?q=cats&token=abc"),
+          response,
+          vi.fn(),
+        );
+        await vi.advanceTimersByTimeAsync(thumbnailTimeoutMs);
+        await handled;
+
+        expect(response.statusCode).toBe(200);
+        expect(response.end).toHaveBeenCalledWith("[]");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("serves an empty result set instead of an error when SearXNG is down", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([]);
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/text?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith("[]");
+    });
   });
 
   it("responds 500 when an unexpected error is thrown", async () => {

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -186,6 +186,165 @@ describe("retry logic", () => {
   });
 });
 
+describe("graceful degradation", () => {
+  // One initial attempt plus MAX_RETRIES.
+  const ATTEMPTS_PER_CALL = 4;
+  // BASE_RETRY_DELAY doubling across the three retries: 1000 + 2000 + 4000.
+  const RETRY_BACKOFF_TOTAL_MS = 7000;
+
+  const breakerOptions = {
+    failureThreshold: 5,
+    resetTimeout: 60_000,
+    successThreshold: 1,
+  };
+
+  /**
+   * Advances only far enough to drain the retry backoff. `runAllTimersAsync`
+   * would also fire the breaker's own reset timer, flipping an open circuit to
+   * half-open and letting the next call reach SearXNG again.
+   */
+  async function searchThroughRetries(breaker: CircuitBreaker) {
+    const promise = fetchSearXNG("failure injection", "text", 30, breaker);
+    await vi.advanceTimersByTimeAsync(RETRY_BACKOFF_TOTAL_MS);
+    return promise;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("counts a whole exhausted retry cycle as a single breaker failure", async () => {
+    const breaker = new CircuitBreaker(breakerOptions);
+    fetchMock.mockResolvedValue(createMockResponse("", false, 500));
+
+    for (let cycle = 0; cycle < breakerOptions.failureThreshold - 1; cycle++) {
+      const results = await searchThroughRetries(breaker);
+      expect(results).toEqual([]);
+    }
+
+    // Four full cycles of upstream requests, still one failure short of opening.
+    expect(fetchMock).toHaveBeenCalledTimes(
+      (breakerOptions.failureThreshold - 1) * ATTEMPTS_PER_CALL,
+    );
+    expect(breaker.getState("searxng")).toBe("CLOSED");
+  });
+
+  it("opens the circuit after five exhausted retry cycles and stops calling SearXNG", async () => {
+    const breaker = new CircuitBreaker(breakerOptions);
+    fetchMock.mockResolvedValue(createMockResponse("", false, 500));
+
+    for (let cycle = 0; cycle < breakerOptions.failureThreshold; cycle++) {
+      await searchThroughRetries(breaker);
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(
+      breakerOptions.failureThreshold * ATTEMPTS_PER_CALL,
+    );
+    expect(breaker.getState("searxng")).toBe("OPEN");
+
+    const callsWhileOpen = fetchMock.mock.calls.length;
+    const results = await searchThroughRetries(breaker);
+
+    expect(results).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(callsWhileOpen);
+  });
+
+  it("closes the circuit again once SearXNG recovers after the reset timeout", async () => {
+    const breaker = new CircuitBreaker(breakerOptions);
+    fetchMock.mockResolvedValue(createMockResponse("", false, 503));
+
+    for (
+      let failure = 0;
+      failure < breakerOptions.failureThreshold;
+      failure++
+    ) {
+      await fetchSearXNG("failure injection", "text", 30, breaker);
+    }
+
+    expect(breaker.getState("searxng")).toBe("OPEN");
+
+    await vi.advanceTimersByTimeAsync(breakerOptions.resetTimeout + 1);
+    fetchMock.mockResolvedValue(successResponse());
+
+    const results = await fetchSearXNG(
+      "failure injection",
+      "text",
+      30,
+      breaker,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(breaker.getState("searxng")).toBe("CLOSED");
+  });
+
+  it("cannot be told apart downstream: provider down and genuinely empty both yield []", async () => {
+    const downBreaker = new CircuitBreaker({ failureThreshold: 1 });
+    fetchMock.mockResolvedValue(createMockResponse("", false, 503));
+    const providerDown = await fetchSearXNG(
+      "failure injection",
+      "text",
+      30,
+      downBreaker,
+    );
+
+    const emptyBreaker = new CircuitBreaker({ failureThreshold: 1 });
+    fetchMock.mockResolvedValue(
+      createMockResponse(JSON.stringify({ results: [] })),
+    );
+    const noResults = await fetchSearXNG(
+      "failure injection",
+      "text",
+      30,
+      emptyBreaker,
+    );
+
+    // The breaker knows which one was a failure; the return value does not.
+    expect(downBreaker.getState("searxng")).toBe("OPEN");
+    expect(emptyBreaker.getState("searxng")).toBe("CLOSED");
+    expect(providerDown).toEqual([]);
+    expect(noResults).toEqual([]);
+  });
+
+  it("returns an empty array when SearXNG answers 200 with a malformed body", async () => {
+    fetchMock.mockResolvedValue(createMockResponse("<html>gateway</html>"));
+
+    const results = await fetchSearXNG(
+      "failure injection",
+      "text",
+      30,
+      new CircuitBreaker(breakerOptions),
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it("returns an empty array when every result is dropped during processing", async () => {
+    fetchMock.mockResolvedValue(
+      createMockResponse(
+        JSON.stringify({
+          results: [
+            { title: "No snippet", url: "https://example.com" },
+            { title: "", content: "orphan snippet", url: "https://other.com" },
+          ],
+        }),
+      ),
+    );
+
+    const results = await fetchSearXNG(
+      "failure injection",
+      "text",
+      30,
+      new CircuitBreaker(breakerOptions),
+    );
+
+    expect(results).toEqual([]);
+  });
+});
+
 describe("circuit breaker", () => {
   it("opens after exactly 5 non-retriable failures", async () => {
     const breaker = new CircuitBreaker({ failureThreshold: 5 });


### PR DESCRIPTION
Adds the degradation matrix asked in #2190: one Vitest case per dependency failure, with the failure injected through a mocked `fetch` or an injected circuit breaker, so no external service is needed.

Each case lives next to the module it covers, in a `describe("graceful degradation")` block, plus one new file for the client-side flow:

- `server/webSearchService.test.ts` - SearXNG answering 500 on every attempt (a whole exhausted retry cycle costs a single breaker failure), the circuit opening after five cycles and closing again after the reset timeout, malformed bodies, and results that are all unusable.
- `server/searchEndpointServerHook.test.ts` - reranker not ready or throwing mid-request, on both the text and the image path (results still served, unranked), a reranked URL that isn't in the result set, a thumbnail host that never answers, and an empty search still answering 200.
- `client/modules/textGeneration.degradation.test.ts` - keyword fallback firing when the first search comes back empty, `/inference` 503 ending in a `failed` state, and the partial answer surviving an aborted stream.

`docs/failure-injection.md` carries the full matrix with a pointer to where each row is pinned, and it's linked from `agents.md` and `docs/development-commands.md`.

The `/inference` server rows the issue asks for (upstream unconfigured, model list unreachable, model rotation, every model failing, stream without a finish part, client disconnect) all landed meanwhile in #2334, so I rebased onto it and dropped my duplicates. The matrix points those rows at the cases that already exist.

Known limitations:

- `fetchSearXNG` catches everything and returns `[]`, so "provider down" and "no results for this query" reach the client as the same response. The test pins it as-is (the breaker still knows the difference, only the return value throws it away), because changing it means changing the endpoint contract.
- The client-side `/inference` 503 case is synthetic: `internalApiEndpointServerHook.ts` sets `hasStartedStreaming` on the first loop iteration before calling `streamText`, and `model` is guaranteed non-null before the loop, so the JSON 503 at the end of the handler is unreachable. What the server actually emits is the SSE error frame. The client test still earns its place (a proxy or the dev server can 503, and nothing else covered `searchAndRespond`'s handling), and the dead branch is worth its own issue.

## How to test

1. `npm run test` (41 files, 427 tests).
2. `npm run lint`.
3. To confirm the cases fail for the right reason, delete a degradation branch and re-run: the `catch` in `handleRanking` (`server/searchEndpointServerHook.ts`), the `if (!result) return null;` guard below it, the empty-results fallback in `startTextSearch` (`client/modules/textGeneration.ts`), or the interrupt check in `generateTextWithInternalApi` (`client/modules/textGenerationWithInternalApi.ts`). I did that for each one and the matching cases go red.

Note: no production code changed. The touched test files also pass under `--sequence.shuffle` at several seeds.

Closes #2190
