### PR TITLE
fix(server): make pre-stream inference failures return 503

### DIFF
--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -29,10 +29,9 @@ needed.
 | `/inference` upstream is not configured | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › environment configuration |
 | `/inference` cannot list upstream models | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream model fails but another one is available | Retried on the next model, answer still streams | `server/internalApiEndpointServerHook.test.ts` › streaming path |
-| Every model stream fails before streaming starts | HTTP 503 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
-| An established upstream stream fails | SSE error frame, so the client stops waiting | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Every model fails before a single token is sent | HTTP 503 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream stream ends without a finish part | `Stream ended unexpectedly` error frame | `server/internalApiEndpointServerHook.test.ts` › streaming path |
-| Upstream fails after content was already sent | No retry, the partial answer stands | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Upstream fails after content was already sent | No retry, SSE error frame, the partial answer stands | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Response is already unwritable when streaming would start | No headers set, the upstream is never called | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | `/inference` answers 503 | Generation state becomes `failed`, nothing persisted | `client/modules/textGeneration.degradation.test.ts` |
 | Generation interrupted mid-stream | Partial answer preserved, state stays `interrupted` | `client/modules/textGeneration.degradation.test.ts` |

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -29,7 +29,8 @@ needed.
 | `/inference` upstream is not configured | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › environment configuration |
 | `/inference` cannot list upstream models | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream model fails but another one is available | Retried on the next model, answer still streams | `server/internalApiEndpointServerHook.test.ts` › streaming path |
-| Upstream model fails on every attempt | SSE error frame, so the client stops waiting | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Every model stream fails before streaming starts | HTTP 503 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| An established upstream stream fails | SSE error frame, so the client stops waiting | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream stream ends without a finish part | `Stream ended unexpectedly` error frame | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream fails after content was already sent | No retry, the partial answer stands | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Response is already unwritable when streaming would start | No headers set, the upstream is never called | `server/internalApiEndpointServerHook.test.ts` › streaming path |

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -571,7 +571,7 @@ describe("internalApiEndpointServerHook", () => {
       }
     });
 
-    it("emits SSE error when the only model fails", async () => {
+    it("responds 503 JSON when the only model cannot start", async () => {
       vi.mocked(streamText).mockImplementation(() => {
         throw new Error("upstream down");
       });
@@ -582,8 +582,17 @@ describe("internalApiEndpointServerHook", () => {
         response,
         vi.fn(),
       );
-      const writes = response.write.mock.calls.map((c) => c[0]).join("");
-      expect(writes).toContain("all models failed: upstream down");
+      expect(response.statusCode).toBe(503);
+      expect(response.setHeader).toHaveBeenCalledWith(
+        "Content-Type",
+        "application/json",
+      );
+      const payload = JSON.parse(response.end.mock.calls[0][0]);
+      expect(payload).toEqual({
+        error: "Service unavailable - all models failed",
+        lastError: "upstream down",
+      });
+      expect(response.write).not.toHaveBeenCalled();
       expect(vi.mocked(streamText)).toHaveBeenCalledTimes(1);
     });
 

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -571,6 +571,34 @@ describe("internalApiEndpointServerHook", () => {
       }
     });
 
+    it("responds 503 JSON when the only model's stream fails before any content", async () => {
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "error", error: new Error("upstream down") },
+          ]) as never,
+      );
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+      await handler(
+        createRequest({ messages: [{ role: "user", content: "hi" }] }),
+        response,
+        vi.fn(),
+      );
+      expect(response.statusCode).toBe(503);
+      expect(response.setHeader).toHaveBeenCalledWith(
+        "Content-Type",
+        "application/json",
+      );
+      const payload = JSON.parse(response.end.mock.calls[0][0]);
+      expect(payload).toEqual({
+        error: "Service unavailable - all models failed",
+        lastError: "upstream down",
+      });
+      expect(response.write).not.toHaveBeenCalled();
+      expect(vi.mocked(streamText)).toHaveBeenCalledTimes(1);
+    });
+
     it("responds 503 JSON when the only model cannot start", async () => {
       vi.mocked(streamText).mockImplementation(() => {
         throw new Error("upstream down");

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -595,6 +595,10 @@ describe("internalApiEndpointServerHook", () => {
         error: "Service unavailable - all models failed",
         lastError: "upstream down",
       });
+      expect(response.setHeader).not.toHaveBeenCalledWith(
+        "Content-Type",
+        "text/event-stream",
+      );
       expect(response.write).not.toHaveBeenCalled();
       expect(vi.mocked(streamText)).toHaveBeenCalledTimes(1);
     });
@@ -708,6 +712,7 @@ describe("internalApiEndpointServerHook", () => {
       const writes = response.write.mock.calls.map((c) => c[0]).join("");
       expect(writes).not.toContain("A different answer");
       expect(writes).toContain("all models failed");
+      expect(writes).toContain("[DONE]");
     });
 
     it("responds 500 when model list fetch fails and no env model set", async () => {

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -95,7 +95,16 @@ function sendJsonError(
   safeEndResponse(response, JSON.stringify(payload));
 }
 
+function ensureSseHeaders(response: ServerResponse): void {
+  if (response.headersSent) return;
+
+  response.setHeader("Content-Type", "text/event-stream");
+  response.setHeader("Cache-Control", "no-cache");
+  response.setHeader("Connection", "keep-alive");
+}
+
 function sendSseData(response: ServerResponse, data: unknown): void {
+  ensureSseHeaders(response);
   safeWriteResponse(response, `data: ${JSON.stringify(data)}\n\n`);
 }
 
@@ -109,12 +118,6 @@ function sendSseError(
   message: string,
   model?: string,
 ): void {
-  if (!response.headersSent) {
-    response.setHeader("Content-Type", "text/event-stream");
-    response.setHeader("Cache-Control", "no-cache");
-    response.setHeader("Connection", "keep-alive");
-  }
-
   sendSseData(response, {
     error: message,
     ...(model ? { model } : {}),
@@ -258,7 +261,6 @@ export function internalApiEndpointServerHook<
         const config = getModelConfig();
         const maxAttempts = 5;
         let lastError: unknown = null;
-        let hasStartedStreaming = false;
 
         const clampedMaxTokens =
           requestBody.max_tokens !== undefined
@@ -291,13 +293,6 @@ export function internalApiEndpointServerHook<
               maxOutputTokens: clampedMaxTokens,
               maxRetries: 0,
             });
-
-            if (!hasStartedStreaming) {
-              response.setHeader("Content-Type", "text/event-stream");
-              response.setHeader("Cache-Control", "no-cache");
-              response.setHeader("Connection", "keep-alive");
-              hasStartedStreaming = true;
-            }
 
             for await (const part of stream.fullStream) {
               if (!isResponseWritable(response)) return;
@@ -355,7 +350,7 @@ export function internalApiEndpointServerHook<
         const lastErrorMessage =
           lastError instanceof Error ? lastError.message : "Unknown error";
 
-        if (!hasStartedStreaming) {
+        if (!response.headersSent) {
           sendJsonError(response, 503, {
             error: "Service unavailable - all models failed",
             lastError: lastErrorMessage,

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -282,13 +282,6 @@ export function internalApiEndpointServerHook<
             return;
           }
 
-          if (!hasStartedStreaming) {
-            response.setHeader("Content-Type", "text/event-stream");
-            response.setHeader("Cache-Control", "no-cache");
-            response.setHeader("Connection", "keep-alive");
-            hasStartedStreaming = true;
-          }
-
           try {
             const stream = streamText({
               model: openaiProvider.chatModel(model),
@@ -298,6 +291,13 @@ export function internalApiEndpointServerHook<
               maxOutputTokens: clampedMaxTokens,
               maxRetries: 0,
             });
+
+            if (!hasStartedStreaming) {
+              response.setHeader("Content-Type", "text/event-stream");
+              response.setHeader("Cache-Control", "no-cache");
+              response.setHeader("Connection", "keep-alive");
+              hasStartedStreaming = true;
+            }
 
             for await (const part of stream.fullStream) {
               if (!isResponseWritable(response)) return;


### PR DESCRIPTION
## Description

When every upstream model fails before `streamText()` returns, the `/inference` handler had already sent SSE headers. That made the final JSON 503 branch unreachable and left clients with a 200 SSE response containing an error frame.

This moves SSE header initialization until after a stream is created successfully. Failures before streaming now return the intended JSON 503 response, while failures from an established stream keep the existing SSE error and `[DONE]` behavior.

## Related issue(s)

Fixes #2337

## Type of change

- [x] Bug fix (non-breaking change)
- [x] Tests that prove the fix
- [x] Documentation update

## Checklist

- [x] I have linked the related issue above
- [x] I have added a regression test for the reachable 503 response
- [x] I have updated the failure-injection matrix
- [ ] I have addressed all Coderabbit comments (none yet)

## Checks

Passed:

- `vitest run`: 41 files, 427 tests passed
- Biome check on changed files
- Vite production build
- GitHub Actions: Docker, current Node, and LTS jobs

Repository baseline limitations:

- `tsc --noEmit` and `tsc -p tsconfig.node.json --noEmit` both stop on the existing missing `@types/debug` errors in unchanged server files.
- The repository-wide Biome check reports existing CRLF/schema-format differences.
- jscpd reports existing duplicate test helpers.
- The architectural linter reports pre-existing external API violations in unchanged search files.