### PR TITLE
fix(server): treat an empty upstream stream as a failure

### DIFF
--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -30,7 +30,7 @@ needed.
 | `/inference` cannot list upstream models | HTTP 500 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream model fails but another one is available | Retried on the next model, answer still streams | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Every model fails before a single token is sent | HTTP 503 with a JSON error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
-| Upstream stream ends without a finish part | `Stream ended unexpectedly` error frame | `server/internalApiEndpointServerHook.test.ts` › streaming path |
+| Upstream stream ends without a finish part | Treated as a failure: retried, then `Stream ended unexpectedly` as the last error | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Upstream fails after content was already sent | No retry, SSE error frame, the partial answer stands | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | Response is already unwritable when streaming would start | No headers set, the upstream is never called | `server/internalApiEndpointServerHook.test.ts` › streaming path |
 | `/inference` answers 503 | Generation state becomes `failed`, nothing persisted | `client/modules/textGeneration.degradation.test.ts` |

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -484,6 +484,65 @@ describe("internalApiEndpointServerHook", () => {
       ).toBe(true);
     });
 
+    it("responds 503 JSON when the stream ends before any content", async () => {
+      vi.mocked(streamText).mockImplementation(() => streamOf([]) as never);
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+      await handler(
+        createRequest({ messages: [{ role: "user", content: "hi" }] }),
+        response,
+        vi.fn(),
+      );
+      expect(response.statusCode).toBe(503);
+      const payload = JSON.parse(response.end.mock.calls[0][0]);
+      expect(payload.lastError).toBe("Stream ended unexpectedly");
+      expect(response.write).not.toHaveBeenCalled();
+    });
+
+    it("retries with another model when the stream ends before any content", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      vi.mocked(listOpenAiCompatibleModels).mockResolvedValue([
+        { id: "model-a" },
+        { id: "model-b" },
+      ]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      let callCount = 0;
+      vi.mocked(streamText).mockImplementation(() => {
+        callCount += 1;
+        return (
+          callCount === 1
+            ? streamOf([])
+            : streamOf([
+                { type: "text-delta", text: "Recovered" },
+                { type: "finish" },
+              ])
+        ) as never;
+      });
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        expect(streamText).toHaveBeenCalledTimes(2);
+        const writes = response.write.mock.calls.map((c) => c[0]).join("");
+        expect(writes).toContain("Recovered");
+        expect(writes).not.toContain("Stream ended unexpectedly");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("returns early when response is no longer writable", async () => {
       vi.mocked(streamText).mockImplementation(
         () => streamOf([{ type: "text-delta", text: "Hello" }]) as never,

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -312,8 +312,7 @@ export function internalApiEndpointServerHook<
               }
             }
 
-            sendSseError(response, "Stream ended unexpectedly", model);
-            return;
+            throw new Error("Stream ended unexpectedly");
           } catch (error) {
             lastError = error;
             console.error("Error during streaming:", error);


### PR DESCRIPTION
## Description

Currently, an upstream stream that ends with no `text-delta`, no `error` part and no `finish` answers 200 with a `Stream ended unexpectedly` SSE frame, and never retries. Every other failure before the first token retries the next model and, since #2339, ends in a JSON 503. So the same thing (a request that fails before a single token arrives) reaches the client in two different shapes depending on how the upstream gave up.

This PR throws `Stream ended unexpectedly` instead of writing the frame, so the existing `catch` handles it like any other failure: retry the next model, then JSON 503 if nothing was written, or the SSE error frame if content was already sent. The special case goes away and one line of the handler goes with it.

Follow-up to #2339, where [@claude](https://claude.com/claude-code) spotted the inconsistency while reviewing the 503 fix.

### Behavior change

The `Stream ended unexpectedly` text still reaches the client on the content-already-sent path, now wrapped in the usual `Service unavailable - all models failed: ...` message. `docs/failure-injection.md` row updated.

## How to test

1. Run `npx vitest run server/internalApiEndpointServerHook.test.ts` (34 tests, 2 of them new).
2. Check the two new cases fail on `main`: `git stash` the change to `server/internalApiEndpointServerHook.ts` and re-run. `responds 503 JSON when the stream ends before any content` and `retries with another model when the stream ends before any content` both go red.

Note: this is only exercised through the mocked `streamText`. I don't have an upstream that returns an empty stream to try it against for real.
