### PR TITLE
chore: read from the ai SDK's `stream` instead of the deprecated `fullStream`

### DIFF
--- a/client/modules/textGenerationWithOpenAi.ts
+++ b/client/modules/textGenerationWithOpenAi.ts
@@ -84,7 +84,7 @@ async function createOpenAiStream({
     let shouldRetry = false;
 
     try {
-      const stream = streamText({
+      const result = streamText({
         model: openaiProvider.chatModel(effectiveModel),
         messages,
         maxOutputTokens: params.max_tokens,
@@ -122,7 +122,7 @@ async function createOpenAiStream({
 
       let text = "";
       let reasoning = "";
-      for await (const part of stream.fullStream) {
+      for await (const part of result.stream) {
         if (getTextGenerationState() === "interrupted") {
           currentAbortController.abort();
           throw new Error("Chat generation interrupted");

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -103,7 +103,7 @@ function streamOf(
   pieces: Array<{ type: string; text?: string; error?: unknown }>,
 ) {
   return {
-    fullStream: (async function* () {
+    stream: (async function* () {
       for (const piece of pieces) yield piece as never;
     })(),
   };

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -285,7 +285,7 @@ export function internalApiEndpointServerHook<
           }
 
           try {
-            const stream = streamText({
+            const result = streamText({
               model: openaiProvider.chatModel(model),
               messages: requestBody.messages,
               temperature: clampedTemperature,
@@ -294,7 +294,7 @@ export function internalApiEndpointServerHook<
               maxRetries: 0,
             });
 
-            for await (const part of stream.fullStream) {
+            for await (const part of result.stream) {
               if (!isResponseWritable(response)) return;
 
               if (part.type === "text-delta") {


### PR DESCRIPTION
## Description

`StreamTextResult.fullStream` is marked `@deprecated Use 'stream' instead` in `ai` 7.x, and it will be removed in the next major release. Renovate keeps the dependency current, so this would break on a bump.

Both properties are typed `AsyncIterableStream<TextStreamPart<TOOLS>>` and carry the same parts, so this is a rename and nothing else. The locals go from `stream` to `result`, so the property read is `result.stream` instead of `stream.stream`.

Two call sites, plus the `streamOf` helper in the server tests:

- `server/internalApiEndpointServerHook.ts` - the `/inference` retry loop.
- `client/modules/textGenerationWithOpenAi.ts` - the OpenAI-compatible generation loop.

Follow-up to #2339.

## How to test

For the client path, run the app with an OpenAI-compatible endpoint configured and confirm an answer still streams token by token.