### PR TITLE
fix(doc-gardening): remove git operations from lint path

### DIFF
--- a/scripts/doc-gardening.cjs
+++ b/scripts/doc-gardening.cjs
@@ -1,6 +1,5 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const { execSync } = require("node:child_process");
 
 class DocGardener {
   constructor(rootDir) {
@@ -8,22 +7,17 @@ class DocGardener {
     this.issues = [];
   }
 
-  async garden(fix = false) {
+  async garden() {
     console.log("🌱 Starting doc gardening...");
 
     await this.checkDocFreshness();
     await this.checkCrossReferences();
     await this.checkCodeDocAlignment();
 
-    await this.reportIssues();
-
-    if (fix) {
-      await this.createFixupPRs();
-      return;
-    }
+    this.reportIssues();
 
     if (this.issues.some((issue) => issue.severity === "error")) {
-      process.exit(1);
+      process.exitCode = 1;
     }
   }
 
@@ -61,31 +55,26 @@ class DocGardener {
 
     for (const docFile of docFiles) {
       const content = fs.readFileSync(docFile, "utf8");
-      const links = content.match(/\[.*?\]\((.*?)\)/g) || [];
 
-      for (const link of links) {
-        const match = link.match(/\[.*?\]\((.*?)\)/);
-        if (!match) continue;
-
-        const target = match[1];
+      for (const [, rawTarget] of content.matchAll(/\[.*?\]\((.*?)\)/g)) {
+        // Drop the optional link title, then the anchor or query, the way a
+        // markdown renderer does before resolving the path.
+        const [pathPart] = rawTarget.trim().split(/\s+/);
+        const [target] = pathPart.split(/[#?]/);
 
         if (
           target.startsWith("./") ||
           target.startsWith("../") ||
           target.startsWith("docs/")
         ) {
-          const [cleanTarget] = target.split(/[#?]/);
-          if (!cleanTarget) continue;
-          const targetPath = cleanTarget.startsWith("docs/")
-            ? path.resolve(this.rootDir, cleanTarget)
-            : path.resolve(path.dirname(docFile), cleanTarget);
+          const targetPath = path.resolve(path.dirname(docFile), target);
 
           if (!fs.existsSync(targetPath)) {
             this.issues.push({
               type: "broken_link",
               file: docFile,
               severity: "error",
-              message: `Broken link in ${path.relative(this.rootDir, docFile)} to ${target}`,
+              message: `Broken link in ${path.relative(this.rootDir, docFile)} to ${rawTarget}`,
               remediation: `Update link to point to existing documentation or create missing file: ${path.relative(this.rootDir, targetPath)}`,
             });
           }
@@ -122,7 +111,7 @@ class DocGardener {
     }
   }
 
-  async reportIssues() {
+  reportIssues() {
     if (this.issues.length === 0) {
       console.log("✅ No documentation issues found!");
       return;
@@ -134,7 +123,7 @@ class DocGardener {
       console.log(
         `${issue.severity === "error" ? "🚫" : "⚠️"}  ${issue.message}`,
       );
-      console.log(`   📁 File: ${issue.file}`);
+      console.log(`   📁 File: ${path.relative(this.rootDir, issue.file)}`);
       console.log(`   💡 ${issue.remediation}\n`);
     }
 
@@ -144,99 +133,6 @@ class DocGardener {
     ).length;
 
     console.log(`Summary: ${errorCount} errors, ${warningCount} warnings`);
-
-    if (errorCount > 0) {
-      process.exit(1);
-    }
-  }
-
-  async createFixupPRs() {
-    let clean;
-    try {
-      clean = execSync("git status --porcelain", {
-        cwd: this.rootDir,
-        encoding: "utf8",
-      }).trim();
-    } catch (error) {
-      console.error("❌ Failed to check working tree status:", error.message);
-      process.exit(1);
-    }
-
-    if (clean) {
-      console.error(
-        "❌ Cannot apply fixes: working tree is not clean. Commit or stash your changes first.",
-      );
-      process.exit(1);
-    }
-
-    const errorIssues = this.issues.filter((i) => i.severity === "error");
-
-    if (errorIssues.length === 0) {
-      console.log("✅ No fix-up PRs needed!");
-      return;
-    }
-
-    console.log(`🔧 Creating fix-up PR for ${errorIssues.length} issues...`);
-
-    const branchName = `doc-gardening-${Date.now()}`;
-    let originalBranch;
-    try {
-      originalBranch = execSync("git rev-parse --abbrev-ref HEAD", {
-        cwd: this.rootDir,
-        encoding: "utf8",
-      }).trim();
-
-      execSync(`git checkout -b ${branchName}`, { cwd: this.rootDir });
-
-      for (const issue of errorIssues) {
-        await this.applyFix(issue);
-      }
-
-      const changedFiles = errorIssues.map((issue) =>
-        path.relative(this.rootDir, issue.file),
-      );
-      execSync(`git add ${changedFiles.map((f) => `"${f}"`).join(" ")}`, {
-        cwd: this.rootDir,
-      });
-      execSync(
-        `git commit -m "docs: fix documentation issues found by doc gardening"`,
-        { cwd: this.rootDir },
-      );
-
-      console.log(`✅ Created fix-up PR branch: ${branchName}`);
-      console.log("📝 Run the following to create the PR:");
-      console.log(`   git push -u origin ${branchName}`);
-      console.log(
-        '   gh pr create --title "docs: fix documentation issues" --body "Automated documentation fixes from doc gardening process"',
-      );
-    } catch (error) {
-      console.error("❌ Failed to create fix-up PR:", error.message);
-      process.exit(1);
-    } finally {
-      if (originalBranch) {
-        try {
-          execSync(`git checkout ${originalBranch}`, {
-            cwd: this.rootDir,
-          });
-        } catch {
-          // Ignore checkout errors in finally — the user already has the branch info.
-        }
-      }
-    }
-  }
-
-  async applyFix(issue) {
-    switch (issue.type) {
-      case "broken_link": {
-        console.log(
-          `⚠️  No automatic fix available for broken link in ${path.relative(this.rootDir, issue.file)}`,
-        );
-        break;
-      }
-
-      default:
-        console.log(`⚠️  No automatic fix available for ${issue.type}`);
-    }
   }
 
   getAllMarkdownFiles(dir) {
@@ -272,13 +168,29 @@ class DocGardener {
 
 if (require.main === module) {
   const args = process.argv.slice(2);
-  const fix = args.includes("--fix");
-  const rootDir = args.find((arg) => !arg.startsWith("--")) || process.cwd();
-  const gardener = new DocGardener(rootDir);
+  const [rootDirArg] = args;
+  const usage = "Usage: node scripts/doc-gardening.cjs [rootDir]";
 
-  gardener.garden(fix).catch((error) => {
-    console.error("Doc gardening error:", error);
+  if (args.length > 1) {
+    console.error(`❌ Too many arguments\n   ${usage}`);
     process.exit(1);
+  }
+
+  if (rootDirArg?.startsWith("-")) {
+    console.error(`❌ Unknown option: ${rootDirArg}\n   ${usage}`);
+    process.exit(1);
+  }
+
+  if (rootDirArg && !fs.existsSync(rootDirArg)) {
+    console.error(`❌ Directory not found: ${rootDirArg}`);
+    process.exit(1);
+  }
+
+  const gardener = new DocGardener(rootDirArg || process.cwd());
+
+  gardener.garden().catch((error) => {
+    console.error("Doc gardening error:", error);
+    process.exitCode = 1;
   });
 }
 

--- a/scripts/doc-gardening.cjs
+++ b/scripts/doc-gardening.cjs
@@ -85,8 +85,8 @@ class DocGardener {
               type: "broken_link",
               file: docFile,
               severity: "error",
-              message: `Broken link in ${docFile} to ${target}`,
-              remediation: `Update link to point to existing documentation or create missing file: ${targetPath}`,
+              message: `Broken link in ${path.relative(this.rootDir, docFile)} to ${target}`,
+              remediation: `Update link to point to existing documentation or create missing file: ${path.relative(this.rootDir, targetPath)}`,
             });
           }
         }
@@ -192,7 +192,12 @@ class DocGardener {
         await this.applyFix(issue);
       }
 
-      execSync("git add .", { cwd: this.rootDir });
+      const changedFiles = errorIssues.map((issue) =>
+        path.relative(this.rootDir, issue.file),
+      );
+      execSync(`git add ${changedFiles.map((f) => `"${f}"`).join(" ")}`, {
+        cwd: this.rootDir,
+      });
       execSync(
         `git commit -m "docs: fix documentation issues found by doc gardening"`,
         { cwd: this.rootDir },
@@ -223,29 +228,9 @@ class DocGardener {
   async applyFix(issue) {
     switch (issue.type) {
       case "broken_link": {
-        const content = fs.readFileSync(issue.file, "utf8");
-        const fixedContent = content.replace(/\[.*?\]\([^)]*?\)/g, (match) => {
-          const targetMatch = match.match(/\((.*?)\)/);
-          if (!targetMatch) return match;
-          const target = targetMatch[1];
-          if (
-            target.startsWith("./") ||
-            target.startsWith("../") ||
-            target.startsWith("docs/")
-          ) {
-            const [cleanTarget] = target.split(/[#?]/);
-            if (!cleanTarget) return match;
-            const targetPath = cleanTarget.startsWith("docs/")
-              ? path.resolve(this.rootDir, cleanTarget)
-              : path.resolve(path.dirname(issue.file), cleanTarget);
-            if (!fs.existsSync(targetPath)) {
-              const linkText = match.match(/\[(.*?)\]/)?.[1] ?? "";
-              return `[${linkText}](${target})`;
-            }
-          }
-          return match;
-        });
-        fs.writeFileSync(issue.file, fixedContent);
+        console.log(
+          `⚠️  No automatic fix available for broken link in ${path.relative(this.rootDir, issue.file)}`,
+        );
         break;
       }
 
@@ -288,7 +273,7 @@ class DocGardener {
 if (require.main === module) {
   const args = process.argv.slice(2);
   const fix = args.includes("--fix");
-  const rootDir = args.find((arg) => arg !== "--fix") || process.cwd();
+  const rootDir = args.find((arg) => !arg.startsWith("--")) || process.cwd();
   const gardener = new DocGardener(rootDir);
 
   gardener.garden(fix).catch((error) => {

--- a/scripts/doc-gardening.cjs
+++ b/scripts/doc-gardening.cjs
@@ -151,13 +151,6 @@ class DocGardener {
   }
 
   async createFixupPRs() {
-    const errorIssues = this.issues.filter((i) => i.severity === "error");
-
-    if (errorIssues.length === 0) {
-      console.log("✅ No fix-up PRs needed!");
-      return;
-    }
-
     let clean;
     try {
       clean = execSync("git status --porcelain", {
@@ -174,6 +167,13 @@ class DocGardener {
         "❌ Cannot apply fixes: working tree is not clean. Commit or stash your changes first.",
       );
       process.exit(1);
+    }
+
+    const errorIssues = this.issues.filter((i) => i.severity === "error");
+
+    if (errorIssues.length === 0) {
+      console.log("✅ No fix-up PRs needed!");
+      return;
     }
 
     console.log(`🔧 Creating fix-up PR for ${errorIssues.length} issues...`);

--- a/scripts/doc-gardening.cjs
+++ b/scripts/doc-gardening.cjs
@@ -8,7 +8,7 @@ class DocGardener {
     this.issues = [];
   }
 
-  async garden() {
+  async garden(fix = false) {
     console.log("🌱 Starting doc gardening...");
 
     await this.checkDocFreshness();
@@ -16,7 +16,10 @@ class DocGardener {
     await this.checkCodeDocAlignment();
 
     await this.reportIssues();
-    await this.createFixupPRs();
+
+    if (fix) {
+      await this.createFixupPRs();
+    }
   }
 
   async checkDocFreshness() {
@@ -73,7 +76,7 @@ class DocGardener {
               type: "broken_link",
               file: docFile,
               severity: "error",
-              message: `Broken link to ${target}`,
+              message: `Broken link in ${docFile} to ${target}`,
               remediation: `Update link to point to existing documentation or create missing file: ${targetPath}`,
             });
           }
@@ -132,6 +135,10 @@ class DocGardener {
     ).length;
 
     console.log(`Summary: ${errorCount} errors, ${warningCount} warnings`);
+
+    if (errorCount > 0) {
+      process.exit(1);
+    }
   }
 
   async createFixupPRs() {
@@ -140,6 +147,24 @@ class DocGardener {
     if (errorIssues.length === 0) {
       console.log("✅ No fix-up PRs needed!");
       return;
+    }
+
+    let clean;
+    try {
+      clean = execSync("git status --porcelain", {
+        cwd: this.rootDir,
+        encoding: "utf8",
+      }).trim();
+    } catch (error) {
+      console.error("❌ Failed to check working tree status:", error.message);
+      process.exit(1);
+    }
+
+    if (clean) {
+      console.error(
+        "❌ Cannot apply fixes: working tree is not clean. Commit or stash your changes first.",
+      );
+      process.exit(1);
     }
 
     console.log(`🔧 Creating fix-up PR for ${errorIssues.length} issues...`);
@@ -166,6 +191,7 @@ class DocGardener {
       );
     } catch (error) {
       console.error("❌ Failed to create fix-up PR:", error.message);
+      process.exit(1);
     }
   }
 
@@ -231,10 +257,14 @@ class DocGardener {
 }
 
 if (require.main === module) {
-  const rootDir = process.argv[2] || process.cwd();
+  const args = process.argv.slice(2);
+  const rootDir = args.includes("--fix")
+    ? args[args.indexOf("--fix") + 1] || process.cwd()
+    : args[0] || process.cwd();
+  const fix = args.includes("--fix");
   const gardener = new DocGardener(rootDir);
 
-  gardener.garden().catch((error) => {
+  gardener.garden(fix).catch((error) => {
     console.error("Doc gardening error:", error);
     process.exit(1);
   });

--- a/scripts/doc-gardening.cjs
+++ b/scripts/doc-gardening.cjs
@@ -19,6 +19,11 @@ class DocGardener {
 
     if (fix) {
       await this.createFixupPRs();
+      return;
+    }
+
+    if (this.issues.some((issue) => issue.severity === "error")) {
+      process.exit(1);
     }
   }
 
@@ -69,7 +74,11 @@ class DocGardener {
           target.startsWith("../") ||
           target.startsWith("docs/")
         ) {
-          const targetPath = path.resolve(path.dirname(docFile), target);
+          const [cleanTarget] = target.split(/[#?]/);
+          if (!cleanTarget) continue;
+          const targetPath = cleanTarget.startsWith("docs/")
+            ? path.resolve(this.rootDir, cleanTarget)
+            : path.resolve(path.dirname(docFile), cleanTarget);
 
           if (!fs.existsSync(targetPath)) {
             this.issues.push({
@@ -170,7 +179,13 @@ class DocGardener {
     console.log(`🔧 Creating fix-up PR for ${errorIssues.length} issues...`);
 
     const branchName = `doc-gardening-${Date.now()}`;
+    let originalBranch;
     try {
+      originalBranch = execSync("git rev-parse --abbrev-ref HEAD", {
+        cwd: this.rootDir,
+        encoding: "utf8",
+      }).trim();
+
       execSync(`git checkout -b ${branchName}`, { cwd: this.rootDir });
 
       for (const issue of errorIssues) {
@@ -192,6 +207,16 @@ class DocGardener {
     } catch (error) {
       console.error("❌ Failed to create fix-up PR:", error.message);
       process.exit(1);
+    } finally {
+      if (originalBranch) {
+        try {
+          execSync(`git checkout ${originalBranch}`, {
+            cwd: this.rootDir,
+          });
+        } catch {
+          // Ignore checkout errors in finally — the user already has the branch info.
+        }
+      }
     }
   }
 
@@ -200,18 +225,22 @@ class DocGardener {
       case "broken_link": {
         const content = fs.readFileSync(issue.file, "utf8");
         const fixedContent = content.replace(/\[.*?\]\([^)]*?\)/g, (match) => {
-          const target = match.match(/\((.*?)\)/)[1];
+          const targetMatch = match.match(/\((.*?)\)/);
+          if (!targetMatch) return match;
+          const target = targetMatch[1];
           if (
             target.startsWith("./") ||
             target.startsWith("../") ||
             target.startsWith("docs/")
           ) {
-            const targetPath = path.resolve(path.dirname(issue.file), target);
+            const [cleanTarget] = target.split(/[#?]/);
+            if (!cleanTarget) return match;
+            const targetPath = cleanTarget.startsWith("docs/")
+              ? path.resolve(this.rootDir, cleanTarget)
+              : path.resolve(path.dirname(issue.file), cleanTarget);
             if (!fs.existsSync(targetPath)) {
-              return match.replace(
-                /\[.*?\]\([^)]*?\)/,
-                "[REMOVED BROKEN LINK]",
-              );
+              const linkText = match.match(/\[(.*?)\]/)?.[1] ?? "";
+              return `[${linkText}](${target})`;
             }
           }
           return match;
@@ -258,10 +287,8 @@ class DocGardener {
 
 if (require.main === module) {
   const args = process.argv.slice(2);
-  const rootDir = args.includes("--fix")
-    ? args[args.indexOf("--fix") + 1] || process.cwd()
-    : args[0] || process.cwd();
   const fix = args.includes("--fix");
+  const rootDir = args.find((arg) => arg !== "--fix") || process.cwd();
   const gardener = new DocGardener(rootDir);
 
   gardener.garden(fix).catch((error) => {

--- a/scripts/doc-gardening.test.js
+++ b/scripts/doc-gardening.test.js
@@ -1,0 +1,131 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.resolve(__dirname, "doc-gardening.cjs");
+
+function runGarden(args = [], cwd = __dirname) {
+  const cmd = `node ${SCRIPT_PATH} ${args.join(" ")}`;
+  try {
+    const output = execSync(cmd, { cwd, encoding: "utf8", stdio: "pipe" });
+    return { exitCode: 0, stdout: output, stderr: "" };
+  } catch (error) {
+    return {
+      exitCode: error.status ?? 1,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+    };
+  }
+}
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "doc-garden-test-"));
+}
+
+function writeMd(dir, relPath, content) {
+  const fullPath = path.join(dir, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+  return fullPath;
+}
+
+describe("doc-gardening", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("without --fix", () => {
+    it("exits 0 when there are no errors", () => {
+      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
+      writeMd(tmpDir, "docs/api.md", "# API\n");
+      const { exitCode } = runGarden([], tmpDir);
+      expect(exitCode).toBe(0);
+    });
+
+    it("exits 1 when there is a broken relative link", () => {
+      writeMd(
+        tmpDir,
+        "docs/overview.md",
+        "# Overview\n\n[Link](./nonexistent.md)\n",
+      );
+      const { exitCode, stdout } = runGarden([], tmpDir);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain("docs/overview.md");
+      expect(stdout).toContain("./nonexistent.md");
+    });
+
+    it("does not run any git commands", () => {
+      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
+      writeMd(tmpDir, "docs/api.md", "# API\n");
+      const { stdout } = runGarden([], tmpDir);
+      expect(stdout).not.toContain("git checkout");
+      expect(stdout).not.toContain("git add");
+      expect(stdout).not.toContain("git commit");
+    });
+
+    it("reports stale docs as warnings without failing", () => {
+      const docPath = writeMd(tmpDir, "docs/old.md", "# Old\n");
+      const oldTime = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(docPath, oldTime, oldTime);
+      const { exitCode, stdout } = runGarden([], tmpDir);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("hasn't been updated in");
+    });
+
+    it("does not fail on anchor-only links", () => {
+      writeMd(
+        tmpDir,
+        "docs/overview.md",
+        "# Overview\n\n[Section](./api.md#foo)\n",
+      );
+      writeMd(tmpDir, "docs/api.md", "# API\n");
+      const { exitCode } = runGarden([], tmpDir);
+      expect(exitCode).toBe(0);
+    });
+
+    it("does not fail on docs/-prefixed links that exist", () => {
+      writeMd(
+        tmpDir,
+        "docs/overview.md",
+        "# Overview\n\n[Link](docs/api.md)\n",
+      );
+      writeMd(tmpDir, "docs/api.md", "# API\n");
+      const { exitCode } = runGarden([], tmpDir);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("with --fix", () => {
+    it("requires a clean working tree", () => {
+      execSync("git init", { cwd: tmpDir, stdio: "pipe" });
+      execSync("git add .", { cwd: tmpDir, stdio: "pipe" });
+      execSync("git commit -m init", { cwd: tmpDir, stdio: "pipe" });
+      writeMd(
+        tmpDir,
+        "docs/overview.md",
+        "# Overview\n\n[Link](./nonexistent.md)\n",
+      );
+      fs.writeFileSync(path.join(tmpDir, "README.md"), "uncommitted\n");
+      const { exitCode, stderr } = runGarden(["--fix"], tmpDir);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("working tree is not clean");
+    });
+
+    it("exits 0 when there are no errors even with --fix", () => {
+      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
+      writeMd(tmpDir, "docs/api.md", "# API\n");
+      const { exitCode } = runGarden(["--fix"], tmpDir);
+      expect(exitCode).toBe(0);
+    });
+  });
+});

--- a/scripts/doc-gardening.test.js
+++ b/scripts/doc-gardening.test.js
@@ -108,13 +108,15 @@ describe("doc-gardening", () => {
   describe("with --fix", () => {
     it("requires a clean working tree", () => {
       execSync("git init", { cwd: tmpDir, stdio: "pipe" });
+      execSync("git config user.email 'test@test.com'", {
+        cwd: tmpDir,
+        stdio: "pipe",
+      });
+      execSync("git config user.name 'Test'", { cwd: tmpDir, stdio: "pipe" });
+      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
+      writeMd(tmpDir, "docs/api.md", "# API\n");
       execSync("git add .", { cwd: tmpDir, stdio: "pipe" });
       execSync("git commit -m init", { cwd: tmpDir, stdio: "pipe" });
-      writeMd(
-        tmpDir,
-        "docs/overview.md",
-        "# Overview\n\n[Link](./nonexistent.md)\n",
-      );
       fs.writeFileSync(path.join(tmpDir, "README.md"), "uncommitted\n");
       const { exitCode, stderr } = runGarden(["--fix"], tmpDir);
       expect(exitCode).toBe(1);
@@ -122,8 +124,16 @@ describe("doc-gardening", () => {
     });
 
     it("exits 0 when there are no errors even with --fix", () => {
+      execSync("git init", { cwd: tmpDir, stdio: "pipe" });
+      execSync("git config user.email 'test@test.com'", {
+        cwd: tmpDir,
+        stdio: "pipe",
+      });
+      execSync("git config user.name 'Test'", { cwd: tmpDir, stdio: "pipe" });
       writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
       writeMd(tmpDir, "docs/api.md", "# API\n");
+      execSync("git add .", { cwd: tmpDir, stdio: "pipe" });
+      execSync("git commit -m init", { cwd: tmpDir, stdio: "pipe" });
       const { exitCode } = runGarden(["--fix"], tmpDir);
       expect(exitCode).toBe(0);
     });

--- a/scripts/doc-gardening.test.js
+++ b/scripts/doc-gardening.test.js
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,12 +8,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT_PATH = path.resolve(__dirname, "doc-gardening.cjs");
 
-function runGarden(args = [], cwd = __dirname) {
-  const cmd = `node ${SCRIPT_PATH} ${args.join(" ")}`;
+function runGarden(cwd, args = []) {
   try {
-    const output = execSync(cmd, { cwd, encoding: "utf8", stdio: "pipe" });
+    const output = execFileSync(process.execPath, [SCRIPT_PATH, ...args], {
+      cwd,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
     return { exitCode: 0, stdout: output, stderr: "" };
   } catch (error) {
+    if (error.signal) throw new Error(`Killed by ${error.signal}`);
     return {
       exitCode: error.status ?? 1,
       stdout: error.stdout ?? "",
@@ -22,8 +26,23 @@ function runGarden(args = [], cwd = __dirname) {
   }
 }
 
-function createTempDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "doc-garden-test-"));
+function git(cwd, ...args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: "pipe",
+    // Keep the developer's own git config and repo out of the fixture: a global
+    // commit.gpgsign or core.hooksPath would fail the commit below, and an
+    // inherited GIT_DIR would point these commands at the wrong repository.
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      GIT_DIR: undefined,
+      GIT_WORK_TREE: undefined,
+      GIT_INDEX_FILE: undefined,
+    },
+  });
 }
 
 function writeMd(dir, relPath, content) {
@@ -33,109 +52,133 @@ function writeMd(dir, relPath, content) {
   return fullPath;
 }
 
+function makeStale(docPath) {
+  const oldTime = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(docPath, oldTime, oldTime);
+}
+
 describe("doc-gardening", () => {
   let tmpDir;
 
   beforeEach(() => {
-    tmpDir = createTempDir();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "doc-garden-test-"));
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  describe("without --fix", () => {
-    it("exits 0 when there are no errors", () => {
-      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
-      writeMd(tmpDir, "docs/api.md", "# API\n");
-      const { exitCode } = runGarden([], tmpDir);
-      expect(exitCode).toBe(0);
-    });
-
-    it("exits 1 when there is a broken relative link", () => {
-      writeMd(
-        tmpDir,
-        "docs/overview.md",
-        "# Overview\n\n[Link](./nonexistent.md)\n",
-      );
-      const { exitCode, stdout } = runGarden([], tmpDir);
-      expect(exitCode).toBe(1);
-      expect(stdout).toContain("docs/overview.md");
-      expect(stdout).toContain("./nonexistent.md");
-    });
-
-    it("does not run any git commands", () => {
-      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
-      writeMd(tmpDir, "docs/api.md", "# API\n");
-      const { stdout } = runGarden([], tmpDir);
-      expect(stdout).not.toContain("git checkout");
-      expect(stdout).not.toContain("git add");
-      expect(stdout).not.toContain("git commit");
-    });
-
-    it("reports stale docs as warnings without failing", () => {
-      const docPath = writeMd(tmpDir, "docs/old.md", "# Old\n");
-      const oldTime = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
-      fs.utimesSync(docPath, oldTime, oldTime);
-      const { exitCode, stdout } = runGarden([], tmpDir);
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain("hasn't been updated in");
-    });
-
-    it("does not fail on anchor-only links", () => {
-      writeMd(
-        tmpDir,
-        "docs/overview.md",
-        "# Overview\n\n[Section](./api.md#foo)\n",
-      );
-      writeMd(tmpDir, "docs/api.md", "# API\n");
-      const { exitCode } = runGarden([], tmpDir);
-      expect(exitCode).toBe(0);
-    });
-
-    it("does not fail on docs/-prefixed links that exist", () => {
-      writeMd(
-        tmpDir,
-        "docs/overview.md",
-        "# Overview\n\n[Link](docs/api.md)\n",
-      );
-      writeMd(tmpDir, "docs/api.md", "# API\n");
-      const { exitCode } = runGarden([], tmpDir);
-      expect(exitCode).toBe(0);
-    });
+  it("never reaches for git", () => {
+    expect(fs.readFileSync(SCRIPT_PATH, "utf8")).not.toMatch(
+      /require\((["'])(node:)?child_process\1\)/,
+    );
   });
 
-  describe("with --fix", () => {
-    it("requires a clean working tree", () => {
-      execSync("git init", { cwd: tmpDir, stdio: "pipe" });
-      execSync("git config user.email 'test@test.com'", {
-        cwd: tmpDir,
-        stdio: "pipe",
-      });
-      execSync("git config user.name 'Test'", { cwd: tmpDir, stdio: "pipe" });
-      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
-      writeMd(tmpDir, "docs/api.md", "# API\n");
-      execSync("git add .", { cwd: tmpDir, stdio: "pipe" });
-      execSync("git commit -m init", { cwd: tmpDir, stdio: "pipe" });
-      fs.writeFileSync(path.join(tmpDir, "README.md"), "uncommitted\n");
-      const { exitCode, stderr } = runGarden(["--fix"], tmpDir);
-      expect(exitCode).toBe(1);
-      expect(stderr).toContain("working tree is not clean");
-    });
+  it("exits 0 when there are no errors", () => {
+    writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
+    writeMd(tmpDir, "docs/api.md", "# API\n");
+    expect(runGarden(tmpDir).exitCode).toBe(0);
+  });
 
-    it("exits 0 when there are no errors even with --fix", () => {
-      execSync("git init", { cwd: tmpDir, stdio: "pipe" });
-      execSync("git config user.email 'test@test.com'", {
-        cwd: tmpDir,
-        stdio: "pipe",
-      });
-      execSync("git config user.name 'Test'", { cwd: tmpDir, stdio: "pipe" });
-      writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](./api.md)\n");
-      writeMd(tmpDir, "docs/api.md", "# API\n");
-      execSync("git add .", { cwd: tmpDir, stdio: "pipe" });
-      execSync("git commit -m init", { cwd: tmpDir, stdio: "pipe" });
-      const { exitCode } = runGarden(["--fix"], tmpDir);
-      expect(exitCode).toBe(0);
-    });
+  it("exits 1 naming the file and the target of a broken relative link", () => {
+    writeMd(
+      tmpDir,
+      "docs/overview.md",
+      "# Overview\n\n[Link](./nonexistent.md)\n",
+    );
+    const { exitCode, stdout } = runGarden(tmpDir);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("docs/overview.md");
+    expect(stdout).toContain("./nonexistent.md");
+  });
+
+  it("leaves the branch and the working tree untouched when it finds errors", () => {
+    git(tmpDir, "init");
+    git(tmpDir, "config", "user.email", "test@example.com");
+    git(tmpDir, "config", "user.name", "Test");
+    writeMd(
+      tmpDir,
+      "docs/overview.md",
+      "# Overview\n\n[Link](./nonexistent.md)\n",
+    );
+    git(tmpDir, "add", "docs/overview.md");
+    git(tmpDir, "commit", "-m", "init");
+    fs.writeFileSync(path.join(tmpDir, "unrelated.txt"), "work in progress\n");
+
+    const branchBefore = git(tmpDir, "rev-parse", "--abbrev-ref", "HEAD");
+    const branchesBefore = git(tmpDir, "branch", "--list");
+    const statusBefore = git(tmpDir, "status", "--porcelain");
+
+    const { exitCode, stdout } = runGarden(tmpDir);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("./nonexistent.md");
+    expect(git(tmpDir, "rev-parse", "--abbrev-ref", "HEAD")).toBe(branchBefore);
+    expect(git(tmpDir, "branch", "--list")).toBe(branchesBefore);
+    expect(git(tmpDir, "status", "--porcelain")).toBe(statusBefore);
+  });
+
+  it("reports stale docs as warnings without failing", () => {
+    makeStale(writeMd(tmpDir, "docs/old.md", "# Old\n"));
+    const { exitCode, stdout } = runGarden(tmpDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("hasn't been updated in");
+  });
+
+  it("still exits 1 when a warning accompanies an error", () => {
+    makeStale(writeMd(tmpDir, "docs/old.md", "# Old\n\n[Link](./gone.md)\n"));
+    const { exitCode, stdout } = runGarden(tmpDir);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("Summary: 1 errors, 1 warnings");
+  });
+
+  it("ignores the anchor and the title of an otherwise valid link", () => {
+    writeMd(
+      tmpDir,
+      "docs/overview.md",
+      '# Overview\n\n[Section](./api.md#foo)\n[Titled](./api.md "The API")\n',
+    );
+    writeMd(tmpDir, "docs/api.md", "# API\n");
+    expect(runGarden(tmpDir).exitCode).toBe(0);
+  });
+
+  it("resolves a docs/-prefixed link the way a renderer does, against the linking file", () => {
+    writeMd(tmpDir, "docs/overview.md", "# Overview\n\n[Link](docs/api.md)\n");
+    writeMd(tmpDir, "docs/api.md", "# API\n");
+    const { exitCode, stdout } = runGarden(tmpDir);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain(path.join("docs", "docs", "api.md"));
+  });
+
+  it("accepts a root directory outside the current one", () => {
+    writeMd(
+      tmpDir,
+      "docs/overview.md",
+      "# Overview\n\n[Link](./nonexistent.md)\n",
+    );
+    const { exitCode, stdout } = runGarden(__dirname, [tmpDir]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain(path.join("docs", "overview.md"));
+    expect(stdout).not.toContain(os.tmpdir());
+  });
+
+  it("rejects an unknown option instead of treating it as the root directory", () => {
+    const { exitCode, stderr } = runGarden(tmpDir, ["--fix"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown option");
+  });
+
+  it("rejects a root directory that does not exist", () => {
+    const { exitCode, stderr } = runGarden(tmpDir, [
+      path.join(tmpDir, "missing"),
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Directory not found");
+  });
+
+  it("rejects extra arguments", () => {
+    const { exitCode, stderr } = runGarden(tmpDir, [tmpDir, "--fix"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Too many arguments");
   });
 });


### PR DESCRIPTION
## Description

Currently, `npm run lint` runs `scripts/doc-gardening.cjs`, whose last step is `createFixupPRs()`. One broken relative link in `docs/**/*.md` is enough to make the lint run `git checkout -b doc-gardening-<timestamp>`, rewrite the offending doc, `git add .` (staging unrelated work) and commit it. Despite the name, it never opens a PR: it prints the `git push` and `gh pr create` commands for you to run.

This PR deletes `createFixupPRs()` and `applyFix()` rather than putting them behind a flag. The earlier attempt at a `--fix` flag was unreachable anyway: `reportIssues()` exited whenever it found an error, so it returned before `createFixupPRs()` could run, which is exactly the case the flag existed for. And with the destructive rewrite gone (a broken link became the literal text `[REMOVED BROKEN LINK]`), `applyFix()` had nothing left to apply. There is no correct automatic fix for a broken link, since the intended target can't be inferred.

The script is now a reporter. `node:child_process` is gone from it, so "the lint path cannot reach git" is a property of the file instead of a property of the call order.

### Also in here

- Link resolution follows the renderer more closely: an optional link title is stripped before resolving (`[x](./a.md "title")` was reported as broken), and a `docs/`-prefixed target resolves against the linking file like any other relative link. Resolving it against the repository root hid links a renderer would not follow: `docs/api.md` written inside `docs/overview.md` points at `docs/docs/api.md` on GitHub. No link in `docs/` changes color today, since the docs cross-reference each other with backticked paths.
- `garden()` sets `process.exitCode` instead of calling `process.exit(1)`, so buffered output isn't truncated on the way out.
- The CLI rejects an unknown option, extra arguments, and a missing root directory, instead of taking them as the directory to scan and reporting nothing.
- The freshness check already reported stale docs, so it needed no change.

### Follow-ups, not in this PR

- The freshness check reads `mtime`, and `actions/checkout` sets every file's mtime to checkout time, so it can only ever fire in a long-lived local clone.
- The link gate matches `./`, `../` and `docs/` only, so plain `api.md` and `guides/api.md` still go unchecked. Widening it to "any target with no scheme that doesn't start with `#`" would subsume the `docs/` case.
- `documentation-validator.cjs` checks `README.md` and `.github/` with its own definition of a link. The two scripts are worth consolidating.

## How to test

1. `npm run lint` passes.
2. `npx vitest run scripts/doc-gardening.test.js` passes (12 tests).
3. For the behavior this fixes, in a scratch repo:

```sh
git init repro && cd repro && git config user.email t@t.com && git config user.name T
mkdir docs && printf '# Overview\n\n[Link](./nonexistent.md)\n' > docs/overview.md
git add docs/overview.md && git commit -m init
printf 'wip\n' > unrelated.txt
node /path/to/MiniSearch/scripts/doc-gardening.cjs
```

On `main`, that exits 0, leaves you on a `doc-gardening-<timestamp>` branch, and commits `unrelated.txt` along with the rewritten doc. On this branch it exits 1, names the file and the target, and leaves the branch and the working tree alone.

Fixes #2338
