### PR TITLE
Tune the default system prompt for small models

### DIFF
--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -40,15 +40,17 @@ export const defaultSettings = {
   wllamaModelId: DEFAULT_WLLAMA_MODEL_ID,
   cpuThreads: getDefaultCpuThreads(),
   searchResultsLimit: 15,
-  systemPrompt: `Answer using the search results below as your primary source, supplemented by your own knowledge when needed. Write your response in the same language as the query.
+  systemPrompt: `Answer the question using the search results below. Reply in the same language as the question.
 
-Cite every fact taken from the search results with an inline Markdown link immediately after it. Format: [domain.com](https://full-url). Use only the top-level domain (no https://, www., or paths) as link text. Example: [youtube.com](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
+Cite each fact with a Markdown link right after it, using the site's domain as the link text. Example: [youtube.com](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
 
-When the search results disagree with each other, point out the conflict. When you rely on your own knowledge because the results don't cover something, make that clear rather than presenting it as sourced.
+Start with the answer. No preamble, no repeating the question, no closing summary.
 
-Today's date is {{currentDate}}. Use it to resolve relative date references in both the question and the results.
+Use only these Markdown elements: link, bold, italic, code, quote, table.
 
-You are allowed to use these Markdown elements: anchor, bold, italic, code, quote, table.
+If the results disagree, say so. If you answer from your own knowledge because the results do not cover it, say so.
+
+Today's date is {{currentDate}}. Use it for relative dates such as "yesterday".
 
 Search results:
 


### PR DESCRIPTION
## Description

Currently the default system prompt is written as if a capable model will read it, while the default browser model is `littlelamb-290m`. At that size instructions do not fail neutrally: every extra one dilutes the rest, and the one most worth protecting is the citation format, since that is the feature.

This rewrites the prompt for the smallest model that has to follow it, without giving up anything a large model does well with.

Ordering does most of the work. Grounding, the answer's language and the citation format come first; the instructions that need real reasoning (noticing that results disagree, noticing that an answer came from the model's own knowledge) move to the end. A large model still follows all of it, and a small one degrades to the part that matters instead of dropping an arbitrary subset.

| Change | Why |
|---|---|
| Citation rule keeps its example, loses the prose around it | `Format: [domain.com](https://full-url). Use only the top-level domain (no https://, www., or paths) as link text` was 32 tokens describing what the example already demonstrates. Small models copy a pattern; they do not parse a parenthesized exclusion list |
| `anchor` becomes `link` | The model emits Markdown, not HTML, and `link` is the word it has actually seen |
| The opening no longer offers "supplemented by your own knowledge when needed" | It invited an ungrounded answer in the first sentence. The permission still exists, next to the obligation to say so |
| New: "Start with the answer. No preamble, no repeating the question, no closing summary." | Padding and restated questions are what a search answer actually gets wrong, and this holds in any language, unlike register advice |
| Reordered as above | Primacy is the only lever that works on a 290M model |

Net 151 tokens, down from 192. That matters because excerpts already take 1,433 of a browser model's 4,096, leaving 2,663 for the prompt, the snippets, the question and the answer.

Both placeholders are preserved, and `{{searchResults}}` still appears exactly once, since `getSystemPrompt` substitutes it with `String.replace` and would only replace the first occurrence.

### What this does not do

It only reaches profiles that have never been saved. `applyServerConfig` returns early when settings were stored, and the prompt is stored per browser, so everyone who has already used the app keeps the old one. Reaching them needs a separate change, and `SystemPromptInput` already distinguishes an edited prompt from the default if we want to migrate only the untouched ones.

## How to test

1. Run `npm run test`. No test asserts the prompt text, so this is a regression check rather than a check of the change.
2. Open AI Settings > System Prompt in a browser with no stored settings (or clear site data) and confirm the new prompt is what loads, and that "Reset to default" restores it.
3. Turn on AI responses and search for something factual. Answers should open on the answer rather than on a restatement of the question, and facts should still carry `[domain.com](url)` links.
4. Search in a non-English language and confirm the answer still comes back in that language.

## Known limitations

Whether this reads better on `littlelamb-290m` is reasoned, not measured. Confirming it means comparing citation compliance and answer shape across a set of real searches, which is what #2192 is for. I would treat this as the first thing that harness measures, and I am happy to hold the PR until it can.
