### PR TITLE
fix(search): stop logging the search query

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -225,8 +225,8 @@ The `/status` endpoint returns a JSON object:
 | `graphicalSearches` | number | Image search count since last restart |
 | `averageTextualSearchesPerSession` | number | Text searches / sessions ratio |
 | `averageGraphicalSearchesPerSession` | number | Image searches / sessions ratio |
-| `searchesWithoutResults` | number | Searches SearXNG answered with zero results |
-| `searchesWithAllResultsDiscarded` | number | Searches whose results were all dropped during processing |
+| `searchesWithoutResults` | number | Searches, text and image together, that SearXNG answered with zero results |
+| `searchesWithAllResultsDiscarded` | number | Text searches whose results were all dropped during processing |
 | `rerankerServiceStatus` | string | `"healthy"` or `"unhealthy"` |
 | `webSearchServiceStatus` | string | `"healthy"` or `"unhealthy"` |
 | `pageReads` | object | Page-reading counters since last restart, see below |
@@ -236,7 +236,10 @@ The `/status` endpoint returns a JSON object:
 `searchesWithoutResults` and `searchesWithAllResultsDiscarded` are the aggregate
 form of two log lines that used to carry the query text. The log still names the
 unresponsive engines behind an empty response and the size and type of a
-discarded batch; how often either happens is read from here instead.
+discarded batch; how often either happens is read from here instead. The
+discarded count covers text searches only, because an image result is never
+dropped at this stage: an unusable thumbnail is dropped later, when
+`searchEndpointServerHook` fetches it.
 
 `pageReads` reports what happened to the pages read for AI answers. Each field
 is attached to a constant that someone will want to move, which is the reason it

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -225,11 +225,18 @@ The `/status` endpoint returns a JSON object:
 | `graphicalSearches` | number | Image search count since last restart |
 | `averageTextualSearchesPerSession` | number | Text searches / sessions ratio |
 | `averageGraphicalSearchesPerSession` | number | Image searches / sessions ratio |
+| `searchesWithoutResults` | number | Searches SearXNG answered with zero results |
+| `searchesWithAllResultsDiscarded` | number | Searches whose results were all dropped during processing |
 | `rerankerServiceStatus` | string | `"healthy"` or `"unhealthy"` |
 | `webSearchServiceStatus` | string | `"healthy"` or `"unhealthy"` |
 | `pageReads` | object | Page-reading counters since last restart, see below |
 | `build.timestamp` | string | ISO 8601 build time |
 | `build.gitCommit` | string | Short Git commit hash |
+
+`searchesWithoutResults` and `searchesWithAllResultsDiscarded` are the aggregate
+form of two log lines that used to carry the query text. The log still names the
+unresponsive engines behind an empty response and the size and type of a
+discarded batch; how often either happens is read from here instead.
 
 `pageReads` reports what happened to the pages read for AI answers. Each field
 is attached to a constant that someone will want to move, which is the reason it

--- a/server/searchesSinceLastRestart.ts
+++ b/server/searchesSinceLastRestart.ts
@@ -37,13 +37,17 @@ export function incrementGraphicalSearchesSinceLastRestart() {
   graphicalSearchesSinceLastRestart++;
 }
 
+// The two counters below stand in for the per-search log lines that used to
+// carry the query text: how often either case happens is what anyone acts on,
+// and that survives without recording what was searched for.
+
 /**
- * Counters for the two ways a search ends up with nothing to show. They stand
- * in for the per-search log lines that used to carry the query text: how often
- * either happens is what anyone needs to act on, and that survives without
- * recording what was searched for.
+ * Counter for searches SearXNG answered with zero results
  */
 let searchesWithoutResultsSinceLastRestart = 0;
+/**
+ * Counter for searches whose results were all dropped during processing
+ */
 let searchesWithAllResultsDiscardedSinceLastRestart = 0;
 
 /**

--- a/server/searchesSinceLastRestart.ts
+++ b/server/searchesSinceLastRestart.ts
@@ -36,3 +36,42 @@ export function getGraphicalSearchesSinceLastRestart() {
 export function incrementGraphicalSearchesSinceLastRestart() {
   graphicalSearchesSinceLastRestart++;
 }
+
+/**
+ * Counters for the two ways a search ends up with nothing to show. They stand
+ * in for the per-search log lines that used to carry the query text: how often
+ * either happens is what anyone needs to act on, and that survives without
+ * recording what was searched for.
+ */
+let searchesWithoutResultsSinceLastRestart = 0;
+let searchesWithAllResultsDiscardedSinceLastRestart = 0;
+
+/**
+ * Gets the number of searches SearXNG answered with zero results
+ * @returns Number of empty searches
+ */
+export function getSearchesWithoutResultsSinceLastRestart() {
+  return searchesWithoutResultsSinceLastRestart;
+}
+
+/**
+ * Increments the empty-search counter
+ */
+export function incrementSearchesWithoutResultsSinceLastRestart() {
+  searchesWithoutResultsSinceLastRestart++;
+}
+
+/**
+ * Gets the number of searches whose results were all dropped during processing
+ * @returns Number of fully discarded searches
+ */
+export function getSearchesWithAllResultsDiscardedSinceLastRestart() {
+  return searchesWithAllResultsDiscardedSinceLastRestart;
+}
+
+/**
+ * Increments the fully-discarded-search counter
+ */
+export function incrementSearchesWithAllResultsDiscardedSinceLastRestart() {
+  searchesWithAllResultsDiscardedSinceLastRestart++;
+}

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -4,6 +4,8 @@ import { getPageReadStats } from "./pageReadsSinceLastRestart.ts";
 import { getRerankerStatus } from "./rerankerService.ts";
 import {
   getGraphicalSearchesSinceLastRestart,
+  getSearchesWithAllResultsDiscardedSinceLastRestart,
+  getSearchesWithoutResultsSinceLastRestart,
   getTextualSearchesSinceLastRestart,
 } from "./searchesSinceLastRestart.ts";
 import { getVerifiedTokensAmount } from "./verifiedTokens.ts";
@@ -49,6 +51,9 @@ export function statusEndpointServerHook<
       graphicalSearches,
       averageTextualSearchesPerSession,
       averageGraphicalSearchesPerSession,
+      searchesWithoutResults: getSearchesWithoutResultsSinceLastRestart(),
+      searchesWithAllResultsDiscarded:
+        getSearchesWithAllResultsDiscardedSinceLastRestart(),
       rerankerServiceStatus,
       webSearchServiceStatus,
       pageReads: getPageReadStats(),

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -399,6 +399,22 @@ describe("query privacy", () => {
     );
   }
 
+  function imageResultsResponse() {
+    return createMockResponse(
+      JSON.stringify({
+        results: [
+          {
+            title: "picture",
+            url: "https://example.com/picture",
+            category: "images",
+            img_src: "https://example.com/picture.jpg",
+            thumbnail_src: "https://example.com/thumbnail.jpg",
+          },
+        ],
+      }),
+    );
+  }
+
   it("never writes the query to the log", async () => {
     for (const response of [
       emptyResponse(),
@@ -409,6 +425,9 @@ describe("query privacy", () => {
       await fetchSearXNG(DISTINCTIVE_QUERY, "text", 30, new CircuitBreaker());
     }
 
+    fetchMock.mockResolvedValue(imageResultsResponse());
+    await fetchSearXNG(DISTINCTIVE_QUERY, "images", 30, new CircuitBreaker());
+
     fetchMock.mockRejectedValue(new Error("Network failure"));
     await fetchSearXNG(DISTINCTIVE_QUERY, "images", 30, new CircuitBreaker());
 
@@ -418,7 +437,7 @@ describe("query privacy", () => {
     for (const form of [
       DISTINCTIVE_QUERY,
       encodeURIComponent(DISTINCTIVE_QUERY),
-      new URLSearchParams({ q: DISTINCTIVE_QUERY }).toString(),
+      DISTINCTIVE_QUERY.replaceAll(" ", "+"),
     ]) {
       expect(output).not.toContain(form);
     }
@@ -443,7 +462,7 @@ describe("query privacy", () => {
     await fetchSearXNG(DISTINCTIVE_QUERY, "text", 30, new CircuitBreaker());
 
     expect(logLines.join("\n")).toContain(
-      "All 1 text result(s) from SearXNG were discarded during processing",
+      "All 1 text result(s) processed from the SearXNG response were discarded",
     );
     expect(getSearchesWithAllResultsDiscardedSinceLastRestart()).toBe(
       before + 1,

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -351,14 +351,18 @@ describe("graceful degradation", () => {
 });
 
 describe("query privacy", () => {
-  const DISTINCTIVE_QUERY = "borogoves-outgrabe-mimsy-42";
+  // The space is here on purpose: a leak of the search URL would carry the
+  // percent-encoded form, which the raw string alone would not catch.
+  const DISTINCTIVE_QUERY = "borogoves outgrabe mimsy-42";
 
   let logLines: string[];
   let originalLog: typeof debug.log;
 
   /**
    * `debug` resolves its writer at call time, so replacing it here captures
-   * everything the module logs regardless of where the writer points.
+   * everything the module logs through `debug`, which under jsdom never reaches
+   * `console` in a spy-able way. The console spies cover the calls the module
+   * makes directly, so a new logging line is caught whichever it uses.
    */
   beforeEach(() => {
     logLines = [];
@@ -366,10 +370,16 @@ describe("query privacy", () => {
     debug.log = (...args: unknown[]) => {
       logLines.push(args.map(String).join(" "));
     };
+    for (const method of ["log", "info", "warn", "error", "debug"] as const) {
+      vi.spyOn(console, method).mockImplementation((...args: unknown[]) => {
+        logLines.push(args.map(String).join(" "));
+      });
+    }
   });
 
   afterEach(() => {
     debug.log = originalLog;
+    vi.restoreAllMocks();
   });
 
   function emptyResponse() {
@@ -402,8 +412,16 @@ describe("query privacy", () => {
     fetchMock.mockRejectedValue(new Error("Network failure"));
     await fetchSearXNG(DISTINCTIVE_QUERY, "images", 30, new CircuitBreaker());
 
+    const output = logLines.join("\n");
     expect(logLines.length).toBeGreaterThan(0);
-    expect(logLines.join("\n")).not.toContain(DISTINCTIVE_QUERY);
+
+    for (const form of [
+      DISTINCTIVE_QUERY,
+      encodeURIComponent(DISTINCTIVE_QUERY),
+      new URLSearchParams({ q: DISTINCTIVE_QUERY }).toString(),
+    ]) {
+      expect(output).not.toContain(form);
+    }
   });
 
   it("still reports the unresponsive engines behind an empty response", async () => {

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -1,3 +1,4 @@
+import debug from "debug";
 import {
   afterEach,
   beforeEach,
@@ -7,6 +8,10 @@ import {
   type MockedFunction,
   vi,
 } from "vitest";
+import {
+  getSearchesWithAllResultsDiscardedSinceLastRestart,
+  getSearchesWithoutResultsSinceLastRestart,
+} from "./searchesSinceLastRestart";
 import { CircuitBreaker } from "./utils/circuitBreaker";
 import {
   describeUnresponsiveEngines,
@@ -342,6 +347,89 @@ describe("graceful degradation", () => {
     );
 
     expect(results).toEqual([]);
+  });
+});
+
+describe("query privacy", () => {
+  const DISTINCTIVE_QUERY = "borogoves-outgrabe-mimsy-42";
+
+  let logLines: string[];
+  let originalLog: typeof debug.log;
+
+  /**
+   * `debug` resolves its writer at call time, so replacing it here captures
+   * everything the module logs regardless of where the writer points.
+   */
+  beforeEach(() => {
+    logLines = [];
+    originalLog = debug.log;
+    debug.log = (...args: unknown[]) => {
+      logLines.push(args.map(String).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    debug.log = originalLog;
+  });
+
+  function emptyResponse() {
+    return createMockResponse(
+      JSON.stringify({
+        results: [],
+        unresponsive_engines: [["google", "Timeout"]],
+      }),
+    );
+  }
+
+  function unusableResultsResponse() {
+    return createMockResponse(
+      JSON.stringify({
+        results: [{ title: "No snippet", url: "https://example.com" }],
+      }),
+    );
+  }
+
+  it("never writes the query to the log", async () => {
+    for (const response of [
+      emptyResponse(),
+      unusableResultsResponse(),
+      createMockResponse("<html>gateway</html>"),
+    ]) {
+      fetchMock.mockResolvedValue(response);
+      await fetchSearXNG(DISTINCTIVE_QUERY, "text", 30, new CircuitBreaker());
+    }
+
+    fetchMock.mockRejectedValue(new Error("Network failure"));
+    await fetchSearXNG(DISTINCTIVE_QUERY, "images", 30, new CircuitBreaker());
+
+    expect(logLines.length).toBeGreaterThan(0);
+    expect(logLines.join("\n")).not.toContain(DISTINCTIVE_QUERY);
+  });
+
+  it("still reports the unresponsive engines behind an empty response", async () => {
+    fetchMock.mockResolvedValue(emptyResponse());
+    const before = getSearchesWithoutResultsSinceLastRestart();
+
+    await fetchSearXNG(DISTINCTIVE_QUERY, "text", 30, new CircuitBreaker());
+
+    expect(logLines.join("\n")).toContain(
+      "Unresponsive engines: google (Timeout)",
+    );
+    expect(getSearchesWithoutResultsSinceLastRestart()).toBe(before + 1);
+  });
+
+  it("still reports the count and search type of a discarded batch", async () => {
+    fetchMock.mockResolvedValue(unusableResultsResponse());
+    const before = getSearchesWithAllResultsDiscardedSinceLastRestart();
+
+    await fetchSearXNG(DISTINCTIVE_QUERY, "text", 30, new CircuitBreaker());
+
+    expect(logLines.join("\n")).toContain(
+      "All 1 text result(s) from SearXNG were discarded during processing",
+    );
+    expect(getSearchesWithAllResultsDiscardedSinceLastRestart()).toBe(
+      before + 1,
+    );
   });
 });
 

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -351,8 +351,8 @@ describe("graceful degradation", () => {
 });
 
 describe("query privacy", () => {
-  // The space is here on purpose: a leak of the search URL would carry the
-  // percent-encoded form, which the raw string alone would not catch.
+  // The space is here on purpose: a leaked search URL carries it encoded (as
+  // `+`, from URLSearchParams), which a match on the raw string alone misses.
   const DISTINCTIVE_QUERY = "borogoves outgrabe mimsy-42";
 
   let logLines: string[];

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -2,6 +2,10 @@ import { basename } from "node:path";
 import debug from "debug";
 import { convert as convertHtmlToPlainText } from "html-to-text";
 import { strip as stripEmojis } from "node-emoji";
+import {
+  incrementSearchesWithAllResultsDiscardedSinceLastRestart,
+  incrementSearchesWithoutResultsSinceLastRestart,
+} from "./searchesSinceLastRestart.ts";
 import { CircuitBreaker } from "./utils/circuitBreaker.ts";
 
 const fileName = basename(import.meta.url);
@@ -148,11 +152,12 @@ async function performSearch(
     const results = Array.isArray(data.results) ? data.results : [];
 
     if (results.length === 0) {
+      incrementSearchesWithoutResultsSinceLastRestart();
       const reason = describeUnresponsiveEngines(data.unresponsive_engines);
       printMessage(
         reason
-          ? `No results returned from SearXNG for query: ${query}. Unresponsive engines: ${reason}`
-          : `No results returned from SearXNG for query: ${query}. No engine errors were reported; all engines returned zero results.`,
+          ? `No results returned from SearXNG. Unresponsive engines: ${reason}`
+          : "No results returned from SearXNG. No engine errors were reported; all engines returned zero results.",
       );
     }
 
@@ -182,7 +187,6 @@ async function processSearchResults(
     return reportDiscardedResults(
       filterNullResults(textualResults),
       results.length,
-      query,
       searchType,
     );
   }
@@ -193,7 +197,6 @@ async function processSearchResults(
   return reportDiscardedResults(
     filterNullResults(graphicalResults),
     results.length,
-    query,
     searchType,
   );
 }
@@ -207,12 +210,12 @@ async function processSearchResults(
 function reportDiscardedResults<T>(
   filteredResults: T[],
   rawResultCount: number,
-  query: string,
   searchType: SearchType,
 ): T[] {
   if (rawResultCount > 0 && filteredResults.length === 0) {
+    incrementSearchesWithAllResultsDiscardedSinceLastRestart();
     printMessage(
-      `All ${rawResultCount} ${searchType} result(s) from SearXNG for query: ${query} were discarded during processing (missing title, snippet, or media source).`,
+      `All ${rawResultCount} ${searchType} result(s) from SearXNG were discarded during processing (missing title, snippet, or media source).`,
     );
   }
   return filteredResults;

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -178,44 +178,45 @@ async function processSearchResults(
   const results = await breaker.execute("searxng", () =>
     performSearch(query, searchType),
   );
-  const deduplicatedResults = deduplicateResults(results);
+  const consideredResults = deduplicateResults(results).slice(0, limit);
 
   if (searchType === "text") {
     const textualResults = await Promise.all(
-      deduplicatedResults.slice(0, limit).map(processTextualResult),
+      consideredResults.map(processTextualResult),
     );
     return reportDiscardedResults(
       filterNullResults(textualResults),
-      results.length,
+      consideredResults.length,
       searchType,
     );
   }
 
   const graphicalResults = await Promise.all(
-    deduplicatedResults.slice(0, limit).map(processGraphicalResult),
+    consideredResults.map(processGraphicalResult),
   );
   return reportDiscardedResults(
     filterNullResults(graphicalResults),
-    results.length,
+    consideredResults.length,
     searchType,
   );
 }
 
 /**
- * Logs when SearXNG returned results but every one was dropped during processing
- * (e.g. missing title, snippet, or media source). Without this, the discarded
- * batch surfaces to the user as an opaque "Search failed" with no server-side
- * trace of why the non-empty response yielded nothing usable.
+ * Counts and logs when SearXNG returned results but every one that was looked at
+ * got dropped during processing (e.g. missing title, snippet, or media source).
+ * Without this, the discarded batch surfaces to the user as an opaque "Search
+ * failed" with no server-side trace of why the non-empty response yielded
+ * nothing usable.
  */
 function reportDiscardedResults<T>(
   filteredResults: T[],
-  rawResultCount: number,
+  processedResultCount: number,
   searchType: SearchType,
 ): T[] {
-  if (rawResultCount > 0 && filteredResults.length === 0) {
+  if (processedResultCount > 0 && filteredResults.length === 0) {
     incrementSearchesWithAllResultsDiscardedSinceLastRestart();
     printMessage(
-      `All ${rawResultCount} ${searchType} result(s) from SearXNG were discarded during processing (missing title, snippet, or media source).`,
+      `All ${processedResultCount} ${searchType} result(s) from SearXNG were discarded during processing (missing title, snippet, or media source).`,
     );
   }
   return filteredResults;

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -216,7 +216,7 @@ function reportDiscardedResults<T>(
   if (processedResultCount > 0 && filteredResults.length === 0) {
     incrementSearchesWithAllResultsDiscardedSinceLastRestart();
     printMessage(
-      `All ${processedResultCount} ${searchType} result(s) from SearXNG were discarded during processing (missing title, snippet, or media source).`,
+      `All ${processedResultCount} ${searchType} result(s) processed from the SearXNG response were discarded (missing title, snippet, or media source).`,
     );
   }
   return filteredResults;


### PR DESCRIPTION
## Description

Currently, `server/webSearchService.ts` writes the query into the log in two places: when SearXNG returns nothing, and when a non-empty response is filtered down to nothing. `printMessage.enabled = true` at the top of the file, so no setting turns them off, and on an instance with more than one user that log becomes a record of what people searched for.

Both lines keep their diagnosis and lose the query: the unresponsive engine names still appear behind an empty response, and the discarded-batch line still reports its count and search type. `reportDiscardedResults` no longer takes a `query` parameter.

The aggregate moves to two counters in `server/searchesSinceLastRestart.ts`, next to the existing search counters, and `/status` reports them as `searchesWithoutResults` and `searchesWithAllResultsDiscarded`.

On the open question in the issue: the engine names stay, since they describe the instance rather than the person searching.

While in the function, the discarded-batch line also stopped overstating its count. It reported `results.length` (before dedup, before the limit), so a 200-result response would claim all 200 were discarded when only 30 were ever looked at. It now reports what was processed, and the parameter is named `processedResultCount`.

Fixes #2354.

## How to test

1. Run `npx vitest run server/webSearchService.test.ts`. The new `query privacy` block drives five searches with a distinctive query (empty response, all results discarded, malformed body, a successful image search, and a network failure) and asserts it appears in no line the module logs, in its raw, percent-encoded and `+`-encoded forms. The capture covers both `debug` and direct `console` calls, so a new logging line is caught whichever it uses.
2. Start the app and open `/status`: the two new fields sit right after `averageGraphicalSearchesPerSession`.

Checks I ran: the privacy test fails on the pre-fix code for the right reason, and it also fails if I add a `console.warn` or a line logging the search URL (both tried by hand, both reverted). `npx vitest run` passes 572 tests, `npm run lint` exits 0.

Note: the counters were exercised through the unit tests, not against a live SearXNG. I ran the dev server to confirm the `/status` payload, but SearXNG wasn't reachable from there, so both fields read 0.

Two follow-ups came out of a review of this branch, both left out on purpose: #2357 (say in `docs/security.md` that queries never reach the log) and #2358 (`/inference` logs whole error objects, and an AI SDK error carries the prompt in `requestBodyValues`, which is a larger leak than this one).
