### PR TITLE
Fix the issue-template paths in the documentation validator

### DIFF
--- a/scripts/documentation-validator.cjs
+++ b/scripts/documentation-validator.cjs
@@ -11,23 +11,25 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 // Configuration
-const docsDir = path.join(__dirname, "..");
+const defaultDocsDir = path.join(__dirname, "..");
+// The .yml issue forms are listed so a renamed or deleted template is caught;
+// they only link out today, so the link check finds nothing in them.
 const documentationFiles = [
   "README.md",
   ".github/CONTRIBUTING.md",
   ".github/CODE_OF_CONDUCT.md",
   ".github/SECURITY.md",
   ".github/PULL_REQUEST_TEMPLATE.md",
-  ".github/ISSUE_TEMPLATE/bug_report.md",
-  ".github/ISSUE_TEMPLATE/feature_request.md",
-  ".github/ISSUE_TEMPLATE/security_vulnerability.md",
+  ".github/ISSUE_TEMPLATE/bug_report.yml",
+  ".github/ISSUE_TEMPLATE/feature_request.yml",
+  ".github/ISSUE_TEMPLATE/security_vulnerability.yml",
 ];
 
 // Regex patterns for finding internal links
 const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
 const htmlLinkRegex = /<a[^>]+href="([^"]+)"[^>]*>/g;
 
-function validateFile(filePath) {
+function validateFile(filePath, docsDir = defaultDocsDir) {
   try {
     const content = fs.readFileSync(filePath, "utf8");
     const relativePath = path.relative(docsDir, filePath);
@@ -103,7 +105,7 @@ function validateFile(filePath) {
   }
 }
 
-function main() {
+function main(docsDir = defaultDocsDir) {
   console.log("🔍 Validating documentation links...\n");
 
   let totalIssues = 0;
@@ -114,14 +116,16 @@ function main() {
 
     if (!fs.existsSync(filePath)) {
       console.log(`❌ File not found: ${docFile}`);
+      totalIssues++;
       continue;
     }
 
     totalFiles++;
-    const result = validateFile(filePath);
+    const result = validateFile(filePath, docsDir);
 
     if (result.error) {
       console.log(`❌ Error reading ${result.file}: ${result.error}`);
+      totalIssues++;
       continue;
     }
 
@@ -140,7 +144,7 @@ function main() {
   }
 
   console.log(`\n📊 Summary:`);
-  console.log(`   Files checked: ${totalFiles}`);
+  console.log(`   Files checked: ${totalFiles}/${documentationFiles.length}`);
   console.log(`   Issues found: ${totalIssues}`);
 
   if (totalIssues > 0) {
@@ -155,7 +159,17 @@ function main() {
 }
 
 if (require.main === module) {
-  main();
+  const rootDirArg = process.argv[2];
+
+  if (
+    rootDirArg &&
+    !fs.statSync(rootDirArg, { throwIfNoEntry: false })?.isDirectory()
+  ) {
+    console.error(`❌ Directory not found: ${rootDirArg}`);
+    process.exit(1);
+  }
+
+  main(rootDirArg || undefined);
 }
 
-module.exports = { validateFile };
+module.exports = { validateFile, documentationFiles };

--- a/scripts/documentation-validator.test.js
+++ b/scripts/documentation-validator.test.js
@@ -1,0 +1,116 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.resolve(__dirname, "documentation-validator.cjs");
+const REPO_ROOT = path.resolve(__dirname, "..");
+const { documentationFiles } = createRequire(import.meta.url)(SCRIPT_PATH);
+
+function runValidator(rootDir, cwd = REPO_ROOT) {
+  try {
+    const output = execFileSync(process.execPath, [SCRIPT_PATH, rootDir], {
+      cwd,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { exitCode: 0, stdout: output, stderr: "" };
+  } catch (error) {
+    if (error.signal) throw new Error(`Killed by ${error.signal}`);
+    return {
+      exitCode: error.status ?? 1,
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+    };
+  }
+}
+
+function writeDoc(dir, relPath, content) {
+  const fullPath = path.join(dir, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+}
+
+describe("documentation-validator", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "doc-validator-test-"));
+    for (const docFile of documentationFiles) {
+      writeDoc(tmpDir, docFile, "# Doc\n");
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists no file this repository is missing", () => {
+    expect(runValidator(REPO_ROOT).stdout).not.toContain("File not found");
+  });
+
+  it("fails and counts the issue when a listed file is missing", () => {
+    const missing = ".github/ISSUE_TEMPLATE/bug_report.yml";
+    fs.rmSync(path.join(tmpDir, missing));
+
+    const { exitCode, stdout } = runValidator(tmpDir);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain(`File not found: ${missing}`);
+    expect(stdout).toMatch(/Issues found: 1$/m);
+  });
+
+  it("fails and counts the issue when a listed file cannot be read", () => {
+    const unreadable = path.join(tmpDir, ".github/SECURITY.md");
+    fs.rmSync(unreadable);
+    fs.mkdirSync(unreadable);
+
+    const { exitCode, stdout } = runValidator(tmpDir);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("Error reading .github/SECURITY.md");
+    expect(stdout).toMatch(/Issues found: 1$/m);
+  });
+
+  it("counts a broken link the same way it reports it", () => {
+    writeDoc(tmpDir, "README.md", "# Doc\n\n[Gone](./nonexistent.md)\n");
+
+    const { exitCode, stdout } = runValidator(tmpDir);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Missing target: "./nonexistent.md"');
+    expect(stdout).toMatch(/Issues found: 1$/m);
+  });
+
+  it("rejects a root directory that does not exist", () => {
+    const { exitCode, stderr } = runValidator(path.join(tmpDir, "missing"));
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Directory not found");
+  });
+
+  it("rejects a file given where a root directory belongs", () => {
+    const { exitCode, stderr } = runValidator(path.join(tmpDir, "README.md"));
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Directory not found");
+  });
+
+  it("falls back to the repository root when the argument is empty", () => {
+    const elsewhere = fs.mkdtempSync(
+      path.join(os.tmpdir(), "doc-validator-cwd-"),
+    );
+
+    try {
+      expect(runValidator("", elsewhere).stdout).not.toContain(
+        "File not found",
+      );
+    } finally {
+      fs.rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Description

Currently, `scripts/documentation-validator.cjs` looks for the three issue templates as `.md`, but the repo ships them as `.yml`. So every lint run prints three `File not found` lines nobody can act on, the three templates that do exist are never checked, and the summary right below says `Issues found: 0`, contradicting the output above it.

This PR does three things:

- Points the three entries at the `.yml` paths, so a renamed or deleted form is caught. (Today the only link in them is external, to docs.github.com, so the link check finds nothing else there.)
- Counts a missing or unreadable file as an issue. This changes the lint gate: before, deleting a listed doc printed a line and still exited 0, so only broken links could fail the check. Now a missing or unreadable doc fails `npm run lint` too.
- Prints `Files checked: 8/8` instead of `Files checked: 8`, so a file that was skipped is visible in the count.

It also adds `scripts/documentation-validator.test.js`, and with it an optional root-directory argument (`node scripts/documentation-validator.cjs [rootDir]`) so the tests can run against a fixture instead of the real tree. It defaults to the repository root, so the script keeps working from any directory. (`doc-gardening.cjs` and `architectural-linter.cjs` take the same argument, but default to the current working directory.)

Fixes #2352

## How to test

1. Run `npm run lint`. There are no `File not found` lines, and it ends with `Files checked: 8/8` and `Issues found: 0`.
2. Run `npx vitest run scripts/documentation-validator.test.js` (7 tests).
3. Point the script at an empty directory: `node scripts/documentation-validator.cjs "$(mktemp -d)"`. It reports all eight files as missing, prints `Files checked: 0/8` and `Issues found: 8`, and exits 1. Your working tree is untouched.
