### PR TITLE
fix(results): tolerate unparseable image source URLs

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -109,4 +109,40 @@ describe("ImageResultsList", () => {
     expect(slide).toBeInTheDocument();
     expect(slide?.getAttribute("style") ?? "").not.toContain("transition");
   });
+
+  it("renders when a result's source URL is protocol-relative or relative", async () => {
+    const resultsWithUnparseableSource: ImageSearchResult[] = [
+      [
+        "Protocol-relative source",
+        "https://example.com/protocol-relative",
+        "https://example.com/protocol-relative.jpg",
+        "//cdn.example.com/protocol-relative.jpg",
+      ],
+      [
+        "Relative source",
+        "https://example.com/relative",
+        "https://example.com/relative.jpg",
+        "/img/relative.jpg",
+      ],
+    ];
+
+    render(
+      <MantineProvider>
+        <ImageResultsList imageResults={resultsWithUnparseableSource} />
+      </MantineProvider>,
+    );
+
+    // The lightbox slides are built on every render, so an unparseable source
+    // URL used to throw here and take down the whole image section.
+    expect(
+      await screen.findByRole("button", {
+        name: "Open image preview: Protocol-relative source",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: "Open image preview: Relative source",
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -115,7 +115,7 @@ export default function ImageResultsList({
               )}
               {sourceUrl && (
                 <Text size="xs" c="dimmed">
-                  Source: {new URL(sourceUrl).hostname}
+                  Source: {getHostname(sourceUrl)}
                 </Text>
               )}
               <Group align="center" justify="center" gap="xs">


### PR DESCRIPTION
## Description

The lightbox slides in `ImageResultsList` are built on every render, and the source label ran `new URL(sourceUrl).hostname` directly. When SearXNG returns a protocol-relative or relative source URL — which happens for videos via `iframe_src` (e.g. `//www.youtube.com/embed/...`) and sometimes for images via `img_src` — `new URL()` throws `TypeError: Invalid URL`. Because the component sits inside the `ErrorBoundary` in `SearchResultsSection`, one bad result replaced the whole image section with the "Error loading search results" alert.

The fix uses `getHostname()`, which this component already imports and uses for the thumbnail aria-label and the "Visit" link. It returns the hostname when the URL parses and falls back to the original string otherwise, so the section keeps rendering no matter what an engine returns.

### What changed

- `client/components/Search/Results/Graphical/ImageResultsList.tsx`: source label now uses `getHostname(sourceUrl)`.
- `client/components/Search/Results/Graphical/ImageResultsList.test.tsx`: regression test rendering the list with a protocol-relative and a relative source URL; it fails on the pre-fix code with the render crash and passes after.

## How to test

1. Run `npx vitest run client/components/Search/Results/Graphical/ImageResultsList.test.tsx` — all 5 tests pass, including the new one.
2. The new test throws on the old `new URL(sourceUrl).hostname` line (verified by hand), so it actually pins the fix.
3. In the UI: search for something that returns a video result; the image section renders instead of collapsing to the error alert.

Checks I ran: the new test fails on the pre-fix line and passes on the fix; `npx vitest run` passes 578 tests (the only 2 failures are the pre-existing Windows-only path-separator assertions in the doc scripts, present on a clean checkout too); `biome check` and `tsc -p tsconfig.node.json --noEmit` are clean on the changed files.

Fixes #2363
