### PR TITLE
fix: stop crashing on protocol-relative image source URLs

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -109,4 +109,41 @@ describe("ImageResultsList", () => {
     expect(slide).toBeInTheDocument();
     expect(slide?.getAttribute("style") ?? "").not.toContain("transition");
   });
+
+  it("renders source labels for protocol-relative and relative source URLs", async () => {
+    const user = userEvent.setup();
+    render(
+      <MantineProvider>
+        <ImageResultsList
+          imageResults={[
+            [
+              "Protocol-relative video",
+              "https://example.com/video",
+              "https://example.com/video.jpg",
+              "//www.youtube.com/embed/dQw4w9WgXcQ",
+            ],
+            [
+              "Relative source image",
+              "https://example.com/relative",
+              "https://example.com/relative.jpg",
+              "/images/source.jpg",
+            ],
+          ]}
+        />
+      </MantineProvider>,
+    );
+
+    const thumbnail = await screen.findByRole("button", {
+      name: "Open image preview: Protocol-relative video",
+    });
+    await user.click(thumbnail);
+
+    const dialog = await screen.findByRole("dialog");
+    // getHostname() leaves unparseable URLs untouched instead of throwing, so
+    // a protocol-relative or relative source URL no longer takes down the
+    // whole image section during render.
+    expect(dialog).toHaveTextContent(
+      "Source: //www.youtube.com/embed/dQw4w9WgXcQ",
+    );
+  });
 });

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -115,7 +115,7 @@ export default function ImageResultsList({
               )}
               {sourceUrl && (
                 <Text size="xs" c="dimmed">
-                  Source: {new URL(sourceUrl).hostname}
+                  Source: {getHostname(sourceUrl)}
                 </Text>
               )}
               <Group align="center" justify="center" gap="xs">


### PR DESCRIPTION
Fixes #2363

`new URL(sourceUrl).hostname` throws on protocol-relative (`//www.youtube.com/embed/...`) and relative (`/images/...`) source URLs, and since the lightbox slides are rebuilt on every render, a single bad result swapped the whole image section for the "Error loading search results" alert.

Video results come in as SearXNG `iframe_src`, which engines routinely return protocol-relative (YouTube embeds especially), and some image engines return relative `img_src` values too, so this isn't an exotic case.

Swapped the label to the existing `getHostname()` helper — it already falls back to the raw string for unparseable URLs and is what this same component uses for the aria-label and the "Visit" link.

Added a regression test with a protocol-relative and a relative source URL; before the change the render threw `TypeError: Invalid URL`.

Verified with `vitest run`, `biome check`, and `tsc`.