### PR TITLE
fix: tell a failed search apart from one with no results

### DIFF
--- a/client/modules/search.test.ts
+++ b/client/modules/search.test.ts
@@ -317,15 +317,16 @@ describe("Search Module", () => {
   });
 
   describe("Cache Failure Scenarios", () => {
-    it("should return empty results instead of throwing when a text search fails end-to-end", async () => {
+    it("should propagate the failure when a text search fails end-to-end", async () => {
       // getCachedResult/cacheResult swallow their own read/write errors, so a
       // cache failure surfaces as a miss followed by a real fetch — searchText
-      // must still resolve gracefully instead of throwing.
+      // must reject so callers can tell an outage apart from an empty result
+      // set instead of collapsing both into [].
       mockFetch.mockRejectedValue(new Error("Cache read error"));
 
-      const results = await searchModule.searchText("test query");
-
-      expect(results).toEqual([]);
+      await expect(searchModule.searchText("test query")).rejects.toThrow(
+        "Cache read error",
+      );
       expect(addLogEntry).toHaveBeenCalledWith(
         expect.stringContaining("Text search failed"),
       );
@@ -344,15 +345,16 @@ describe("Search Module", () => {
   });
 
   describe("Database Integrity Failures", () => {
-    it("should return empty results instead of throwing when an image search fails end-to-end", async () => {
+    it("should propagate the failure when an image search fails end-to-end", async () => {
       // ensureIntegrity/cleanExpiredCache swallow their own errors, so a
       // corrupted database surfaces as a miss followed by a real fetch —
-      // searchImages must still resolve gracefully instead of throwing.
+      // searchImages must reject so callers can tell an outage apart from an
+      // empty result set instead of collapsing both into [].
       mockFetch.mockRejectedValue(new Error("Database integrity check failed"));
 
-      const results = await searchModule.searchImages("test query");
-
-      expect(results).toEqual([]);
+      await expect(searchModule.searchImages("test query")).rejects.toThrow(
+        "Database integrity check failed",
+      );
       expect(addLogEntry).toHaveBeenCalledWith(
         expect.stringContaining("Image search failed"),
       );

--- a/client/modules/search.ts
+++ b/client/modules/search.ts
@@ -497,7 +497,7 @@ const searchService = {
       addLogEntry(
         `Text search failed: ${error instanceof Error ? error.message : String(error)}`,
       );
-      return [];
+      throw error;
     }
   },
 
@@ -525,7 +525,7 @@ const searchService = {
       addLogEntry(
         `Image search failed: ${error instanceof Error ? error.message : String(error)}`,
       );
-      return [];
+      throw error;
     }
   },
 

--- a/client/modules/textGeneration.degradation.test.ts
+++ b/client/modules/textGeneration.degradation.test.ts
@@ -6,6 +6,7 @@ const harness = vi.hoisted(() => {
     response: "",
     textGenerationState: "idle",
     textSearchState: "idle",
+    imageSearchState: "idle",
     textSearchResults: [] as unknown[],
     pageContents: {} as Record<string, string>,
     searchRunId: "run-1",
@@ -40,7 +41,9 @@ vi.mock("./pubSub", () => ({
   updateChatMessages: vi.fn(),
   updateConversationSummary: vi.fn(),
   updateImageSearchResults: vi.fn(),
-  updateImageSearchState: vi.fn(),
+  updateImageSearchState: (value: string) => {
+    harness.state.imageSearchState = value;
+  },
   updateLlmTextSearchResults: vi.fn(),
   updatePageContents: (contents: Record<string, string>) => {
     harness.state.pageContents = contents;
@@ -149,6 +152,7 @@ describe("search degradation", () => {
     harness.state.response = "";
     harness.state.textGenerationState = "idle";
     harness.state.textSearchState = "idle";
+    harness.state.imageSearchState = "idle";
     harness.state.textSearchResults = [];
     harness.state.settings.enableAiResponse = false;
     harness.state.settings.enableTextSearch = true;
@@ -179,7 +183,7 @@ describe("search degradation", () => {
     expect(harness.state.textSearchState).toBe("completed");
   });
 
-  it("reports the text search as failed when the keyword fallback is also empty", async () => {
+  it("leaves the text search completed with no results when the keyword fallback is also empty", async () => {
     vi.mocked(searchText).mockResolvedValue([]);
 
     await searchAndRespond();
@@ -187,7 +191,67 @@ describe("search degradation", () => {
 
     expect(searchText).toHaveBeenCalledTimes(2);
     expect(harness.state.textSearchResults).toEqual([]);
+    expect(harness.state.textSearchState).toBe("completed");
+  });
+
+  it("reports the text search as failed when the provider is down", async () => {
+    vi.mocked(searchText).mockRejectedValue(
+      new Error("HTTP error! status: 503"),
+    );
+
+    await searchAndRespond();
+    await harness.state.searchPromise;
+
+    // An outage is not an empty result set, so there is no keyword fallback.
+    expect(searchText).toHaveBeenCalledTimes(1);
+    expect(harness.state.textSearchResults).toEqual([]);
     expect(harness.state.textSearchState).toBe("failed");
+  });
+
+  it("reports the text search as failed when the keyword fallback also fails", async () => {
+    vi.mocked(searchText)
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("HTTP error! status: 503"));
+
+    await searchAndRespond();
+    await harness.state.searchPromise;
+
+    expect(searchText).toHaveBeenCalledTimes(2);
+    expect(harness.state.textSearchResults).toEqual([]);
+    expect(harness.state.textSearchState).toBe("failed");
+  });
+});
+
+describe("image search degradation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.state.query = "cat pictures";
+    harness.state.imageSearchState = "idle";
+    harness.state.settings.enableAiResponse = false;
+    harness.state.settings.enableTextSearch = false;
+    harness.state.settings.enableImageSearch = true;
+  });
+
+  it("leaves the image search completed with no results when the search comes back empty", async () => {
+    vi.mocked(searchImages).mockResolvedValue([]);
+
+    await searchAndRespond();
+
+    await vi.waitFor(() =>
+      expect(harness.state.imageSearchState).toBe("completed"),
+    );
+  });
+
+  it("reports the image search as failed when the provider is down", async () => {
+    vi.mocked(searchImages).mockRejectedValue(
+      new Error("HTTP error! status: 503"),
+    );
+
+    await searchAndRespond();
+
+    await vi.waitFor(() =>
+      expect(harness.state.imageSearchState).toBe("failed"),
+    );
   });
 });
 

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -425,29 +425,35 @@ async function startTextSearch(query: string) {
   if (getSettings().enableTextSearch) {
     updateTextSearchState("running");
 
-    let textResults = await searchText(
-      searchQuery,
-      getSettings().searchResultsLimit,
-    );
-
-    if (textResults.length === 0) {
-      const queryKeywords = await getKeywords(query, 10);
-      const keywordResults = await searchText(
-        queryKeywords.join(" "),
+    let textResults: TextSearchResults;
+    let searchFailed = false;
+    try {
+      textResults = await searchText(
+        searchQuery,
         getSettings().searchResultsLimit,
       );
-      textResults = keywordResults;
+
+      if (textResults.length === 0) {
+        const queryKeywords = await getKeywords(query, 10);
+        textResults = await searchText(
+          queryKeywords.join(" "),
+          getSettings().searchResultsLimit,
+        );
+      }
+    } catch (error) {
+      // The provider is down, not the query: don't retry with keywords, and
+      // let the failed state surface instead of the empty-results alert.
+      searchFailed = true;
+      addLogEntry(
+        `Text search failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      textResults = [];
     }
 
     results.textResults = textResults;
 
-    updateTextSearchState(
-      results.textResults.length === 0 ? "failed" : "completed",
-    );
+    updateTextSearchState(searchFailed ? "failed" : "completed");
     updateTextSearchResults(textResults);
-
-    const resultsForLlm = textResults.slice(0, searchResultsToConsider);
-    updateLlmTextSearchResults(resultsForLlm);
 
     updateSearchResults(getCurrentSearchRunId(), {
       type: "text",
@@ -458,9 +464,18 @@ async function startTextSearch(query: string) {
       })),
     });
 
-    // Started here but awaited last: only the AI answer waits on it, while
-    // image search and the history write carry on.
-    pageContentsRead = readPageContents(searchQuery, resultsForLlm);
+    if (searchFailed) {
+      // Keep the next answer from grounding on the previous query's
+      // results when the provider is down.
+      updateLlmTextSearchResults([]);
+    } else {
+      const resultsForLlm = textResults.slice(0, searchResultsToConsider);
+      updateLlmTextSearchResults(resultsForLlm);
+
+      // Started here but awaited last: only the AI answer waits on it, while
+      // image search and the history write carry on.
+      pageContentsRead = readPageContents(searchQuery, resultsForLlm);
+    }
   }
 
   if (getSettings().enableImageSearch) {
@@ -476,25 +491,35 @@ async function startImageSearch(
   searchQuery: string,
   results: { textResults: TextSearchResults; imageResults: ImageSearchResults },
 ) {
-  const imageResults = await searchImages(
-    searchQuery,
-    getSettings().searchResultsLimit,
-  );
-  results.imageResults = imageResults;
-  updateImageSearchState(
-    results.imageResults.length === 0 ? "failed" : "completed",
-  );
-  updateImageSearchResults(imageResults);
+  try {
+    const imageResults = await searchImages(
+      searchQuery,
+      getSettings().searchResultsLimit,
+    );
+    results.imageResults = imageResults;
+    updateImageSearchState("completed");
+    updateImageSearchResults(imageResults);
 
-  updateSearchResults(getCurrentSearchRunId(), {
-    type: "image",
-    items: imageResults.map(([title, url, thumbnailUrl, sourceUrl]) => ({
-      title,
-      url,
-      thumbnail: thumbnailUrl,
-      sourceUrl,
-    })),
-  });
+    updateSearchResults(getCurrentSearchRunId(), {
+      type: "image",
+      items: imageResults.map(([title, url, thumbnailUrl, sourceUrl]) => ({
+        title,
+        url,
+        thumbnail: thumbnailUrl,
+        sourceUrl,
+      })),
+    });
+  } catch (error) {
+    addLogEntry(
+      `Image search failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    updateImageSearchState("failed");
+    updateImageSearchResults([]);
+    updateSearchResults(getCurrentSearchRunId(), {
+      type: "image",
+      items: [],
+    });
+  }
 }
 
 function canDownloadModels(): Promise<void> {

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -14,9 +14,10 @@ needed.
 | SearXNG answers 500 on every attempt | Retry cycle exhausts (4 requests) and costs a single circuit-breaker failure | `server/webSearchService.test.ts` › graceful degradation |
 | SearXNG fails five cycles in a row | Circuit opens; further searches short-circuit without calling the upstream | `server/webSearchService.test.ts` › graceful degradation |
 | SearXNG recovers after the reset timeout | One healthy response closes the circuit again | `server/webSearchService.test.ts` › graceful degradation |
-| SearXNG answers 200 with a non-JSON body | Empty result set, no throw | `server/webSearchService.test.ts` › graceful degradation |
+| SearXNG answers 200 with a non-JSON body | Search fails: 503 from `/search/*`, client state `failed` | `server/webSearchService.test.ts` › graceful degradation |
 | SearXNG returns results that are all unusable | Empty result set, no throw | `server/webSearchService.test.ts` › graceful degradation |
-| Provider down vs. genuinely zero results | Both yield `[]` (indistinguishable downstream, see Known Limitations) | `server/webSearchService.test.ts` › graceful degradation |
+| SearXNG is down (bad status, network error, or open circuit) | Search fails: 503 from `/search/*`, client state `failed`, no keyword fallback | `server/webSearchService.test.ts` › graceful degradation, `server/searchEndpointServerHook.test.ts` › graceful degradation, `client/modules/textGeneration.degradation.test.ts` |
+| SearXNG answers with genuinely zero results | HTTP 200 with `[]`; client state `completed`, empty-state alert renders | `server/webSearchService.test.ts` › graceful degradation, `server/searchEndpointServerHook.test.ts` › graceful degradation, `client/modules/textGeneration.degradation.test.ts` |
 | Reranker is not ready | Results served in SearXNG order, HTTP 200 | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Reranking throws mid-request | Results served in SearXNG order, HTTP 200 | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Reranker is not ready on an image search | Images still served with thumbnails | `server/searchEndpointServerHook.test.ts` › graceful degradation |
@@ -25,7 +26,10 @@ needed.
 | Thumbnail host never answers | Request aborted after the timeout, image dropped | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |
-| Keyword fallback also returns nothing | Text search state becomes `failed` | `client/modules/textGeneration.degradation.test.ts` |
+| Keyword fallback also returns nothing | Text search state becomes `completed`, empty-state alert renders | `client/modules/textGeneration.degradation.test.ts` |
+| Text search provider is down | State becomes `failed`, keyword fallback is not attempted | `client/modules/textGeneration.degradation.test.ts` |
+| Image search provider is down | Image search state becomes `failed` | `client/modules/textGeneration.degradation.test.ts` |
+| Image search returns nothing | Image search state becomes `completed`, empty-state alert renders | `client/modules/textGeneration.degradation.test.ts` |
 | Result page host resolves into a private range | Page skipped, no request is made | `server/pageContentService.test.ts` › fetchPageContents |
 | Result page redirects into a private range | Redirect not followed, page skipped | `server/pageContentService.test.ts` › fetchPageContents |
 | Result page errors, is not a document, or yields no text | That page is skipped, the others still return | `server/pageContentService.test.ts` › fetchPageContents |
@@ -41,12 +45,14 @@ needed.
 | `/inference` answers 503 | Generation state becomes `failed`, nothing persisted | `client/modules/textGeneration.degradation.test.ts` |
 | Generation interrupted mid-stream | Partial answer preserved, state stays `interrupted` | `client/modules/textGeneration.degradation.test.ts` |
 
-## Known Limitations
+## Failure vs. empty results
 
-`fetchSearXNG` catches every failure and returns `[]`, so "the provider is down"
-and "there are no results for this query" reach the client as the same response.
-The matrix pins that behavior rather than hiding it: changing it means changing
-the endpoint contract, and the test is where that decision becomes visible.
+`fetchSearXNG` rethrows upstream failures as `SearXNGSearchError`, the endpoint
+answers 503 for them, and the client maps that to the `failed` state — so an
+outage no longer masquerades as "no results for this query". A genuinely empty
+result set still travels as HTTP 200 with `[]` and lands on the `completed`
+state with the empty-state alert, and the keyword fallback only fires for real
+empty result sets, never for an outage.
 
 ## Adding a Row
 

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -20,6 +20,12 @@ vi.mock("./searchesSinceLastRestart", () => ({
 
 vi.mock("./webSearchService", () => ({
   fetchSearXNG: vi.fn(),
+  SearXNGSearchError: class SearXNGSearchError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "SearXNGSearchError";
+    }
+  },
 }));
 
 import { handleTokenVerification } from "./handleTokenVerification";
@@ -30,7 +36,7 @@ import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
 } from "./searchesSinceLastRestart";
-import { fetchSearXNG } from "./webSearchService";
+import { fetchSearXNG, SearXNGSearchError } from "./webSearchService";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -443,7 +449,47 @@ describe("searchEndpointServerHook", () => {
       }
     });
 
-    it("serves an empty result set instead of an error when SearXNG is down", async () => {
+    it("answers 503 when SearXNG is down", async () => {
+      vi.mocked(fetchSearXNG).mockRejectedValue(
+        new SearXNGSearchError("SearXNG request failed with status 503"),
+      );
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/text?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(503);
+      expect(response.end).toHaveBeenCalledWith(
+        JSON.stringify({ error: "Search provider unavailable" }),
+      );
+    });
+
+    it("answers 503 on an image search when SearXNG is down", async () => {
+      vi.mocked(fetchSearXNG).mockRejectedValue(
+        new SearXNGSearchError("SearXNG request failed with status 503"),
+      );
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(503);
+      expect(response.end).toHaveBeenCalledWith(
+        JSON.stringify({ error: "Search provider unavailable" }),
+      );
+    });
+
+    it("serves an empty result set when SearXNG returns no results", async () => {
       vi.mocked(fetchSearXNG).mockResolvedValue([]);
 
       const handler = getRegisteredHandler();

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -7,7 +7,7 @@ import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
 } from "./searchesSinceLastRestart.ts";
-import { fetchSearXNG } from "./webSearchService.ts";
+import { fetchSearXNG, SearXNGSearchError } from "./webSearchService.ts";
 
 const THUMBNAIL_TIMEOUT_MS = 1000;
 const DEFAULT_SEARCH_LIMIT = 30;
@@ -176,9 +176,18 @@ export function searchEndpointServerHook<
         "Error processing search:",
         error instanceof Error ? error.message : error,
       );
-      response.statusCode = 500;
+      // A failed SearXNG call means the provider is down, not that the query
+      // has no results — those two cases must reach the client differently.
+      const isUpstreamFailure = error instanceof SearXNGSearchError;
+      response.statusCode = isUpstreamFailure ? 503 : 500;
       response.setHeader("Content-Type", "application/json");
-      response.end(JSON.stringify({ error: "Internal server error" }));
+      response.end(
+        JSON.stringify({
+          error: isUpstreamFailure
+            ? "Search provider unavailable"
+            : "Internal server error",
+        }),
+      );
     }
   });
 }

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -17,6 +17,7 @@ import {
   describeUnresponsiveEngines,
   fetchSearXNG,
   getWebSearchStatus,
+  SearXNGSearchError,
 } from "./webSearchService";
 
 function createMockResponse(
@@ -121,13 +122,13 @@ describe("WebSearchService", () => {
     }
   });
 
-  it("should return empty array on fetchSearXNG error", async () => {
+  it("rejects when SearXNG is unreachable", async () => {
     (global.fetch as MockedFunction<typeof fetch>).mockRejectedValue(
       new Error("Network failure"),
     );
-    const results = await fetchSearXNG("test query", "text");
-    expect(Array.isArray(results)).toBe(true);
-    expect(results).toHaveLength(0);
+    await expect(fetchSearXNG("test query", "text")).rejects.toThrow(
+      SearXNGSearchError,
+    );
   });
 });
 
@@ -179,15 +180,20 @@ describe("retry logic", () => {
     expect(results).toHaveLength(1);
   });
 
-  it("returns empty array when all retries return 500", async () => {
+  it("rejects when every retry answers 500", async () => {
     fetchMock.mockResolvedValue(createMockResponse("", false, 500));
 
     const promise = fetchSearXNG("test", "text");
+    const guarded = promise.catch((error: unknown) => {
+      throw error;
+    });
+    guarded.catch(() => {});
     await vi.runAllTimersAsync();
-    const results = await promise;
 
+    await expect(guarded).rejects.toThrow(
+      "SearXNG request failed with status 500",
+    );
     expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(results).toHaveLength(0);
   });
 });
 
@@ -210,8 +216,15 @@ describe("graceful degradation", () => {
    */
   async function searchThroughRetries(breaker: CircuitBreaker) {
     const promise = fetchSearXNG("failure injection", "text", 30, breaker);
+    const guarded = promise.catch((error: unknown) => {
+      throw error;
+    });
+    // Observe the rejection now so the failed retry cycle is not flagged as
+    // unhandled while the backoff timers drain; callers still see it through
+    // `guarded`.
+    guarded.catch(() => {});
     await vi.advanceTimersByTimeAsync(RETRY_BACKOFF_TOTAL_MS);
-    return promise;
+    return guarded;
   }
 
   beforeEach(() => {
@@ -227,8 +240,9 @@ describe("graceful degradation", () => {
     fetchMock.mockResolvedValue(createMockResponse("", false, 500));
 
     for (let cycle = 0; cycle < breakerOptions.failureThreshold - 1; cycle++) {
-      const results = await searchThroughRetries(breaker);
-      expect(results).toEqual([]);
+      await expect(searchThroughRetries(breaker)).rejects.toThrow(
+        SearXNGSearchError,
+      );
     }
 
     // Four full cycles of upstream requests, still one failure short of opening.
@@ -243,7 +257,7 @@ describe("graceful degradation", () => {
     fetchMock.mockResolvedValue(createMockResponse("", false, 500));
 
     for (let cycle = 0; cycle < breakerOptions.failureThreshold; cycle++) {
-      await searchThroughRetries(breaker);
+      await expect(searchThroughRetries(breaker)).rejects.toThrow();
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(
@@ -252,9 +266,7 @@ describe("graceful degradation", () => {
     expect(breaker.getState("searxng")).toBe("OPEN");
 
     const callsWhileOpen = fetchMock.mock.calls.length;
-    const results = await searchThroughRetries(breaker);
-
-    expect(results).toEqual([]);
+    await expect(searchThroughRetries(breaker)).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(callsWhileOpen);
   });
 
@@ -267,7 +279,9 @@ describe("graceful degradation", () => {
       failure < breakerOptions.failureThreshold;
       failure++
     ) {
-      await fetchSearXNG("failure injection", "text", 30, breaker);
+      await expect(
+        fetchSearXNG("failure injection", "text", 30, breaker),
+      ).rejects.toThrow();
     }
 
     expect(breaker.getState("searxng")).toBe("OPEN");
@@ -286,15 +300,12 @@ describe("graceful degradation", () => {
     expect(breaker.getState("searxng")).toBe("CLOSED");
   });
 
-  it("cannot be told apart downstream: provider down and genuinely empty both yield []", async () => {
+  it("lets callers tell a provider outage apart from a genuinely empty result set", async () => {
     const downBreaker = new CircuitBreaker({ failureThreshold: 1 });
     fetchMock.mockResolvedValue(createMockResponse("", false, 503));
-    const providerDown = await fetchSearXNG(
-      "failure injection",
-      "text",
-      30,
-      downBreaker,
-    );
+    await expect(
+      fetchSearXNG("failure injection", "text", 30, downBreaker),
+    ).rejects.toThrow(SearXNGSearchError);
 
     const emptyBreaker = new CircuitBreaker({ failureThreshold: 1 });
     fetchMock.mockResolvedValue(
@@ -307,24 +318,25 @@ describe("graceful degradation", () => {
       emptyBreaker,
     );
 
-    // The breaker knows which one was a failure; the return value does not.
+    // The breaker always knew which one was a failure; now the return value
+    // carries the same distinction: the outage rejects, the empty result set
+    // resolves to [].
     expect(downBreaker.getState("searxng")).toBe("OPEN");
     expect(emptyBreaker.getState("searxng")).toBe("CLOSED");
-    expect(providerDown).toEqual([]);
     expect(noResults).toEqual([]);
   });
 
-  it("returns an empty array when SearXNG answers 200 with a malformed body", async () => {
+  it("rejects when SearXNG answers 200 with a malformed body", async () => {
     fetchMock.mockResolvedValue(createMockResponse("<html>gateway</html>"));
 
-    const results = await fetchSearXNG(
-      "failure injection",
-      "text",
-      30,
-      new CircuitBreaker(breakerOptions),
-    );
-
-    expect(results).toEqual([]);
+    await expect(
+      fetchSearXNG(
+        "failure injection",
+        "text",
+        30,
+        new CircuitBreaker(breakerOptions),
+      ),
+    ).rejects.toThrow(SearXNGSearchError);
   });
 
   it("returns an empty array when every result is dropped during processing", async () => {
@@ -422,14 +434,24 @@ describe("query privacy", () => {
       createMockResponse("<html>gateway</html>"),
     ]) {
       fetchMock.mockResolvedValue(response);
-      await fetchSearXNG(DISTINCTIVE_QUERY, "text", 30, new CircuitBreaker());
+      await fetchSearXNG(
+        DISTINCTIVE_QUERY,
+        "text",
+        30,
+        new CircuitBreaker(),
+      ).catch(() => {});
     }
 
     fetchMock.mockResolvedValue(imageResultsResponse());
     await fetchSearXNG(DISTINCTIVE_QUERY, "images", 30, new CircuitBreaker());
 
     fetchMock.mockRejectedValue(new Error("Network failure"));
-    await fetchSearXNG(DISTINCTIVE_QUERY, "images", 30, new CircuitBreaker());
+    await fetchSearXNG(
+      DISTINCTIVE_QUERY,
+      "images",
+      30,
+      new CircuitBreaker(),
+    ).catch(() => {});
 
     const output = logLines.join("\n");
     expect(logLines.length).toBeGreaterThan(0);
@@ -476,11 +498,11 @@ describe("circuit breaker", () => {
     fetchMock.mockResolvedValue(createMockResponse("", false, 503));
 
     for (let i = 0; i < 5; i++) {
-      await fetchSearXNG("test", "text", 30, breaker);
+      await expect(fetchSearXNG("test", "text", 30, breaker)).rejects.toThrow();
     }
 
     const callsBeforeBreak = fetchMock.mock.calls.length;
-    await fetchSearXNG("test", "text", 30, breaker);
+    await expect(fetchSearXNG("test", "text", 30, breaker)).rejects.toThrow();
 
     expect(fetchMock.mock.calls.length).toBe(callsBeforeBreak);
   });
@@ -490,11 +512,11 @@ describe("circuit breaker", () => {
     fetchMock.mockResolvedValue(createMockResponse("", false, 503));
 
     for (let i = 0; i < 4; i++) {
-      await fetchSearXNG("test", "text", 30, breaker);
+      await expect(fetchSearXNG("test", "text", 30, breaker)).rejects.toThrow();
     }
 
     const callsBefore = fetchMock.mock.calls.length;
-    await fetchSearXNG("test", "text", 30, breaker);
+    await expect(fetchSearXNG("test", "text", 30, breaker)).rejects.toThrow();
 
     expect(fetchMock.mock.calls.length).toBe(callsBefore + 1);
   });

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -29,6 +29,19 @@ const searxngCircuitBreaker = new CircuitBreaker({
 
 type SearchType = "text" | "images";
 
+/**
+ * Raised when the search could not be completed because the upstream
+ * (SearXNG) is unavailable or answered with something unusable. The endpoint
+ * maps it to a 503 so callers can tell an outage apart from a legitimately
+ * empty result set.
+ */
+export class SearXNGSearchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SearXNGSearchError";
+  }
+}
+
 interface SearxngSearchResult {
   title: string;
   url: string;
@@ -233,7 +246,7 @@ export async function fetchSearXNG(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     printMessage(`Search failed: ${errorMessage}`);
-    return [];
+    throw new SearXNGSearchError(errorMessage);
   }
 }
 


### PR DESCRIPTION
Closes #2336.

### What changed

`fetchSearXNG` used to catch every failure and return `[]`, so when SearXNG was down the client got exactly the same response as a search that simply had no results. Both cases showed the red "Search failed" alert with a retry button — someone searching for something genuinely obscure was told the search broke, and a real outage looked like an ordinary empty search.

Now:

- **Server**: upstream failures throw `SearXNGSearchError`, and `/search/text` / `/search/images` answer **503** for them. A genuinely empty result set still comes back as **200 with `[]`**.
- **Client**: `startTextSearch` / `startImageSearch` no longer derive `failed` from `length === 0`. An outage leaves the state `failed`; an empty result set leaves it `completed`, which renders the already-existing "No results found" alert.
- The keyword fallback in `startTextSearch` only runs for real empty result sets now, so an outage doesn't fire a second request.

### Why a status code

The client already treats a non-OK response as a failure in `searchService.performSearch`, so a 503 needs no new client plumbing — the empty array keeps meaning exactly one thing.

### Tests & docs

- Updated the failure-injection matrix in `docs/failure-injection.md` and removed the Known Limitations entry that pinned the old behavior.
- `server/webSearchService.test.ts` now asserts the outage rejects while a zero-result search resolves to `[]`.
- `server/searchEndpointServerHook.test.ts` asserts 503 for text and image searches when SearXNG is down, and 200 with `[]` for a no-result search.
- `client/modules/textGeneration.degradation.test.ts` covers: empty result set → `completed`, outage → `failed` with no fallback, plus the image-search equivalents.
- `client/modules/search.test.ts` updated for `searchText` / `searchImages` propagating failures instead of collapsing them into `[]`.

Full suite is green (`vitest run`), `tsc` passes, and Biome/knip/jscpd report no issues.
