### PR TITLE
fix(search): keep the lightbox source label from crashing on relative URLs

### DIFF
--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -109,4 +109,60 @@ describe("ImageResultsList", () => {
     expect(slide).toBeInTheDocument();
     expect(slide?.getAttribute("style") ?? "").not.toContain("transition");
   });
+
+  it("opens the lightbox when a source URL is protocol-relative", async () => {
+    const user = userEvent.setup();
+    render(
+      <MantineProvider>
+        <ImageResultsList
+          imageResults={[
+            [
+              "Protocol-relative image",
+              "https://example.com/protocol-relative",
+              "https://example.com/protocol-relative.jpg",
+              "//cdn.example.com/protocol-relative.jpg",
+            ],
+          ]}
+        />
+      </MantineProvider>,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Open image preview: Protocol-relative image",
+      }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain(
+      "Source: //cdn.example.com/protocol-relative.jpg",
+    );
+  });
+
+  it("opens the lightbox when a source URL is relative", async () => {
+    const user = userEvent.setup();
+    render(
+      <MantineProvider>
+        <ImageResultsList
+          imageResults={[
+            [
+              "Relative image",
+              "https://example.com/relative",
+              "https://example.com/relative.jpg",
+              "/images/relative.jpg",
+            ],
+          ]}
+        />
+      </MantineProvider>,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Open image preview: Relative image",
+      }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("Source: /images/relative.jpg");
+  });
 });

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -115,7 +115,7 @@ export default function ImageResultsList({
               )}
               {sourceUrl && (
                 <Text size="xs" c="dimmed">
-                  Source: {new URL(sourceUrl).hostname}
+                  Source: {getHostname(sourceUrl)}
                 </Text>
               )}
               <Group align="center" justify="center" gap="xs">


### PR DESCRIPTION
## Description

The lightbox builds its slides on every render, and the source label called `new URL(sourceUrl)` directly. SearXNG video engines regularly return protocol-relative `iframe_src` values like `//www.youtube.com/embed/...`, and image engines can hand back relative `img_src` paths too — without a base, `new URL()` throws `TypeError: Invalid URL`, which kills the render. Since `ImageResultsList` sits inside the error boundary, one bad result replaced the whole image section with the "Error loading search results" alert.

Switched the label to the `getHostname()` helper that's already used in this same component for the thumbnail aria-label and the "Visit" link. Unparseable URLs now just fall back to the raw string instead of crashing the section.

## How to test

1. Search for something that returns image/video results whose source URL is protocol-relative or relative (or pass such a tuple straight into `ImageResultsList`).
2. Open the lightbox and confirm the source label renders and the section stays intact.
3. `npx vitest run client/components/Search/Results/Graphical/ImageResultsList.test.tsx` — includes new regression cases for `//cdn.example.com/...` and `/images/...` source URLs.

Fixes #2363

## Checks

- `vitest run`: 579/581 pass. The 2 failures are pre-existing on main in `scripts/documentation-validator.test.js` and `scripts/doc-gardening.test.js` — they assert forward-slash paths while the scripts print native `\` separators on a Windows checkout (reproduced with my changes stashed).
- Biome: no issues on the changed files (only the known CRLF noise from a Windows checkout).
- `tsc --noEmit`: clean.
