### PR TITLE
fix(server): log error messages instead of whole error objects

### DIFF
--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -687,6 +687,48 @@ describe("internalApiEndpointServerHook", () => {
       expect(vi.mocked(streamText)).toHaveBeenCalledTimes(1);
     });
 
+    it("does not log the request body when a stream error carries requestBodyValues", async () => {
+      const capturedLogs: unknown[][] = [];
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation((...args: unknown[]) => {
+          capturedLogs.push(args);
+        });
+
+      try {
+        const bodyError = new Error("upstream down") as Error & {
+          requestBodyValues?: unknown;
+        };
+        bodyError.requestBodyValues = {
+          messages: [
+            { role: "system", content: "SYSTEM-PROMPT-SECRET" },
+            { role: "user", content: "QUERY-SECRET" },
+          ],
+        };
+        vi.mocked(streamText).mockImplementation(() => {
+          throw bodyError;
+        });
+
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        await handler(
+          createRequest({
+            messages: [{ role: "user", content: "QUERY-SECRET" }],
+          }),
+          response,
+          vi.fn(),
+        );
+
+        expect(response.statusCode).toBe(503);
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        const logged = JSON.stringify(capturedLogs);
+        expect(logged).not.toContain("SYSTEM-PROMPT-SECRET");
+        expect(logged).not.toContain("QUERY-SECRET");
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
     it("retries on model failure and succeeds on second attempt", async () => {
       vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
 

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -245,7 +245,10 @@ export function internalApiEndpointServerHook<
             const selectedModel = selectRandomModel(availableModels);
             model = selectedModel || undefined;
           } catch (error) {
-            console.error("Error fetching models:", error);
+            console.error(
+              "Error fetching models:",
+              error instanceof Error ? error.message : error,
+            );
             sendJsonError(response, 500, {
               error: "Failed to fetch available models",
             });
@@ -315,7 +318,10 @@ export function internalApiEndpointServerHook<
             throw new Error("Stream ended unexpectedly");
           } catch (error) {
             lastError = error;
-            console.error("Error during streaming:", error);
+            console.error(
+              "Error during streaming:",
+              error instanceof Error ? error.message : error,
+            );
 
             if (hasEmittedContent) break;
             if (attempt >= maxAttempts) break;
@@ -363,7 +369,10 @@ export function internalApiEndpointServerHook<
           model,
         );
       } catch (error) {
-        console.error("Error in internal API endpoint:", error);
+        console.error(
+          "Error in internal API endpoint:",
+          error instanceof Error ? error.message : error,
+        );
         sendJsonError(response, 500, {
           error: "Internal server error",
           message: error instanceof Error ? error.message : "Unknown error",


### PR DESCRIPTION
## Description

Two `console.error` calls in the `/inference` handler logged the whole error object. AI SDK `APICallError` instances carry `requestBodyValues` as an own enumerable property, and for a chat model that's the system prompt (with the search results) plus the user query. `console.error` inspects an `Error` together with its own properties, so one failing upstream day wrote the entire prompt to the server log — a few times per request, since the streaming path retries up to `maxAttempts` (5).

This logs the message only, matching what `searchEndpointServerHook.ts` and `pageContentEndpointServerHook.ts` already do. The model-list fetch error on the same path had the same pattern, so it gets the same treatment.

## How to test

1. Run the test suite: `npx vitest run server/internalApiEndpointServerHook.test.ts`.
2. New test drives the endpoint with a rejected upstream call whose error carries `requestBodyValues` and asserts the prompt text appears in no log output.
3. Reproduce a failing upstream (e.g. point `INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL` at a dead endpoint) and confirm the log shows the reason but not the request body.

Fixes #2358

## Checks

- `vitest run`: 578/580 pass. The 2 failures are pre-existing on main in `scripts/documentation-validator.test.js` and `scripts/doc-gardening.test.js` — they assert forward-slash paths while the scripts print native `\` separators on a Windows checkout (reproduced with my changes stashed).
- Biome: no issues on the changed files (only the known CRLF noise from a Windows checkout).
- `tsc --noEmit`: clean.
