### PR TITLE
fix(server): guard thumbnail fetches against SSRF and cap their size

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -81,17 +81,25 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 
 ### Server-Side Fetching of Client-Supplied URLs
 
-`/page-content` is the one endpoint that fetches a URL the client chose, so it
-is the one place where SSRF matters. It is always available; the user's
+`/page-content` is the endpoint that fetches a URL the client chose, so it is
+the main place where SSRF matters. It is always available; the user's
 `enablePageContentFetch` toggle decides whether each browser actually uses it.
 It shares the 10-requests-per-10-seconds bucket with `/search/`, but each
 request can fan out to six pages, so it is the heavier of the two per point.
+
+`/search/images` also fetches on the server's behalf: the thumbnail URLs that
+come back from SearXNG are fetched and returned as data URLs. Thumbnails are
+harder for an attacker to steer than a client-chosen page URL, but a
+compromised or hostile engine result could still point the server at an
+internal address, so the same guard applies.
 
 Every hop - the original URL and each redirect - passes `resolvePublicUrl`
 before a request is made, which blocks loopback, link-local (including
 `169.254.169.254`), private, carrier-grade-NAT, multicast and reserved
 addresses. The DNS answer is checked rather than pinned; the residual rebinding
 window and why it is accepted are documented in `docs/page-content.md`.
+Thumbnail responses are also capped in size, so an oversized image cannot pin
+the server's memory.
 
 ## Threat Model
 

--- a/server/pageContentService.ts
+++ b/server/pageContentService.ts
@@ -5,6 +5,7 @@ import {
   recordPageRead,
 } from "./pageReadsSinceLastRestart.ts";
 import { resolvePublicUrl } from "./utils/publicUrl.ts";
+import { readCappedBytes } from "./utils/streamUtils.ts";
 
 const REQUEST_TIMEOUT_MS = 6000;
 const MAX_REDIRECTS = 3;
@@ -134,42 +135,6 @@ function decodeDocument(bytes: Uint8Array, contentType: string): string {
   }
 }
 
-/**
- * Reads at most `MAX_RESPONSE_BYTES` of the body. A hostile or merely huge
- * page must not be able to pin the server's memory, and the extractor gains
- * nothing from the tail of a document it will trim to a few passages anyway.
- */
-async function readCappedBytes(
-  response: Response,
-): Promise<{ bytes: Uint8Array; truncated: boolean }> {
-  const reader = response.body?.getReader();
-  if (!reader) return { bytes: new Uint8Array(), truncated: false };
-
-  const chunks: Uint8Array[] = [];
-  let bytesRead = 0;
-  let reachedEnd = false;
-
-  while (bytesRead < MAX_RESPONSE_BYTES) {
-    const { done, value } = await reader.read();
-    if (done) {
-      reachedEnd = true;
-      break;
-    }
-    bytesRead += value.byteLength;
-    chunks.push(value);
-  }
-
-  await reader.cancel().catch(() => {});
-
-  const bytes = new Uint8Array(bytesRead);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return { bytes, truncated: !reachedEnd };
-}
-
 /** `AbortSignal.timeout` rejects with this; a network failure is a `TypeError`. */
 function isTimeout(error: unknown): boolean {
   return error instanceof Error && error.name === "TimeoutError";
@@ -234,7 +199,10 @@ async function downloadDocument(rawUrl: string): Promise<DownloadResult> {
     }
 
     try {
-      const { bytes, truncated } = await readCappedBytes(response);
+      const { bytes, truncated } = await readCappedBytes(
+        response,
+        MAX_RESPONSE_BYTES,
+      );
       return {
         outcome: "ok",
         html: decodeDocument(bytes, contentType),

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -1,6 +1,13 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const lookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns/promises", () => ({
+  default: { lookup: lookupMock },
+  lookup: lookupMock,
+}));
+
 vi.mock("./handleTokenVerification", () => ({
   handleTokenVerification: vi.fn(),
 }));
@@ -71,6 +78,8 @@ describe("searchEndpointServerHook", () => {
     // clearAllMocks keeps implementations, and one degradation case installs a
     // fetch that only settles on abort.
     mockFetch.mockReset();
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     vi.mocked(handleTokenVerification).mockResolvedValue({
       shouldContinue: true,
     });
@@ -457,6 +466,105 @@ describe("searchEndpointServerHook", () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.end).toHaveBeenCalledWith("[]");
+    });
+
+    it("drops an image whose thumbnail resolves to a private address", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+      lookupMock.mockResolvedValue([{ address: "192.168.1.5", family: 4 }]);
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith("[]");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("drops an image whose thumbnail URL uses a non-HTTP scheme", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([
+        [
+          "Cat picture",
+          "https://example.com/cat.jpg",
+          "file:///etc/passwd",
+          "https://example.com/cat",
+        ],
+      ]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith("[]");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not follow a thumbnail redirect into a private address", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+      lookupMock
+        .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+        .mockResolvedValue([{ address: "10.0.0.7", family: 4 }]);
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://10.0.0.7/thumb.jpg" },
+        }),
+      );
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.end).toHaveBeenCalledWith("[]");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("truncates an oversized thumbnail body", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+      const bigBody = new Uint8Array(600_000).fill(7);
+      mockFetch.mockResolvedValue(
+        new Response(bigBody, {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+
+      await handler(
+        createRequest("/search/images?q=cats&token=abc"),
+        response,
+        vi.fn(),
+      );
+
+      const [body] = response.end.mock.calls[0];
+      const [thumbnailDataUrl] = JSON.parse(body);
+      expect(thumbnailDataUrl[2]).toContain("data:image/jpeg;base64,");
+      // The cap is 500_000 bytes; a 600_000-byte body must be truncated.
+      const decoded = Buffer.from(thumbnailDataUrl[2].split(",")[1], "base64");
+      expect(decoded.length).toBe(500_000);
     });
   });
 

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -7,9 +7,13 @@ import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
 } from "./searchesSinceLastRestart.ts";
+import { resolvePublicUrl } from "./utils/publicUrl.ts";
+import { readCappedBytes } from "./utils/streamUtils.ts";
 import { fetchSearXNG } from "./webSearchService.ts";
 
 const THUMBNAIL_TIMEOUT_MS = 1000;
+const MAX_THUMBNAIL_REDIRECTS = 3;
+const MAX_THUMBNAIL_BYTES = 500_000;
 const DEFAULT_SEARCH_LIMIT = 30;
 const MAX_SEARCH_LIMIT = 30;
 const MAX_QUERY_LENGTH = 2000;
@@ -43,24 +47,56 @@ async function fetchThumbnailAsDataUrl(thumbnailSource: string) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), THUMBNAIL_TIMEOUT_MS);
   try {
-    const response = await fetch(thumbnailSource, {
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new Error(
-        `Thumbnail request failed with status ${response.status}`,
-      );
+    let target = thumbnailSource;
+
+    for (let hop = 0; hop <= MAX_THUMBNAIL_REDIRECTS; hop++) {
+      let url: URL;
+      try {
+        url = await resolvePublicUrl(target);
+      } catch {
+        // Malformed, non-HTTP, or a private/link-local/reserved address:
+        // do not fetch it on the server's behalf. Throwing lets the caller's
+        // catch drop the whole image result, matching the other failure paths.
+        throw new Error(
+          "Refusing to fetch thumbnail from a non-public address",
+        );
+      }
+
+      const response = await fetch(url, {
+        redirect: "manual",
+        signal: controller.signal,
+      });
+
+      const location = response.headers.get("location");
+      if (isRedirect(response.status) && location) {
+        await response.body?.cancel().catch(() => {});
+        target = new URL(location, url).toString();
+        continue;
+      }
+
+      if (!response.ok) {
+        await response.body?.cancel().catch(() => {});
+        throw new Error(
+          `Thumbnail request failed with status ${response.status}`,
+        );
+      }
+
+      const contentType =
+        response.headers.get("content-type") ?? "application/octet-stream";
+      const { bytes } = await readCappedBytes(response, MAX_THUMBNAIL_BYTES);
+      const base64 = Buffer.from(bytes).toString("base64");
+
+      return `data:${contentType};base64,${base64}`;
     }
 
-    const contentType =
-      response.headers.get("content-type") ?? "application/octet-stream";
-    const arrayBuffer = await response.arrayBuffer();
-    const base64 = Buffer.from(arrayBuffer).toString("base64");
-
-    return `data:${contentType};base64,${base64}`;
+    throw new Error("Thumbnail redirected too many times");
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function isRedirect(status: number): boolean {
+  return status >= 300 && status < 400 && status !== 304;
 }
 
 async function handleRanking(

--- a/server/utils/streamUtils.ts
+++ b/server/utils/streamUtils.ts
@@ -1,6 +1,54 @@
 import type { ServerResponse } from "node:http";
 
 /**
+ * Reads at most `maxBytes` of a fetch response body. A hostile or merely huge
+ * upstream must not be able to pin the server's memory, and callers that only
+ * need the head of a document (page text, thumbnails) gain nothing from the
+ * tail anyway.
+ *
+ * @param response - The response whose body should be read
+ * @param maxBytes - Upper bound on how many bytes to read
+ * @returns The bytes read, and whether the body was truncated by the cap
+ */
+export async function readCappedBytes(
+  response: Response,
+  maxBytes: number,
+): Promise<{ bytes: Uint8Array; truncated: boolean }> {
+  const reader = response.body?.getReader();
+  if (!reader) return { bytes: new Uint8Array(), truncated: false };
+
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+  let reachedEnd = false;
+
+  while (bytesRead < maxBytes) {
+    const { done, value } = await reader.read();
+    if (done) {
+      reachedEnd = true;
+      break;
+    }
+
+    const remaining = maxBytes - bytesRead;
+    const chunk =
+      value.byteLength > remaining ? value.subarray(0, remaining) : value;
+    bytesRead += chunk.byteLength;
+    chunks.push(chunk);
+
+    if (chunk.byteLength < value.byteLength) break;
+  }
+
+  await reader.cancel().catch(() => {});
+
+  const bytes = new Uint8Array(bytesRead);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { bytes, truncated: !reachedEnd };
+}
+
+/**
  * Calculate backoff time with exponential jitter
  * @param attempt - Current attempt number (1-based)
  * @param baseDelayMs - Base delay in milliseconds (default: 100ms)


### PR DESCRIPTION
## Description

`fetchThumbnailAsDataUrl` fetched whatever URL SearXNG returned as the thumbnail for an image result, with no SSRF guard and no size limit. Three concrete problems:

1. **No private-address block.** The thumbnail URL was fetched directly. A hostile engine result (or a compromised SearXNG instance) could point the server at `http://192.168.x.x`, `http://127.0.0.1` or the cloud metadata endpoint `http://169.254.169.254/`.
2. **Redirects were followed unvetted.** Default fetch redirect policy means a public URL could 302 the server into a private address — the exact bypass `/page-content` defends against by validating every hop.
3. **No size cap.** `response.arrayBuffer()` buffered the whole body, base64-encoded, for up to 30 results per request. A huge thumbnail could pin the server's memory.

`/page-content` already guards every hop with `resolvePublicUrl` and caps the body; the thumbnail path got neither, and `docs/security.md` claimed `/page-content` was "the one place where SSRF matters".

### What changed

- `server/searchEndpointServerHook.ts`: `fetchThumbnailAsDataUrl` now validates each hop with `resolvePublicUrl`, follows redirects by hand (every target vetted, same posture as `/page-content`), and reads the body through `readCappedBytes` with a 500 KB cap.
- `server/utils/streamUtils.ts`: `readCappedBytes` moved here from `pageContentService.ts` so both server-fetch paths share it. It now slices a chunk that would exceed the cap instead of overshooting the byte total (a latent bug in the old single-caller version — one oversized chunk could bypass the limit).
- `server/pageContentService.ts`: uses the shared helper, no behavior change.
- `docs/security.md`: now documents that image thumbnails are server-fetched and guarded the same way.
- Tests: private-address block, non-HTTP scheme rejection, redirect-into-private-address block (fetch count stays 1, result dropped), and oversized-body truncation at the cap. The three SSRF tests fail on the pre-fix code and pass after (verified by hand); the truncation test fails on the old overshooting reader.

## How to test

1. `npx vitest run server/searchEndpointServerHook.test.ts server/pageContentService.test.ts` — 64 tests pass.
2. `npx vitest run` — 582 pass; the only 2 failures are the pre-existing Windows-only path-separator assertions in the doc scripts (present on a clean checkout).
3. `npx biome check` and `npx tsc -p tsconfig.node.json --noEmit` are clean on the changed files.

Fixes #2369
