### PR TITLE
docs(security): state that search and page reading log no query

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -46,6 +46,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 - **SearXNG Integration**: All web searches routed through privacy-focused metasearch
 - **No External Requests**: Optional browser-only mode for complete privacy
 - **Page Reading Is On By Default, And Reversible**: `enablePageContentFetch` ships on and the user can turn it off under AI Settings; nothing is read until AI responses are enabled, and the server (never the browser) requests the top result pages, so those sites see the instance and no user cookies or IP
+- **Search And Page Reading Leave No Query In The Log**: The search query is never written to the server log, and neither is the URL of a page read for grounding; how often searches come back empty or are fully discarded, and how page reads ended, are counted instead and reported on `/status` (`searchesWithoutResults`, `searchesWithAllResultsDiscarded`, `pageReads`). Anything in front of the instance keeps its own access log, where `?q=` appears in full
 
 ## Data Protection
 
@@ -71,7 +72,8 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 |--------|---------|
 | `server/searchToken.ts` | Reads/writes the CSRF token from `{tempdir}/minisearch-token` |
 | `server/verifiedTokens.ts` | In-memory `Set<string>` of verified session tokens |
-| `server/searchesSinceLastRestart.ts` | In-memory counters for abuse monitoring |
+| `server/searchesSinceLastRestart.ts` | In-memory counters for aggregate search outcomes (text/image search totals, and how often searches came back empty or were fully discarded), reported on `/status` |
+| `server/pageReadsSinceLastRestart.ts` | In-memory aggregate counters for pages read for grounding (outcomes, durations, passage ratios), reported on `/status`; records no query, URL, host, or per-read timestamp |
 | `server/searchEndpointServerHook.ts` | Proxies text/image search to SearXNG after token verification (via `handleTokenVerification`) |
 | `server/verifyTokenAndRateLimit.ts` | Verifies the Argon2 token hash and enforces rate limiting (10 requests per 10 seconds) shared by the search, page-content and inference endpoints |
 | `server/handleTokenVerification.ts` | Middleware bridge that calls `verifyTokenAndRateLimit` and writes 400/401/429 error responses for the search, page-content and inference endpoints |


### PR DESCRIPTION
Fixes #2357.

## Description

Currently, the Privacy section of `docs/security.md` lists what an instance keeps and exposes but says nothing about the server log, so someone deciding whether to host an instance for other people cannot tell from that section whether the logs record what those people search for. This documents the guarantee that already exists since #2354: the search query and the URL of a page read for grounding never reach the server log, and the aggregate lives on the `/status` counters instead.

| File | Change |
|---|---|
| `docs/security.md` | New Privacy bullet: the query and the grounding-page URL never reach the server log, the aggregate is on `/status` (`searchesWithoutResults`, `searchesWithAllResultsDiscarded`, `pageReads`), and a reverse proxy in front of the instance keeps its own access log where `?q=` appears |
| `docs/security.md` | Module-table row for `searchesSinceLastRestart.ts` corrected from "abuse monitoring" to aggregate search outcomes |
| `docs/security.md` | Added the missing `pageReadsSinceLastRestart.ts` row next to it |

The claim is scoped to search and page reading on purpose: the internal inference proxy can still write the prompt (query plus grounding excerpts) to the log when the upstream provider fails, which is tracked separately in #2358.

## How to test

1. Read the new Privacy bullet and the two module-table rows in `docs/security.md`.
2. Confirm the three `/status` fields named in the bullet exist in `server/statusEndpointServerHook.ts` (lines 54, 55, 59).
3. Run `node scripts/doc-gardening.cjs` and `node scripts/documentation-validator.cjs` (both report 0 errors).

Note: docs-only change, so there is no runtime behavior to exercise. Each factual claim in the bullet was checked against the source (`webSearchService.ts`, `pageContentService.ts`, `pageReadsSinceLastRestart.ts`, `statusEndpointServerHook.ts`, and the `?q=` parameter in `client/modules/search.ts`).
