### PR TITLE
fix(server): rate-limit requests before token verification

### DIFF
--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -105,6 +105,41 @@ describe("verifyTokenAndRateLimit", () => {
     expect(result.error).toBe("Too many requests.");
   });
 
+  it("should rate-limit invalid tokens instead of skipping the limiter", async () => {
+    mockArgon2VerifyResult = false;
+    mockRateLimiterShouldFail = true;
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const result = await verifyTokenAndRateLimit("invalid-token");
+    expect(result.statusCode).toBe(429);
+    expect(result.error).toBe("Too many requests.");
+  });
+
+  it("should not run argon2 verification when the request is already rate limited", async () => {
+    mockRateLimiterShouldFail = true;
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const hashWasm = await import("hash-wasm");
+    const result = await verifyTokenAndRateLimit("some-token");
+    expect(result.statusCode).toBe(429);
+    expect(hashWasm.argon2Verify).not.toHaveBeenCalled();
+  });
+
+  it("should rate-limit requests with a missing token", async () => {
+    mockRateLimiterShouldFail = true;
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const result = await verifyTokenAndRateLimit(null);
+    expect(result.statusCode).toBe(429);
+    expect(result.error).toBe("Too many requests.");
+  });
+
   it("should key rate limiter on the socket address by default (untrusted proxy)", async () => {
     mockRateLimiterShouldFail = false;
     vi.resetModules();

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -59,6 +59,22 @@ export async function verifyTokenAndRateLimit(
   statusCode?: number;
   error?: string;
 }> {
+  // Rate-limit before anything else. An invalid or missing token used to skip
+  // the limiter entirely, and every rejected request still pays for a full
+  // argon2 verification, which is expensive enough to be a DoS lever on a
+  // publicly reachable instance: a caller could send an endless stream of
+  // bogus tokens and pin the server's CPU without ever hitting the limiter.
+  const rateLimitKey = request ? getClientIp(request) : (token ?? "anonymous");
+  try {
+    await rateLimiter.consume(rateLimitKey);
+  } catch {
+    return {
+      isAuthorized: false,
+      statusCode: 429,
+      error: "Too many requests.",
+    };
+  }
+
   if (!token) {
     return {
       isAuthorized: false,
@@ -90,18 +106,6 @@ export async function verifyTokenAndRateLimit(
 
   // Records a new session or refreshes an active one's last-seen time.
   addVerifiedToken(token);
-
-  const rateLimitKey = request ? getClientIp(request) : token;
-
-  try {
-    await rateLimiter.consume(rateLimitKey);
-  } catch {
-    return {
-      isAuthorized: false,
-      statusCode: 429,
-      error: "Too many requests.",
-    };
-  }
 
   return { isAuthorized: true };
 }


### PR DESCRIPTION
## Description

The rate limiter was only applied after a token passed verification, so requests carrying an invalid or missing token were rejected without ever consuming a rate-limit point. Each rejected request still paid for a full argon2 verification though - and that verification is the expensive part - which means a caller could stream bogus tokens and keep the server busy doing memory-heavy checks with no throttling. On a publicly reachable instance that is a cheap way to pin the CPU.

verifyTokenAndRateLimit now consumes a rate-limit point before doing anything else, keyed on the client IP when a request is present. Invalid and missing tokens are throttled like every other request, and the verification is skipped entirely once the limiter has said no. This also lines up with the intent already documented at the /page-content endpoint, which verifies before reading the parameters so that malformed requests from unauthenticated callers count against the rate limiter.

## How to test

- npm test - added three regression tests: an invalid token under a tripped limiter gets 429 instead of 401, no argon2 verification runs when the limiter already rejected the request, and a request with a missing token is rate limited too.
- The existing tests for valid tokens, verified-token caching and socket-address keying are unchanged and still pass.
