### PR TITLE
fix(server): stop logging whole error objects on the internal API endpoint

### DIFF
--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -806,5 +806,100 @@ describe("internalApiEndpointServerHook", () => {
       const payload = JSON.parse(response.end.mock.calls[0][0]);
       expect(payload.error).toBe("No model available");
     });
+
+    describe("error logging", () => {
+      it("logs only the error message when a stream fails", async () => {
+        vi.mocked(streamText).mockImplementation(
+          () =>
+            streamOf([
+              { type: "error", error: new Error("upstream exploded") },
+            ]) as never,
+        );
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        try {
+          const handler = getRegisteredHandler();
+          const response = createResponse();
+          await handler(
+            createRequest({ messages: [{ role: "user", content: "hi" }] }),
+            response,
+            vi.fn(),
+          );
+          const streamingCall = errorSpy.mock.calls.find(
+            (call) => call[0] === "Error during streaming:",
+          );
+          expect(streamingCall).toBeDefined();
+          expect(streamingCall?.[1]).toBe("upstream exploded");
+          expect(
+            errorSpy.mock.calls.every((call) => !(call[1] instanceof Error)),
+          ).toBe(true);
+        } finally {
+          errorSpy.mockRestore();
+        }
+      });
+
+      it("logs only the error message on unexpected endpoint failure", async () => {
+        vi.mocked(streamText).mockImplementation(() => {
+          throw new Error("upstream down");
+        });
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        try {
+          const handler = getRegisteredHandler();
+          const response = createResponse();
+          response.setHeader.mockImplementationOnce(() => {
+            throw new Error("setHeader exploded");
+          });
+          await handler(
+            createRequest({ messages: [{ role: "user", content: "hi" }] }),
+            response,
+            vi.fn(),
+          );
+          const endpointCall = errorSpy.mock.calls.find(
+            (call) => call[0] === "Error in internal API endpoint:",
+          );
+          expect(endpointCall).toBeDefined();
+          expect(endpointCall?.[1]).toBe("setHeader exploded");
+          expect(
+            errorSpy.mock.calls.every((call) => !(call[1] instanceof Error)),
+          ).toBe(true);
+          expect(response.statusCode).toBe(500);
+        } finally {
+          errorSpy.mockRestore();
+        }
+      });
+
+      it("logs only the error message when the model list fetch fails", async () => {
+        vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+        vi.mocked(listOpenAiCompatibleModels).mockRejectedValue(
+          new Error("registry timeout"),
+        );
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        try {
+          const handler = getRegisteredHandler();
+          const response = createResponse();
+          await handler(
+            createRequest({ messages: [{ role: "user", content: "hi" }] }),
+            response,
+            vi.fn(),
+          );
+          const fetchCall = errorSpy.mock.calls.find(
+            (call) => call[0] === "Error fetching models:",
+          );
+          expect(fetchCall).toBeDefined();
+          expect(fetchCall?.[1]).toBe("registry timeout");
+          expect(
+            errorSpy.mock.calls.every((call) => !(call[1] instanceof Error)),
+          ).toBe(true);
+          expect(response.statusCode).toBe(500);
+        } finally {
+          errorSpy.mockRestore();
+        }
+      });
+    });
   });
 });

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -245,7 +245,10 @@ export function internalApiEndpointServerHook<
             const selectedModel = selectRandomModel(availableModels);
             model = selectedModel || undefined;
           } catch (error) {
-            console.error("Error fetching models:", error);
+            console.error(
+              "Error fetching models:",
+              error instanceof Error ? error.message : error,
+            );
             sendJsonError(response, 500, {
               error: "Failed to fetch available models",
             });
@@ -315,7 +318,10 @@ export function internalApiEndpointServerHook<
             throw new Error("Stream ended unexpectedly");
           } catch (error) {
             lastError = error;
-            console.error("Error during streaming:", error);
+            console.error(
+              "Error during streaming:",
+              error instanceof Error ? error.message : error,
+            );
 
             if (hasEmittedContent) break;
             if (attempt >= maxAttempts) break;
@@ -330,7 +336,12 @@ export function internalApiEndpointServerHook<
                   process.env.INTERNAL_OPENAI_COMPATIBLE_API_KEY,
                 );
               } catch (refetchError) {
-                console.warn("Failed to refetch models:", refetchError);
+                console.warn(
+                  "Failed to refetch models:",
+                  refetchError instanceof Error
+                    ? refetchError.message
+                    : refetchError,
+                );
               }
             }
 
@@ -363,7 +374,10 @@ export function internalApiEndpointServerHook<
           model,
         );
       } catch (error) {
-        console.error("Error in internal API endpoint:", error);
+        console.error(
+          "Error in internal API endpoint:",
+          error instanceof Error ? error.message : error,
+        );
         sendJsonError(response, 500, {
           error: "Internal server error",
           message: error instanceof Error ? error.message : "Unknown error",


### PR DESCRIPTION
Closes #2358.

The internal API endpoint was dumping full `Error` objects into the server log in four places. In practice that means stack traces plus whatever internal state rode along on the error, which is noisy and gets in the way when you're trying to scan the log for what actually happened.

The two spots called out in the issue (`Error during streaming:` and `Error in internal API endpoint:`) plus the two neighboring ones with the same pattern (`Error fetching models:` and the model-refetch warning) now log just the error message. The 503 response already carries the last error message, so callers don't lose anything - this only makes the log line readable.

**Changes**
- Log only `error.message` (falling back to the raw value for non-`Error` throws) at all four console sites in `server/internalApiEndpointServerHook.ts`.

**Tests**
- Added three tests that spy on `console.error` and assert only the message is logged, not the `Error` instance. The stream-failure one fails against the previous code.
- `npx vitest run server/internalApiEndpointServerHook.test.ts` - 37 passed
- `npx biome check` on the two changed files - clean
- `npx tsc --noEmit` - clean