### PR TITLE
Surface existing features in the settings menu

### DIFF
--- a/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
@@ -105,6 +105,7 @@ describe("MenuDrawer", () => {
       screen.getByText(/Make it your browser's default search engine/),
     ).toBeInTheDocument();
     expect(screen.getByText(/\/\?q=%s/)).toBeInTheDocument();
+    expect(screen.getByText(/Raycast Quicklink/)).toBeInTheDocument();
     expect(
       screen.getByText(/use the speaker button on an answer/),
     ).toBeInTheDocument();

--- a/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
@@ -97,7 +97,7 @@ describe("MenuDrawer", () => {
     }
   });
 
-  it("shows the tips with the default-search-engine URL when enabled", async () => {
+  it("shows the tips with both search URLs when enabled", async () => {
     await renderMenuDrawer(createMenuState({ showFeatureTips: true }));
 
     expect(screen.getByText("Tips")).toBeInTheDocument();

--- a/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
@@ -1,0 +1,129 @@
+import { MantineProvider } from "@mantine/core";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { usePubSub } from "create-pubsub/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  menuExpandedAccordionsPubSub,
+  showFeatureTipsPubSub,
+} from "@/modules/pubSub";
+
+vi.mock("create-pubsub/react", () => ({
+  usePubSub: vi.fn(),
+}));
+
+vi.mock("./AISettings/AISettingsForm", () => ({
+  default: () => <div data-testid="ai-settings-form" />,
+}));
+
+vi.mock("./SearchSettingsForm", () => ({
+  default: () => <div data-testid="search-settings-form" />,
+}));
+
+vi.mock("./InterfaceSettingsForm", () => ({
+  default: () => <div data-testid="interface-settings-form" />,
+}));
+
+vi.mock("./VoiceSettingsForm", () => ({
+  default: () => <div data-testid="voice-settings-form" />,
+}));
+
+vi.mock("./ActionsForm", () => ({
+  default: () => <div data-testid="actions-form" />,
+}));
+
+vi.mock("@/components/Settings/HistorySettings", () => ({
+  default: () => <div data-testid="history-settings-form" />,
+}));
+
+interface MenuState {
+  expandedAccordions: string[];
+  showFeatureTips: boolean;
+}
+
+function createMenuState(overrides: Partial<MenuState> = {}): MenuState {
+  return {
+    expandedAccordions: [],
+    showFeatureTips: true,
+    ...overrides,
+  };
+}
+
+function mockMenuState(state: MenuState) {
+  const setShowFeatureTips = vi.fn();
+  vi.mocked(usePubSub).mockImplementation((pubSub: unknown) => {
+    if (pubSub === menuExpandedAccordionsPubSub)
+      return [state.expandedAccordions, vi.fn()];
+    if (pubSub === showFeatureTipsPubSub)
+      return [state.showFeatureTips, setShowFeatureTips];
+    throw new Error("MenuDrawer.test.tsx: unexpected pubSub in usePubSub mock");
+  });
+  return { setShowFeatureTips };
+}
+
+async function renderMenuDrawer(state: MenuState) {
+  const handlers = mockMenuState(state);
+  const MenuDrawer = (await import("./MenuDrawer")).default;
+  const utils = render(
+    <MantineProvider>
+      <MenuDrawer opened onClose={vi.fn()} />
+    </MantineProvider>,
+  );
+  return { ...utils, ...handlers };
+}
+
+describe("MenuDrawer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a description under each accordion control", async () => {
+    await renderMenuDrawer(createMenuState());
+
+    const sections: Array<[title: string, description: string]> = [
+      ["AI Settings", "AI responses, where inference runs, and reasoning"],
+      ["Search Settings", "Text and image results, and how many to show"],
+      ["Interface Settings", "Appearance and search-box input"],
+      ["History Settings", "How long and how many searches to keep"],
+      ["Voice Settings", "The voice used when reading answers aloud"],
+      ["Actions", "Clear stored data and view the log"],
+    ];
+
+    // Scoped to the control so the test fails if a description moves into the
+    // (keepMounted) panel, where it would no longer be visible while collapsed.
+    for (const [title, description] of sections) {
+      const control = screen.getByRole("button", { name: new RegExp(title) });
+      expect(within(control).getByText(description)).toBeInTheDocument();
+    }
+  });
+
+  it("shows the tips with the default-search-engine URL when enabled", async () => {
+    await renderMenuDrawer(createMenuState({ showFeatureTips: true }));
+
+    expect(screen.getByText("Tips")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Make it your browser's default search engine/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/\/\?q=%s/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/use the speaker button on an answer/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the tips when showFeatureTips is false", async () => {
+    await renderMenuDrawer(createMenuState({ showFeatureTips: false }));
+
+    expect(screen.queryByText("Tips")).not.toBeInTheDocument();
+  });
+
+  it("persists the dismissal when the tips are closed", async () => {
+    const user = userEvent.setup();
+    const { setShowFeatureTips } = await renderMenuDrawer(
+      createMenuState({ showFeatureTips: true }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Dismiss tips" }));
+
+    expect(setShowFeatureTips).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
@@ -101,9 +101,7 @@ describe("MenuDrawer", () => {
     await renderMenuDrawer(createMenuState({ showFeatureTips: true }));
 
     expect(screen.getByText("Tips")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Make it your browser's default search engine/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Search from anywhere/)).toBeInTheDocument();
     expect(screen.getByText(/\/\?q=%s/)).toBeInTheDocument();
     expect(screen.getByText(/\/\?q=\{Query\}/)).toBeInTheDocument();
     expect(screen.getByText(/Raycast Quicklink/)).toBeInTheDocument();

--- a/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.test.tsx
@@ -105,6 +105,7 @@ describe("MenuDrawer", () => {
       screen.getByText(/Make it your browser's default search engine/),
     ).toBeInTheDocument();
     expect(screen.getByText(/\/\?q=%s/)).toBeInTheDocument();
+    expect(screen.getByText(/\/\?q=\{Query\}/)).toBeInTheDocument();
     expect(screen.getByText(/Raycast Quicklink/)).toBeInTheDocument();
     expect(
       screen.getByText(/use the speaker button on an answer/),

--- a/client/components/Pages/Main/Menu/MenuDrawer.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.tsx
@@ -124,7 +124,7 @@ export default function MenuDrawer(drawerProps: DrawerProps) {
               <Text size="xs" lh="sm">
                 Make it your browser's default search engine: add{" "}
                 <Code>{`${self.location.origin}/?q=%s`}</Code> as a custom
-                search engine.
+                search engine (the same pattern works in a Raycast Quicklink).
               </Text>
               <Text size="xs" lh="sm">
                 Turn on AI Response, then use the speaker button on an answer to

--- a/client/components/Pages/Main/Menu/MenuDrawer.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.tsx
@@ -124,7 +124,9 @@ export default function MenuDrawer(drawerProps: DrawerProps) {
               <Text size="xs" lh="sm">
                 Make it your browser's default search engine: add{" "}
                 <Code>{`${self.location.origin}/?q=%s`}</Code> as a custom
-                search engine (the same pattern works in a Raycast Quicklink).
+                search engine, or{" "}
+                <Code>{`${self.location.origin}/?q={Query}`}</Code> as a Raycast
+                Quicklink.
               </Text>
               <Text size="xs" lh="sm">
                 Turn on AI Response, then use the speaker button on an answer to

--- a/client/components/Pages/Main/Menu/MenuDrawer.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.tsx
@@ -122,9 +122,9 @@ export default function MenuDrawer(drawerProps: DrawerProps) {
           >
             <Stack gap="xs">
               <Text size="xs" lh="sm">
-                Make it your browser's default search engine: add{" "}
-                <Code>{`${self.location.origin}/?q=%s`}</Code> as a custom
-                search engine, or{" "}
+                Search from anywhere: add{" "}
+                <Code>{`${self.location.origin}/?q=%s`}</Code> as your browser's
+                custom search engine, or{" "}
                 <Code>{`${self.location.origin}/?q={Query}`}</Code> as a Raycast
                 Quicklink.
               </Text>

--- a/client/components/Pages/Main/Menu/MenuDrawer.tsx
+++ b/client/components/Pages/Main/Menu/MenuDrawer.tsx
@@ -1,32 +1,64 @@
 import {
   Accordion,
   ActionIcon,
+  Alert,
   Center,
+  Code,
   Drawer,
   type DrawerProps,
   FocusTrap,
   Group,
   HoverCard,
   Stack,
+  Text,
   Tooltip,
 } from "@mantine/core";
 import { repository } from "@root/package.json";
-import { IconBrandGithub } from "@tabler/icons-react";
+import { IconBrandGithub, IconBulb } from "@tabler/icons-react";
 import { usePubSub } from "create-pubsub/react";
 import prettyMilliseconds from "pretty-ms";
 import HistorySettings from "@/components/Settings/HistorySettings";
 import { appName, appVersion } from "@/modules/appInfo";
 import { addLogEntry } from "@/modules/logEntries";
-import { menuExpandedAccordionsPubSub } from "@/modules/pubSub";
+import {
+  menuExpandedAccordionsPubSub,
+  showFeatureTipsPubSub,
+} from "@/modules/pubSub";
 import ActionsForm from "./ActionsForm";
 import AISettingsForm from "./AISettings/AISettingsForm";
 import InterfaceSettingsForm from "./InterfaceSettingsForm";
 import SearchSettingsForm from "./SearchSettingsForm";
 import VoiceSettingsForm from "./VoiceSettingsForm";
 
+/**
+ * Accordion control label with a one-line description, so each section's
+ * purpose is visible while collapsed.
+ */
+function ControlLabel({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <>
+      <Text span fw={500} display="block">
+        {title}
+      </Text>
+      <Text span size="xs" c="dimmed" display="block">
+        {description}
+      </Text>
+    </>
+  );
+}
+
 export default function MenuDrawer(drawerProps: DrawerProps) {
   const [menuExpandedAccordions, updateMenuExpandedAccordions] = usePubSub(
     menuExpandedAccordionsPubSub,
+  );
+  const [showFeatureTips, setShowFeatureTips] = usePubSub(
+    showFeatureTipsPubSub,
   );
 
   return (
@@ -74,6 +106,33 @@ export default function MenuDrawer(drawerProps: DrawerProps) {
     >
       <FocusTrap.InitialFocus />
       <Drawer.Body>
+        {showFeatureTips && (
+          <Alert
+            // Override Mantine's default role="alert": this is an
+            // informational tips box, not an assertive alert.
+            role="note"
+            variant="light"
+            color="blue"
+            icon={<IconBulb size="1rem" />}
+            title="Tips"
+            withCloseButton
+            closeButtonLabel="Dismiss tips"
+            onClose={() => setShowFeatureTips(false)}
+            mb="md"
+          >
+            <Stack gap="xs">
+              <Text size="xs" lh="sm">
+                Make it your browser's default search engine: add{" "}
+                <Code>{`${self.location.origin}/?q=%s`}</Code> as a custom
+                search engine.
+              </Text>
+              <Text size="xs" lh="sm">
+                Turn on AI Response, then use the speaker button on an answer to
+                hear it read aloud.
+              </Text>
+            </Stack>
+          </Alert>
+        )}
         <Accordion
           variant="separated"
           multiple
@@ -81,37 +140,67 @@ export default function MenuDrawer(drawerProps: DrawerProps) {
           onChange={updateMenuExpandedAccordions}
         >
           <Accordion.Item value="aiSettings">
-            <Accordion.Control>AI Settings</Accordion.Control>
+            <Accordion.Control>
+              <ControlLabel
+                title="AI Settings"
+                description="AI responses, where inference runs, and reasoning"
+              />
+            </Accordion.Control>
             <Accordion.Panel>
               <AISettingsForm />
             </Accordion.Panel>
           </Accordion.Item>
           <Accordion.Item value="searchSettings">
-            <Accordion.Control>Search Settings</Accordion.Control>
+            <Accordion.Control>
+              <ControlLabel
+                title="Search Settings"
+                description="Text and image results, and how many to show"
+              />
+            </Accordion.Control>
             <Accordion.Panel>
               <SearchSettingsForm />
             </Accordion.Panel>
           </Accordion.Item>
           <Accordion.Item value="interfaceSettings">
-            <Accordion.Control>Interface Settings</Accordion.Control>
+            <Accordion.Control>
+              <ControlLabel
+                title="Interface Settings"
+                description="Appearance and search-box input"
+              />
+            </Accordion.Control>
             <Accordion.Panel>
               <InterfaceSettingsForm />
             </Accordion.Panel>
           </Accordion.Item>
           <Accordion.Item value="historySettings">
-            <Accordion.Control>History Settings</Accordion.Control>
+            <Accordion.Control>
+              <ControlLabel
+                title="History Settings"
+                description="How long and how many searches to keep"
+              />
+            </Accordion.Control>
             <Accordion.Panel>
               <HistorySettings />
             </Accordion.Panel>
           </Accordion.Item>
           <Accordion.Item value="voiceSettings">
-            <Accordion.Control>Voice Settings</Accordion.Control>
+            <Accordion.Control>
+              <ControlLabel
+                title="Voice Settings"
+                description="The voice used when reading answers aloud"
+              />
+            </Accordion.Control>
             <Accordion.Panel>
               <VoiceSettingsForm />
             </Accordion.Panel>
           </Accordion.Item>
           <Accordion.Item value="actions">
-            <Accordion.Control>Actions</Accordion.Control>
+            <Accordion.Control>
+              <ControlLabel
+                title="Actions"
+                description="Clear stored data and view the log"
+              />
+            </Accordion.Control>
             <Accordion.Panel>
               <ActionsForm />
             </Accordion.Panel>

--- a/client/modules/pubSub.test.ts
+++ b/client/modules/pubSub.test.ts
@@ -51,4 +51,15 @@ describe("PubSub localStorage persistence", () => {
     const [, , getMenuExpandedAccordions] = menuExpandedAccordionsPubSub;
     expect(getMenuExpandedAccordions()).toEqual([]);
   });
+
+  it("keeps a dismissed feature-tips flag across a reload", async () => {
+    const { showFeatureTipsPubSub } = await import("./pubSub");
+    const [dismissTips] = showFeatureTipsPubSub;
+    dismissTips(false);
+    expect(localStorage.getItem("showFeatureTips")).toBe("false");
+    vi.resetModules();
+    const reloaded = await import("./pubSub");
+    const [, , getTips] = reloaded.showFeatureTipsPubSub;
+    expect(getTips()).toBe(false);
+  });
 });

--- a/client/modules/pubSub.test.ts
+++ b/client/modules/pubSub.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addLogEntry } from "./logEntries";
+
+vi.mock("./logEntries", () => ({
+  addLogEntry: vi.fn(),
+}));
 
 beforeEach(() => {
   const storage: Record<string, string> = {};
@@ -14,6 +19,7 @@ beforeEach(() => {
       for (const k in storage) delete storage[k];
     },
   });
+  vi.clearAllMocks();
 });
 
 describe("PubSub localStorage persistence", () => {
@@ -44,12 +50,28 @@ describe("PubSub localStorage persistence", () => {
     expect(stored).toEqual(modified);
   });
 
-  it("falls back to the default when the stored value is corrupted JSON", async () => {
+  it("falls back to the default and drops the value when the stored JSON is corrupted", async () => {
     localStorage.setItem("menuExpandedAccordions", "{not valid json");
     vi.resetModules();
     const { menuExpandedAccordionsPubSub } = await import("./pubSub");
     const [, , getMenuExpandedAccordions] = menuExpandedAccordionsPubSub;
     expect(getMenuExpandedAccordions()).toEqual([]);
+    expect(localStorage.getItem("menuExpandedAccordions")).toBeNull();
+    expect(addLogEntry).toHaveBeenCalledWith(
+      "Discarded an unusable stored value for 'menuExpandedAccordions'",
+    );
+  });
+
+  it("falls back to the default and drops the value when the stored JSON has the wrong type", async () => {
+    localStorage.setItem("showFeatureTips", '"false"');
+    vi.resetModules();
+    const { showFeatureTipsPubSub } = await import("./pubSub");
+    const [, , getTips] = showFeatureTipsPubSub;
+    expect(getTips()).toBe(true);
+    expect(localStorage.getItem("showFeatureTips")).toBeNull();
+    expect(addLogEntry).toHaveBeenCalledWith(
+      "Discarded an unusable stored value for 'showFeatureTips'",
+    );
   });
 
   it("keeps a dismissed feature-tips flag across a reload", async () => {

--- a/client/modules/pubSub.test.ts
+++ b/client/modules/pubSub.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
     },
   });
   vi.clearAllMocks();
+  vi.resetModules();
 });
 
 describe("PubSub localStorage persistence", () => {
@@ -52,7 +53,6 @@ describe("PubSub localStorage persistence", () => {
 
   it("falls back to the default and drops the value when the stored JSON is corrupted", async () => {
     localStorage.setItem("menuExpandedAccordions", "{not valid json");
-    vi.resetModules();
     const { menuExpandedAccordionsPubSub } = await import("./pubSub");
     const [, , getMenuExpandedAccordions] = menuExpandedAccordionsPubSub;
     expect(getMenuExpandedAccordions()).toEqual([]);
@@ -64,7 +64,6 @@ describe("PubSub localStorage persistence", () => {
 
   it("falls back to the default and drops the value when the stored JSON has the wrong type", async () => {
     localStorage.setItem("showFeatureTips", '"false"');
-    vi.resetModules();
     const { showFeatureTipsPubSub } = await import("./pubSub");
     const [, , getTips] = showFeatureTipsPubSub;
     expect(getTips()).toBe(true);

--- a/client/modules/pubSub.test.ts
+++ b/client/modules/pubSub.test.ts
@@ -43,4 +43,12 @@ describe("PubSub localStorage persistence", () => {
     const stored = JSON.parse(localStorage.getItem("settings") as string);
     expect(stored).toEqual(modified);
   });
+
+  it("falls back to the default when the stored value is corrupted JSON", async () => {
+    localStorage.setItem("menuExpandedAccordions", "{not valid json");
+    vi.resetModules();
+    const { menuExpandedAccordionsPubSub } = await import("./pubSub");
+    const [, , getMenuExpandedAccordions] = menuExpandedAccordionsPubSub;
+    expect(getMenuExpandedAccordions()).toEqual([]);
+  });
 });

--- a/client/modules/pubSub.test.ts
+++ b/client/modules/pubSub.test.ts
@@ -73,6 +73,17 @@ describe("PubSub localStorage persistence", () => {
     );
   });
 
+  it("falls back to the default and drops the value when the stored value is empty", async () => {
+    localStorage.setItem("menuExpandedAccordions", "");
+    const { menuExpandedAccordionsPubSub } = await import("./pubSub");
+    const [, , getMenuExpandedAccordions] = menuExpandedAccordionsPubSub;
+    expect(getMenuExpandedAccordions()).toEqual([]);
+    expect(localStorage.getItem("menuExpandedAccordions")).toBeNull();
+    expect(addLogEntry).toHaveBeenCalledWith(
+      "Discarded an unusable stored value for 'menuExpandedAccordions'",
+    );
+  });
+
   it("keeps a dismissed feature-tips flag across a reload", async () => {
     const { showFeatureTipsPubSub } = await import("./pubSub");
     const [dismissTips] = showFeatureTipsPubSub;

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -19,9 +19,18 @@ import type {
  */
 function createLocalStoragePubSub<T>(localStorageKey: string, defaultValue: T) {
   const localStorageValue = localStorage.getItem(localStorageKey);
-  const localStoragePubSub = createPubSub(
-    localStorageValue ? (JSON.parse(localStorageValue) as T) : defaultValue,
-  );
+  let initialValue: T = defaultValue;
+  if (localStorageValue) {
+    try {
+      initialValue = JSON.parse(localStorageValue) as T;
+    } catch {
+      // This runs at module load, so a corrupted stored value must fall back
+      // to the default instead of crashing the app. Log it, since the corrupt
+      // value stays in storage and the fallback repeats on every load.
+      addLogEntry(`Discarded corrupted stored value for '${localStorageKey}'`);
+    }
+  }
+  const localStoragePubSub = createPubSub(initialValue);
 
   const [, onValueChange] = localStoragePubSub;
 

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -225,6 +225,17 @@ export const menuExpandedAccordionsPubSub = createLocalStoragePubSub<string[]>(
 );
 
 /**
+ * Whether the menu's dismissible feature-tips hint is still visible. Kept in
+ * its own channel rather than `settings` because the settings forms snapshot
+ * `settings` at mount and write the whole object back, which would resurrect
+ * a dismissed flag.
+ */
+export const showFeatureTipsPubSub = createLocalStoragePubSub(
+  "showFeatureTips",
+  true,
+);
+
+/**
  * PubSub instance for managing chat input content
  */
 export const chatInputPubSub = createPubSub("");

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -12,6 +12,21 @@ import type {
 } from "./types";
 
 /**
+ * Whether two values share the same JSON top-level kind (array, null, or a
+ * primitive type), so a stored value is checked against the default's shape
+ * before it is trusted.
+ */
+function isSameJsonKind(value: unknown, reference: unknown): boolean {
+  if (Array.isArray(value) || Array.isArray(reference)) {
+    return Array.isArray(value) === Array.isArray(reference);
+  }
+  if (value === null || reference === null) {
+    return value === null && reference === null;
+  }
+  return typeof value === typeof reference;
+}
+
+/**
  * Creates a PubSub instance that persists data to localStorage
  * @param localStorageKey - The key to use for localStorage storage
  * @param defaultValue - The default value if no localStorage value exists
@@ -21,13 +36,22 @@ function createLocalStoragePubSub<T>(localStorageKey: string, defaultValue: T) {
   const localStorageValue = localStorage.getItem(localStorageKey);
   let initialValue: T = defaultValue;
   if (localStorageValue) {
+    let parsed: unknown;
     try {
-      initialValue = JSON.parse(localStorageValue) as T;
+      parsed = JSON.parse(localStorageValue);
     } catch {
-      // This runs at module load, so a corrupted stored value must fall back
-      // to the default instead of crashing the app. Log it, since the corrupt
-      // value stays in storage and the fallback repeats on every load.
-      addLogEntry(`Discarded corrupted stored value for '${localStorageKey}'`);
+      parsed = undefined;
+    }
+    if (parsed !== undefined && isSameJsonKind(parsed, defaultValue)) {
+      initialValue = parsed as T;
+    } else {
+      // Runs at module load, so an unparseable or wrong-type stored value must
+      // not crash the app. Remove it (so the fallback doesn't repeat on every
+      // load) and log it for the in-app log panel.
+      localStorage.removeItem(localStorageKey);
+      addLogEntry(
+        `Discarded an unusable stored value for '${localStorageKey}'`,
+      );
     }
   }
   const localStoragePubSub = createPubSub(initialValue);

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -35,7 +35,7 @@ function isSameJsonKind(value: unknown, reference: unknown): boolean {
 function createLocalStoragePubSub<T>(localStorageKey: string, defaultValue: T) {
   const localStorageValue = localStorage.getItem(localStorageKey);
   let initialValue: T = defaultValue;
-  if (localStorageValue) {
+  if (localStorageValue !== null) {
     let parsed: unknown;
     try {
       parsed = JSON.parse(localStorageValue);

--- a/client/modules/settings.test.ts
+++ b/client/modules/settings.test.ts
@@ -26,6 +26,14 @@ describe("Settings Module", () => {
     expect(defaultSettings.inferenceType).toBeDefined();
   });
 
+  it("keeps the feature-tips flag out of settings", () => {
+    // The menu's feature-tips hint persists in its own localStorage channel
+    // (showFeatureTipsPubSub). If it were a settings field, the settings forms
+    // (which snapshot settings at mount and write the whole object back) would
+    // resurrect a dismissed hint on the next toggle.
+    expect(defaultSettings).not.toHaveProperty("showFeatureTips");
+  });
+
   describe("getDefaultCpuThreads", () => {
     it("should always leave at least one thread on tiny machines", () => {
       expect(getDefaultCpuThreads(1)).toBe(1);

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -303,6 +303,7 @@ Lightweight state persisted across sessions via `createLocalStoragePubSub` patte
 - `querySuggestions`: Shuffled search suggestion pool
 - `lastSearchTokenHash`: Cached security token hash
 - `menuExpandedAccordions`: UI state for settings menu sections
+- `showFeatureTips`: Whether the menu's dismissible feature-tips hint is still shown
 
 ## Application Bootstrap Flow
 


### PR DESCRIPTION
Fixes #2197.

The settings menu's six accordions were bare labels, so users had to open each one to guess what it controls, and nothing in the app pointed at MiniSearch's least-discovered features (setting it as the default search engine, read-aloud).

## What changed

| File | Change |
|---|---|
| `client/components/Pages/Main/Menu/MenuDrawer.tsx` | One-line description under each accordion control; a dismissible "Tips" block at the top of the drawer (search from anywhere: browser custom engine + Raycast Quicklink, and read-aloud) |
| `client/modules/pubSub.ts` | New `showFeatureTipsPubSub` localStorage channel for the tips dismissal; hardened `createLocalStoragePubSub` to reject unparseable or wrong-type stored values |
| `client/components/Pages/Main/Menu/MenuDrawer.test.tsx` | Tests for the descriptions, the tips (both search URLs), and the persisted dismissal |
| `client/modules/pubSub.test.ts` | Tests for the corrupted, wrong-type, and empty stored-value fallbacks |
| `client/modules/settings.test.ts` | Regression test: the tips flag stays out of `defaultSettings` |
| `docs/overview.md` | Documents the new `showFeatureTips` localStorage key |

### The localStorage hardening

Found while editing `pubSub.ts`: the stored value was parsed with an unguarded `JSON.parse` at module load, so a corrupted localStorage value crashed the whole app at import. It now falls back to the default, removes the unusable value (so the fallback doesn't repeat on every load), and logs the discard. The guard also rejects a stored value whose top-level JSON kind doesn't match the default (a string where a boolean is expected, for example), and treats an empty-string value the same as a missing one.

### Why the tips flag is not a settings field

The settings forms snapshot `settings` at mount and write the whole object back via `onValuesChange: setSettings`. A tips flag in `settings` dismissed through the alert's close button would be resurrected by the next settings save. Keeping it in its own pubSub channel removes that path entirely (this was the blocking bug caught in review).

## Verification

- `npx vitest run`: 588 passed (50 files)
- `npm run lint`: clean (biome, tsc, knip, jscpd, architectural linter, doc validators)
- Four review rounds; final verdict: approved

## Out of scope

- Pre-existing (not introduced here): the speaker button in `AiResponseContent.tsx` has no `aria-label` (tooltip only). Worth a follow-up since the new tip points users at that button.
- Pre-existing: `localStorage.getItem` in `createLocalStoragePubSub` is unguarded and throws a `SecurityError` when storage is blocked (Safari private browsing, cookies disabled). Separate issue.
