### PR TITLE
docs(security): state that queries and page URLs never reach the server log

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -46,6 +46,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 - **SearXNG Integration**: All web searches routed through privacy-focused metasearch
 - **No External Requests**: Optional browser-only mode for complete privacy
 - **Page Reading Is On By Default, And Reversible**: `enablePageContentFetch` ships on and the user can turn it off under AI Settings; nothing is read until AI responses are enabled, and the server (never the browser) requests the top result pages, so those sites see the instance and no user cookies or IP
+- **Server Logs Carry No Queries**: the query never reaches the server log, and neither does the URL of a page read for grounding. The aggregate lives in the `/status` counters (`searchesWithoutResults`, `searchesWithAllResultsDiscarded`, `pageReads`)
 
 ## Data Protection
 
@@ -71,7 +72,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 |--------|---------|
 | `server/searchToken.ts` | Reads/writes the CSRF token from `{tempdir}/minisearch-token` |
 | `server/verifiedTokens.ts` | In-memory `Set<string>` of verified session tokens |
-| `server/searchesSinceLastRestart.ts` | In-memory counters for abuse monitoring |
+| `server/searchesSinceLastRestart.ts` | In-memory aggregate counters for search outcomes since the last restart, exposed via `/status` |
 | `server/searchEndpointServerHook.ts` | Proxies text/image search to SearXNG after token verification (via `handleTokenVerification`) |
 | `server/verifyTokenAndRateLimit.ts` | Verifies the Argon2 token hash and enforces rate limiting (10 requests per 10 seconds) shared by the search, page-content and inference endpoints |
 | `server/handleTokenVerification.ts` | Middleware bridge that calls `verifyTokenAndRateLimit` and writes 400/401/429 error responses for the search, page-content and inference endpoints |


### PR DESCRIPTION
Closes #2357.

The Privacy section of `docs/security.md` listed what an instance keeps and exposes, but said nothing about the server log - so someone deciding whether to host for other people could not tell from that section whether the logs record what people search for.

Since #2354 no log line in `server/webSearchService.ts` carries the query, and `server/pageContentService.ts` records neither the query nor the URL of a page it reads. This writes that guarantee down where an operator would look:

- One bullet under **Privacy**: queries never reach the server log, and neither does the URL of a page read for grounding; the aggregate lives in the `/status` counters (`searchesWithoutResults`, `searchesWithAllResultsDiscarded`, `pageReads`).
- Fixed the module table row that described `server/searchesSinceLastRestart.ts` as "abuse monitoring" - the counters track aggregate search outcomes, not abuse.

Verified against the code: `pageContentService.ts` has no log statements at all, the `/status` fields match `statusEndpointServerHook.ts`, and `webSearchService`'s "never writes the query to the log" test still guards that behavior. `npx vitest run scripts/documentation-validator.test.js scripts/doc-gardening.test.js` shows only the two pre-existing Windows path-separator failures (they fail on `main` too).