### PR TITLE
State the value proposition and surface the AI opt-in on first run

### DIFF
--- a/client/components/AiResponse/EnableAiResponsePrompt.test.tsx
+++ b/client/components/AiResponse/EnableAiResponsePrompt.test.tsx
@@ -1,0 +1,32 @@
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EnableAiResponsePrompt from "./EnableAiResponsePrompt";
+
+describe("EnableAiResponsePrompt", () => {
+  it("is announced politely (status), not assertively (alert)", () => {
+    render(
+      <MantineProvider>
+        <EnableAiResponsePrompt onAccept={() => {}} onDecline={() => {}} />
+      </MantineProvider>,
+    );
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("offers accept and decline", () => {
+    render(
+      <MantineProvider>
+        <EnableAiResponsePrompt onAccept={() => {}} onDecline={() => {}} />
+      </MantineProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Yes, please" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "No, thanks" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/components/AiResponse/EnableAiResponsePrompt.tsx
+++ b/client/components/AiResponse/EnableAiResponsePrompt.tsx
@@ -38,7 +38,7 @@ export default function EnableAiResponsePrompt({
   );
 
   return (
-    <Alert variant="light" color="blue" p="xs">
+    <Alert role="status" variant="light" color="blue" p="xs">
       <Grid justify="space-between" align="center">
         <Grid.Col span="content">
           <Group gap="xs">

--- a/client/components/Pages/Main/MainPage.test.tsx
+++ b/client/components/Pages/Main/MainPage.test.tsx
@@ -109,7 +109,7 @@ describe("MainPage", () => {
     vi.clearAllMocks();
   });
 
-  it("shows only the search form when the query is empty", async () => {
+  it("hides results and the AI section when the query is empty", async () => {
     await renderMainPage(createPageState());
 
     expect(screen.getByTestId("search-form")).toBeInTheDocument();
@@ -120,6 +120,62 @@ describe("MainPage", () => {
     expect(
       screen.queryByTestId("enable-ai-response-prompt"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the value proposition in the empty state", async () => {
+    await renderMainPage(createPageState());
+
+    expect(
+      screen.getByText(/answers with sources, on your own instance/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the value proposition once a query is present", async () => {
+    await renderMainPage(createPageState({ query: "cats" }));
+
+    expect(
+      screen.queryByText(/answers with sources, on your own instance/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the AI opt-in in the empty state before searching", async () => {
+    await renderMainPage(
+      createPageState({ settings: { showEnableAiResponsePrompt: true } }),
+    );
+
+    expect(
+      await screen.findByTestId("enable-ai-response-prompt"),
+    ).toBeInTheDocument();
+  });
+
+  it("enables AI response without triggering a search when accepted in the empty state", async () => {
+    const user = userEvent.setup();
+    const { setSettings } = await renderMainPage(
+      createPageState({ settings: { showEnableAiResponsePrompt: true } }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Accept" }));
+
+    expect(setSettings).toHaveBeenCalledWith({
+      showEnableAiResponsePrompt: false,
+      enableAiResponse: true,
+    });
+    expect(searchAndRespond).not.toHaveBeenCalled();
+  });
+
+  it("disables AI response without triggering a search when declined in the empty state", async () => {
+    const user = userEvent.setup();
+    const { setSettings } = await renderMainPage(
+      createPageState({ settings: { showEnableAiResponsePrompt: true } }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Decline" }));
+
+    expect(setSettings).toHaveBeenCalledWith({
+      showEnableAiResponsePrompt: false,
+      enableAiResponse: false,
+    });
+    expect(searchAndRespond).not.toHaveBeenCalled();
   });
 
   it("shows search results once a search is underway and the query is non-empty", async () => {

--- a/client/components/Pages/Main/MainPage.tsx
+++ b/client/components/Pages/Main/MainPage.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack, VisuallyHidden } from "@mantine/core";
+import { Container, Stack, Text, VisuallyHidden } from "@mantine/core";
 import { usePubSub } from "create-pubsub/react";
 import { lazy, Suspense } from "react";
 import SearchForm from "@/components/Search/Form/SearchForm";
@@ -42,34 +42,39 @@ export default function MainPage() {
         mih="100vh"
         justify={isQueryEmpty ? "center" : undefined}
       >
+        {isQueryEmpty && (
+          <Text ta="center" size="sm">
+            Private AI search: answers with sources, on your own instance.
+          </Text>
+        )}
         <SearchForm
           query={query}
           updateQuery={updateQuery}
           additionalButtons={<MenuButton />}
         />
+        {settings.showEnableAiResponsePrompt && (
+          <Suspense>
+            <EnableAiResponsePrompt
+              onAccept={() => {
+                setSettings({
+                  ...settings,
+                  showEnableAiResponsePrompt: false,
+                  enableAiResponse: true,
+                });
+                if (!isQueryEmpty) searchAndRespond();
+              }}
+              onDecline={() =>
+                setSettings({
+                  ...settings,
+                  showEnableAiResponsePrompt: false,
+                  enableAiResponse: false,
+                })
+              }
+            />
+          </Suspense>
+        )}
         {!isQueryEmpty && (
           <>
-            {settings.showEnableAiResponsePrompt && (
-              <Suspense>
-                <EnableAiResponsePrompt
-                  onAccept={() => {
-                    setSettings({
-                      ...settings,
-                      showEnableAiResponsePrompt: false,
-                      enableAiResponse: true,
-                    });
-                    searchAndRespond();
-                  }}
-                  onDecline={() => {
-                    setSettings({
-                      ...settings,
-                      showEnableAiResponsePrompt: false,
-                      enableAiResponse: false,
-                    });
-                  }}
-                />
-              </Suspense>
-            )}
             {!settings.showEnableAiResponsePrompt &&
               textGenerationState !== "idle" && (
                 <Suspense>


### PR DESCRIPTION
Fixes #2196.

On an empty query, `MainPage` rendered only a centered search box with a random-suggestion placeholder, so a new self-hoster saw no positioning and no sign that cited AI answers exist (the AI opt-in only appeared after the first search). The headline feature was invisible at first impression.

## What changed

| File | Change |
|---|---|
| `client/components/Pages/Main/MainPage.tsx` | In the empty search state, show a one-line value proposition above the search box, and render the AI opt-in in the same spot regardless of query state (collapsed into a single block) |
| `client/components/AiResponse/EnableAiResponsePrompt.tsx` | `role="status"` on the Alert (Mantine defaults to assertive `role="alert"`, which interrupts screen readers when it mounts after first paint) |
| `client/components/AiResponse/EnableAiResponsePrompt.test.tsx` | New: guards the `role="status"` and the accept/decline labels |
| `client/components/Pages/Main/MainPage.test.tsx` | Tests for the value-proposition line, the empty-state opt-in, and that accepting/declining in the empty state sets the settings without triggering a search |

### Behavior change to note

The AI opt-in now appears **before** the first search (in the empty state), not only after it. Its accept/decline handlers set the settings but only call `searchAndRespond()` when a query is present, so accepting on the empty state enables AI without starting a search. If the user searches without deciding, the existing after-search prompt still appears, as before.

## Design notes

- The value-proposition line shows whenever the query is empty; the AI opt-in shows only until the user decides (the `showEnableAiResponsePrompt` flag flips permanently), so it is genuinely first-run.
- `EnableAiResponsePrompt` stays a lazy import. Eagerly importing it would introduce `@floating-ui/react` (via its Popover) into the initial chunk for every visitor, most of whom never see the prompt; the rest of the tree keeps popover/menu/drawer users behind `lazy()` on purpose. The trade-off is a minor, transient re-center on first run.

## Verification

- `npx vitest run`: 586 passed (50 files)
- `npm run lint`: clean (biome, tsc, knip, jscpd, architectural linter, doc validators)
- Three review rounds; final verdict: approved

## Out of scope

- The visible tagline restates the (pre-existing, visually-hidden) `<h1>` almost verbatim, so screen readers hear the value proposition twice. Harmless; the `<h1>` predates this change.
