### PR TITLE
feat(eval): add an offline answer-quality and retrieval eval harness

### DIFF
--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SYSTEM_PROMPT } from "@shared/defaultSystemPrompt";
 import {
   DEFAULT_INFERENCE_TYPE,
   DEFAULT_WLLAMA_MODEL_ID,
@@ -40,19 +41,7 @@ export const defaultSettings = {
   wllamaModelId: DEFAULT_WLLAMA_MODEL_ID,
   cpuThreads: getDefaultCpuThreads(),
   searchResultsLimit: 15,
-  systemPrompt: `Answer the question using the search results below. Reply in the same language as the question.
-
-Cite each fact with a Markdown link right after it, using the site's domain as the link text. Example: [youtube.com](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
-
-If you answer from your own knowledge because the results do not cover it, say so.
-
-Use only these Markdown elements: link, bold, italic, code, quote, table.
-
-Today's date is {{currentDate}}. Use it for relative dates such as "yesterday".
-
-Search results:
-
-{{searchResults}}`,
+  systemPrompt: DEFAULT_SYSTEM_PROMPT,
   inferenceType: DEFAULT_INFERENCE_TYPE,
   openAiApiBaseUrl: "",
   openAiApiKey: "",

--- a/docs/development-commands.md
+++ b/docs/development-commands.md
@@ -21,6 +21,16 @@
 
 Failure-injection cases (dependency down, empty results, aborted stream) are catalogued in `docs/failure-injection.md`.
 
+## Offline eval
+
+`eval/` is an offline eval that gives a regression signal for changes to the
+reranker, the system prompt, the search-results formatting, or the model. See
+`eval/README.md` for details and the LLM-judge environment variables.
+
+- **`npm run eval`**: Run the full eval (retrieval + answer)
+- **`npm run eval:retrieval`**: Retrieval eval (real ONNX reranker; local only, needs the model in `server/models/`)
+- **`npm run eval:answer`**: Answer eval (LLM judge; gated on `EVAL_LLM_API_KEY`, skips without one)
+
 ### Coverage Reports for AI Analysis
 
 After running `test:coverage`, AI agents can analyze these JSON files:

--- a/eval/README.md
+++ b/eval/README.md
@@ -51,9 +51,10 @@ filter / top-result logic in `rankSearchResults.ts`.
 
 Known limit: with `preserveTopResults=true`, `rankSearchResults` sorts the first
 `nextTopResultsCount` (9) surviving results and everything after them as two
-separate blocks, so the tail is never interleaved with the head. Nothing is
-dropped. The golden entries have 4-5 candidates, so that split never binds
-here; it would matter only for much larger result sets.
+separate blocks, so the tail is never interleaved with the head. The split
+itself drops nothing; anything missing from the output was removed earlier by
+the score filter. The golden entries have 4-5 candidates, so that split never
+binds here; it would matter only for much larger result sets.
 
 The metrics live in `metrics.ts` (pure, unit-tested in `metrics.test.ts`).
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -30,11 +30,12 @@ change, not an absolute quality score.
 
 The set is a starting point. Grow it by adding entries with the same shape;
 keep the relevant labels unambiguous so the metric does not hinge on a
-borderline call. Keep at least one relevant result outside the top-3 of the
-input order (`results`): if an entry keeps both relevant results in the input
-top-3, a no-op reranker scores it as well as a working one and the retrieval
-floors stop being falsifiable (the "stays falsifiable" test in
-`goldenSet.test.ts` pins this).
+borderline call. Keep the input top-3 from already holding every relevant
+result it can fit: if it does, a no-op reranker (which preserves input order)
+scores that entry as well as a working one and the retrieval floors stop being
+falsifiable. `goldenSet.test.ts` pins this two ways: a per-entry validator that
+rejects a saturated entry, and a "stays falsifiable" aggregate that scores the
+whole set as a no-op reranker and asserts the mean stays below the floors.
 
 ## Retrieval eval (reranker)
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -30,7 +30,11 @@ change, not an absolute quality score.
 
 The set is a starting point. Grow it by adding entries with the same shape;
 keep the relevant labels unambiguous so the metric does not hinge on a
-borderline call.
+borderline call. Keep at least one relevant result outside the top-3 of the
+input order (`results`): if an entry keeps both relevant results in the input
+top-3, a no-op reranker scores it as well as a working one and the retrieval
+floors stop being falsifiable (the "stays falsifiable" test in
+`goldenSet.test.ts` pins this).
 
 ## Retrieval eval (reranker)
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -49,10 +49,11 @@ costs the ranking, and without it the eval could not tell a good pin from a
 bad one. This is the regression signal for the reranker and for the score
 filter / top-result logic in `rankSearchResults.ts`.
 
-Known limit: with `preserveTopResults=true`, `rankSearchResults` keeps only the
-top `nextTopResultsCount` (9) reranked results. The golden entries have 4-5
-candidates, so that slice never binds here; it would matter only for much
-larger result sets.
+Known limit: with `preserveTopResults=true`, `rankSearchResults` sorts the first
+`nextTopResultsCount` (9) surviving results and everything after them as two
+separate blocks, so the tail is never interleaved with the head. Nothing is
+dropped. The golden entries have 4-5 candidates, so that split never binds
+here; it would matter only for much larger result sets.
 
 The metrics live in `metrics.ts` (pure, unit-tested in `metrics.test.ts`).
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,107 @@
+# Offline eval
+
+A small offline eval that gives a regression signal for changes to the
+reranker, the system prompt, the search-results formatting, or the model. It
+has two parts, both driven by a single fixed golden set (`goldenSet.ts`).
+
+Some of it runs in the default `npm test` suite (and so in CI); the rest is a
+local signal:
+
+- `metrics.test.ts`, `goldenSet.test.ts`, `promptConstruction.test.ts` run in
+  the default suite: pure math, golden-set structure, and prompt construction.
+  No model, no API key.
+- `retrieval.integration.test.ts` (real ONNX model) and
+  `answer.integration.test.ts` (network calls) run only under
+  `vitest.eval.config.ts`.
+
+It is not a benchmark: the numbers are a stable baseline to read direction of
+change, not an absolute quality score.
+
+## The golden set
+
+`goldenSet.ts` is a fixed, hand-curated list of queries. Each entry has:
+
+- `query`: the search query.
+- `results`: realistic candidate results (title, snippet, url), mixed
+  relevant and irrelevant, the way a real search engine returns them.
+- `relevant`: the indices into `results` a human would call relevant.
+- `referenceAnswer`: the key facts a correct answer must contain.
+- `rubric`: the points a good answer must satisfy, checked one at a time.
+
+The set is a starting point. Grow it by adding entries with the same shape;
+keep the relevant labels unambiguous so the metric does not hinge on a
+borderline call.
+
+## Retrieval eval (reranker)
+
+Runs the real ONNX reranker through `server/rankSearchResults.ts` on every
+golden query and scores the ranking with **nDCG@3** and **recall@3** against
+the labeled relevant results. It calls `rankSearchResults` with
+`preserveTopResults=true`, exactly as the app does for text search, so the
+pinned-first-result branch is exercised. The golden set therefore includes a
+few entries whose first candidate is irrelevant: that is the case where the pin
+costs the ranking, and without it the eval could not tell a good pin from a
+bad one. This is the regression signal for the reranker and for the score
+filter / top-result logic in `rankSearchResults.ts`.
+
+Known limit: with `preserveTopResults=true`, `rankSearchResults` keeps only the
+top `nextTopResultsCount` (9) reranked results. The golden entries have 4-5
+candidates, so that slice never binds here; it would matter only for much
+larger result sets.
+
+The metrics live in `metrics.ts` (pure, unit-tested in `metrics.test.ts`).
+
+```sh
+npm run eval:retrieval
+```
+
+Loads the real model (already in `server/models/`), so it is excluded from the
+default `npm test` suite and from CI (which has no model on disk), and runs
+under the node-environment eval config. It is a local signal, matching the
+`server/` integration-test house style. It prints a per-query table and the
+mean, and fails if the mean drops below the regression thresholds.
+
+## Answer eval (LLM judge)
+
+Builds the exact prompt the app sends (via the real
+`getFormattedSearchResults` + `getDefaultChatMessages`, with the pubSub state
+mocked to the golden query), asks a chosen LLM backend for an answer, and
+scores it with a separate LLM judge against the golden set's `referenceAnswer`
+and `rubric`. This is the regression signal for the system prompt, the
+results formatting, and the model.
+
+The system prompt is imported from `shared/defaultSystemPrompt.ts`, the same
+constant `client/modules/settings.ts` uses, so editing the real prompt is what
+the eval grades against. A stale copy here would let prompt regressions ship
+green, which is the point the eval exists to prevent.
+
+The candidate results are fed in a fixed order (the golden set order), not the
+reranker's output, so this signal isolates prompt/model changes from reranker
+changes (which the retrieval eval covers separately).
+
+It makes real network calls, so it is gated on an API key and skips cleanly
+without one. The prompt-construction checks (no model, no key) live in
+`promptConstruction.test.ts` and run in the default suite.
+
+```sh
+EVAL_LLM_API_KEY="..." \
+EVAL_LLM_BASE_URL="https://api.openai.com/v1" \
+EVAL_LLM_MODEL="gpt-4o-mini" \
+EVAL_JUDGE_MODEL="gpt-4o" \
+npm run eval:answer
+```
+
+`EVAL_LLM_MODEL` is the model under test; `EVAL_JUDGE_MODEL` (defaults to the
+same) grades it. Use a different, stronger model as the judge when possible.
+Any OpenAI-compatible chat-completions endpoint works.
+
+Note: reasoning models bill their thinking tokens against max_tokens, so a
+reasoning judge can hit the 512-token judge budget before it emits its JSON
+and fail with a "truncated at max_tokens" error. Use a non-reasoning judge (or
+raise JUDGE_MAX_TOKENS in the source) if you want to grade with one.
+
+## Running everything
+
+```sh
+npm run eval
+```

--- a/eval/answer.integration.test.ts
+++ b/eval/answer.integration.test.ts
@@ -272,15 +272,18 @@ describe("answer eval: LLM-judged quality", () => {
   it.skipIf(!hasLlmKey)(
     "keeps the mean rubric pass fraction above the threshold",
     async () => {
-      // Completeness: the mean is only meaningful if every query was graded.
-      // (A failed per-query test is already red, but this keeps the printed
-      // headline from being a partial-run average.)
-      expect(results).toHaveLength(goldenQueries.length);
-
+      // Print the breakdown before asserting, so a per-query failure still
+      // shows which queries scored what (the diagnostic you need when a
+      // regression fires). The length assert below keeps the headline from
+      // being a partial-run average on a complete run.
       const mean =
-        results.reduce((sum, r) => sum + r.passFraction, 0) / results.length;
+        results.length > 0
+          ? results.reduce((sum, r) => sum + r.passFraction, 0) / results.length
+          : 0;
       const citationRate =
-        results.filter((r) => r.cited).length / results.length;
+        results.length > 0
+          ? results.filter((r) => r.cited).length / results.length
+          : 0;
 
       console.table(
         results.map((r) => ({
@@ -294,6 +297,7 @@ describe("answer eval: LLM-judged quality", () => {
         `mean rubric pass fraction: ${mean.toFixed(3)}  citation rate: ${citationRate.toFixed(3)}`,
       );
 
+      expect(results).toHaveLength(goldenQueries.length);
       expect(mean).toBeGreaterThanOrEqual(MIN_MEAN_RUBRIC_PASS);
       expect(
         citationRate,

--- a/eval/answer.integration.test.ts
+++ b/eval/answer.integration.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment node
+
+/**
+ * Offline answer-quality eval: builds the exact prompt the app sends (via the
+ * real getFormattedSearchResults + getDefaultChatMessages, with the pubSub
+ * state mocked to the golden query), asks a chosen LLM backend for an answer,
+ * and scores it with a separate LLM judge against the golden set's reference
+ * answer and rubric.
+ *
+ * This is the regression signal for changes to the system prompt (imported
+ * from shared/defaultSystemPrompt.ts, the same source the client uses), the
+ * search-results formatting, or the model. The prompt-construction checks
+ * (no model, no key) live in promptConstruction.test.ts and run in the
+ * default suite; only the LLM-judged tests are here. buildMessagesForGolden
+ * is shared with that file (eval/goldenPrompt.ts) so both build the prompt
+ * identically.
+ *
+ * It makes real network calls, so the judged tests are gated on an API key and
+ * skip cleanly without one.
+ *
+ *   EVAL_LLM_API_KEY=... \
+ *   EVAL_LLM_BASE_URL=https://api.openai.com/v1 \
+ *   EVAL_LLM_MODEL=gpt-4o-mini \
+ *   EVAL_JUDGE_MODEL=gpt-4o \
+ *   npx vitest run --config vitest.eval.config.ts answer
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { buildMessagesForGolden, type ChatMessage } from "./goldenPrompt.ts";
+import { goldenQueries } from "./goldenSet.ts";
+
+const state = vi.hoisted(() => ({
+  query: "",
+  searchResults: [] as [string, string, string][],
+  pageContents: {} as Record<string, string>,
+  settings: {
+    systemPrompt: "",
+    inferenceType: "openai",
+    openAiContextLength: 4096,
+  } as {
+    systemPrompt: string;
+    inferenceType?: string;
+    openAiContextLength?: number;
+  },
+}));
+
+vi.mock("../client/modules/pubSub", () => ({
+  getSettings: () => state.settings,
+  getLlmTextSearchResults: () => state.searchResults,
+  getPageContents: () => state.pageContents,
+  getQuery: () => state.query,
+  getSearchPromise: vi.fn(),
+  updateTextGenerationState: vi.fn(),
+}));
+
+const LLM_API_KEY = process.env.EVAL_LLM_API_KEY ?? "";
+// Strip any trailing slash so a configured base URL can't produce /v1//chat/....
+const LLM_BASE_URL = (
+  process.env.EVAL_LLM_BASE_URL ?? "https://api.openai.com/v1"
+).replace(/\/$/, "");
+const LLM_MODEL = process.env.EVAL_LLM_MODEL ?? "gpt-4o-mini";
+const JUDGE_MODEL = process.env.EVAL_JUDGE_MODEL ?? LLM_MODEL;
+// Match the app's own answer budget (openAiContextLength default) so an answer
+// is not truncated for budget reasons; the judge needs far less.
+const ANSWER_MAX_TOKENS = 4096;
+const JUDGE_MAX_TOKENS = 512;
+
+// A regression guard, not a quality target: the current model clears it
+// comfortably, and a prompt/model change that degrades answers drops it.
+const MIN_MEAN_RUBRIC_PASS = 0.7;
+
+/**
+ * The fraction of answers that cite at least one source as a Markdown link.
+ * The system prompt instructs the model to cite each fact; this deterministic
+ * check is what makes deleting that instruction visible. It is a rate rather
+ * than a per-query assert so a single model non-citation does not fail the
+ * run, while a wholesale loss of citations (the regression we care about)
+ * drops the rate to near zero.
+ */
+const MIN_CITATION_RATE = 0.8;
+
+// The mean rubric pass fraction over the snippet-only entries (facts that
+// exist only in the search results). Graded separately so a handful of them
+// can't be drowned out by the rest of the set: this is what catches the
+// results path breaking while the citation rate stays high.
+const MIN_SNIPPET_ONLY_PASS = 0.8;
+
+/** True if the text contains at least one Markdown link, [any](url). */
+function hasMarkdownLink(text: string): boolean {
+  return /\[[^\]]+\]\([^)]+\)/.test(text);
+}
+
+const hasLlmKey = LLM_API_KEY.length > 0;
+
+interface ChatCompletionResponse {
+  error?: { message?: string };
+  choices?: {
+    message?: { content?: string | null };
+    finish_reason?: string;
+  }[];
+}
+
+async function chatCompletion(
+  model: string,
+  messages: ChatMessage[],
+  maxTokens: number,
+  label: string,
+): Promise<string> {
+  const res = await fetch(`${LLM_BASE_URL}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${LLM_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      temperature: 0,
+      max_tokens: maxTokens,
+    }),
+    // Keep each call well under the 180s per-test budget, which covers the two
+    // sequential calls (answer + judge); a hung call is closed here instead of
+    // outliving the test's own timeout.
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) {
+    throw new Error(`LLM call failed (${res.status}): ${await res.text()}`);
+  }
+  const data = (await res.json()) as ChatCompletionResponse;
+  // Some OpenAI-compatible proxies return 200 with an { error } body.
+  if (data.error) {
+    throw new Error(`LLM error: ${JSON.stringify(data.error)}`);
+  }
+  const choice = data.choices?.[0];
+  if (choice?.finish_reason === "length") {
+    throw new Error(
+      `${label} was truncated at max_tokens=${maxTokens}; raise the budget or shorten the prompt.`,
+    );
+  }
+  const content = choice?.message?.content;
+  if (typeof content !== "string") {
+    // Empty choices (content filter) or null content (refusal) are not a
+    // usable answer; fail loudly with the raw body for diagnosis.
+    throw new Error(
+      `${label} returned no usable content: ${JSON.stringify(data).slice(0, 500)}`,
+    );
+  }
+  return content;
+}
+
+const JudgeResponseSchema = z.object({
+  scores: z.array(z.object({ criterion: z.string(), pass: z.boolean() })),
+});
+
+interface JudgeScore {
+  criterion: string;
+  pass: boolean;
+}
+
+/**
+ * Asks the judge to check each rubric point against the answer and return
+ * strict JSON. Throws if the response is not valid JSON matching the schema,
+ * or if the number of returned rubric points does not match the golden
+ * rubric (a judge returning fewer points would silently inflate the score).
+ */
+async function judgeAnswer(
+  goldenId: string,
+  answer: string,
+): Promise<{ scores: JudgeScore[]; passFraction: number }> {
+  const golden = goldenQueries.find((g) => g.id === goldenId);
+  if (!golden) throw new Error(`Unknown golden id: ${goldenId}`);
+
+  const rubric = golden.rubric.map((r, i) => `${i + 1}. ${r}`).join("\n");
+  const judgePrompt = [
+    "You are grading an AI search answer. For each numbered rubric point",
+    "below, decide whether the answer satisfies it. Be strict: a point passes",
+    "only if the answer clearly and correctly satisfies it.",
+    "",
+    `Question: ${golden.query}`,
+    "",
+    `Reference answer: ${golden.referenceAnswer}`,
+    "",
+    `Answer under evaluation:\n${answer}`,
+    "",
+    "Rubric points:",
+    rubric,
+    "",
+    "Respond with ONLY a JSON object of the exact form:",
+    '{"scores":[{"criterion":"<rubric point>","pass":true}]}',
+    "with one entry per rubric point, in the same order.",
+  ].join("\n");
+
+  const raw = await chatCompletion(
+    JUDGE_MODEL,
+    [{ role: "user", content: judgePrompt }],
+    JUDGE_MAX_TOKENS,
+    "Judge",
+  );
+
+  const jsonText = raw
+    .replace(/```json\s*/g, "")
+    .replace(/```/g, "")
+    .trim();
+  const start = jsonText.indexOf("{");
+  const end = jsonText.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`Judge returned no JSON object: ${raw.slice(0, 500)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText.slice(start, end + 1));
+  } catch {
+    throw new Error(`Judge returned invalid JSON: ${raw.slice(0, 500)}`);
+  }
+
+  const result = JudgeResponseSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `Judge response failed schema (${result.error.message}): ${raw.slice(0, 500)}`,
+    );
+  }
+
+  const scores = result.data.scores;
+  if (scores.length !== golden.rubric.length) {
+    throw new Error(
+      `Judge returned ${scores.length} rubric points, expected ${golden.rubric.length}: ${raw.slice(0, 500)}`,
+    );
+  }
+
+  const passFraction = scores.filter((s) => s.pass).length / scores.length;
+  return { scores, passFraction };
+}
+
+describe("answer eval: LLM-judged quality", () => {
+  // Module-level results collected by the per-query tests below and asserted
+  // on by the aggregate test. Within a file, vitest runs tests in order, so
+  // the per-query tests always populate this before the aggregate runs.
+  const results: {
+    id: string;
+    passFraction: number;
+    cited: boolean;
+    failed: string[];
+  }[] = [];
+
+  for (const golden of goldenQueries) {
+    it.skipIf(!hasLlmKey)(
+      `grades ${golden.id}`,
+      async () => {
+        const messages = buildMessagesForGolden(state, golden.id);
+        const answer = await chatCompletion(
+          LLM_MODEL,
+          messages,
+          ANSWER_MAX_TOKENS,
+          "Answer",
+        );
+        expect(answer.trim().length).toBeGreaterThan(0);
+        const { scores, passFraction } = await judgeAnswer(golden.id, answer);
+        const failed = scores.filter((s) => !s.pass).map((s) => s.criterion);
+        results.push({
+          id: golden.id,
+          passFraction,
+          cited: hasMarkdownLink(answer),
+          failed,
+        });
+      },
+      180_000,
+    );
+  }
+
+  it.skipIf(!hasLlmKey)(
+    "keeps the mean rubric pass fraction above the threshold",
+    async () => {
+      // Completeness: the mean is only meaningful if every query was graded.
+      // (A failed per-query test is already red, but this keeps the printed
+      // headline from being a partial-run average.)
+      expect(results).toHaveLength(goldenQueries.length);
+
+      const mean =
+        results.reduce((sum, r) => sum + r.passFraction, 0) / results.length;
+      const citationRate =
+        results.filter((r) => r.cited).length / results.length;
+
+      console.table(
+        results.map((r) => ({
+          id: r.id,
+          "rubric pass": r.passFraction.toFixed(2),
+          cited: r.cited ? "yes" : "no",
+          failed: r.failed.join("; ") || "-",
+        })),
+      );
+      console.log(
+        `mean rubric pass fraction: ${mean.toFixed(3)}  citation rate: ${citationRate.toFixed(3)}`,
+      );
+
+      expect(mean).toBeGreaterThanOrEqual(MIN_MEAN_RUBRIC_PASS);
+      expect(
+        citationRate,
+        "too few answers cite their sources",
+      ).toBeGreaterThanOrEqual(MIN_CITATION_RATE);
+
+      const snippetOnlyIds = new Set(
+        goldenQueries.filter((g) => g.snippetOnly).map((g) => g.id),
+      );
+      const snippetOnly = results.filter((r) => snippetOnlyIds.has(r.id));
+      expect(
+        snippetOnly.length,
+        "no snippet-only entries in the golden set",
+      ).toBeGreaterThan(0);
+      const snippetOnlyMean =
+        snippetOnly.reduce((sum, r) => sum + r.passFraction, 0) /
+        snippetOnly.length;
+      console.log(
+        `mean snippet-only rubric pass fraction: ${snippetOnlyMean.toFixed(3)}`,
+      );
+      expect(
+        snippetOnlyMean,
+        "snippet-only facts are not being answered from the search results",
+      ).toBeGreaterThanOrEqual(MIN_SNIPPET_ONLY_PASS);
+    },
+    60_000,
+  );
+});

--- a/eval/goldenPrompt.ts
+++ b/eval/goldenPrompt.ts
@@ -1,0 +1,55 @@
+import {
+  getDefaultChatMessages,
+  getFormattedSearchResults,
+} from "../client/modules/textGenerationUtilities.ts";
+import { DEFAULT_SYSTEM_PROMPT } from "../shared/defaultSystemPrompt.ts";
+import { goldenQueries } from "./goldenSet.ts";
+
+/** The mockable pubSub state the answer eval drives. */
+export interface EvalState {
+  query: string;
+  searchResults: [string, string, string][];
+  pageContents: Record<string, string>;
+  settings: {
+    systemPrompt: string;
+    inferenceType?: string;
+    openAiContextLength?: number;
+  };
+}
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Builds the messages the app would send for one golden query, mutating the
+ * passed-in pubSub mock state. Shared by promptConstruction.test.ts (default
+ * suite) and answer.integration.test.ts (eval config) so both build the prompt
+ * the same way; a drifted copy in one would let that copy grade a different
+ * prompt than the other. The vi.mock factory itself has to stay per-file
+ * (vitest hoists it above imports), but the prompt-building logic does not.
+ */
+export function buildMessagesForGolden(
+  state: EvalState,
+  goldenId: string,
+): ChatMessage[] {
+  const golden = goldenQueries.find((g) => g.id === goldenId);
+  if (!golden) throw new Error(`Unknown golden id: ${goldenId}`);
+
+  state.query = golden.query;
+  state.searchResults = golden.results.map(({ title, snippet, url }) => [
+    title,
+    snippet,
+    url,
+  ]);
+  state.pageContents = {};
+  state.settings = {
+    systemPrompt: DEFAULT_SYSTEM_PROMPT,
+    inferenceType: "openai",
+    openAiContextLength: 4096,
+  };
+
+  const formatted = getFormattedSearchResults(true);
+  return getDefaultChatMessages(formatted);
+}

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -1,25 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { goldenQueries } from "./goldenSet.ts";
 import { ndcgAtK, recallAtK } from "./metrics.ts";
+import {
+  K,
+  MAX_NOOP_MEAN_NDCG,
+  MAX_NOOP_MEAN_RECALL,
+  MIN_MEAN_NDCG,
+  MIN_MEAN_RECALL,
+} from "./thresholds.ts";
 
 /**
  * Bumped deliberately whenever the golden set grows, so an edit to the set
  * forces the author to re-read (and re-tune if needed) the thresholds in
- * retrieval.integration.test.ts.
+ * thresholds.ts.
  */
 const EXPECTED_QUERY_COUNT = 26;
-
-/**
- * The identity-ranking (no-op reranker) baseline the retrieval eval's floors
- * are placed against. If a golden entry keeps all its relevant results inside
- * the top-K of the input order, a dead reranker scores as well as a working
- * one and MIN_MEAN_NDCG / MIN_MEAN_RECALL in retrieval.integration.test.ts
- * stop being falsifiable. These ceilings must stay below those floors
- * (0.75 / 0.70); the current set sits at 0.587 / 0.500.
- */
-const K = 3;
-const MAX_NOOP_MEAN_NDCG = 0.65;
-const MAX_NOOP_MEAN_RECALL = 0.6;
 
 // Sequences that String.replace treats as special. The app's getSystemPrompt
 // substitutes the search results into the prompt via String.replace, and
@@ -60,6 +55,15 @@ function validateGoldenSet() {
         `${g.id}: relevant index ${i} out of range (0..${g.results.length - 1})`,
       ).toBe(true);
     }
+    // Retrieval falsifiability, per entry: at least one relevant result must
+    // sit outside the input top-K, or a no-op reranker (which preserves input
+    // order) scores this entry as well as a working one. This is the per-entry
+    // form of the "stays falsifiable" aggregate below; the aggregate alone
+    // would let a single degenerate entry pass silently.
+    expect(
+      g.relevant.some((i) => i >= K),
+      `${g.id}: every relevant result sits in the input top-${K}, so a no-op reranker scores it perfectly`,
+    ).toBe(true);
     // The answer eval builds the prompt from these results, but the app slices
     // to searchResultsToConsider (6) before sending it. A longer entry would
     // grade a prompt the app can never send.
@@ -96,6 +100,13 @@ describe("golden set", () => {
 
   it("has the expected number of queries", () => {
     expect(goldenQueries).toHaveLength(EXPECTED_QUERY_COUNT);
+  });
+
+  it("keeps the no-op ceilings below the eval's floors", () => {
+    // If a ceiling reached or passed its floor, a no-op reranker would clear
+    // the floor and the retrieval eval would stop being falsifiable.
+    expect(MAX_NOOP_MEAN_NDCG).toBeLessThan(MIN_MEAN_NDCG);
+    expect(MAX_NOOP_MEAN_RECALL).toBeLessThan(MIN_MEAN_RECALL);
   });
 
   it("stays falsifiable: a no-op reranker scores below the eval's floors", () => {

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -28,12 +28,38 @@ function validateGoldenSet() {
     ).toBeUndefined();
     expect(g.query.length, `${g.id}: empty query`).toBeGreaterThan(0);
     expect(g.rubric.length, `${g.id}: empty rubric`).toBeGreaterThan(0);
+    expect(
+      g.referenceAnswer.length,
+      `${g.id}: empty referenceAnswer (weakens the judge)`,
+    ).toBeGreaterThan(0);
     expect(g.relevant.length, `${g.id}: no relevant labels`).toBeGreaterThan(0);
+    expect(
+      new Set(g.relevant).size === g.relevant.length,
+      `${g.id}: duplicate relevant index (dedupes to a trivial entry)`,
+    ).toBe(true);
     for (const i of g.relevant) {
+      expect(
+        Number.isInteger(i),
+        `${g.id}: relevant index ${i} is not an integer`,
+      ).toBe(true);
       expect(
         i >= 0 && i < g.results.length,
         `${g.id}: relevant index ${i} out of range (0..${g.results.length - 1})`,
       ).toBe(true);
+    }
+    // The answer eval builds the prompt from these results, but the app slices
+    // to searchResultsToConsider (6) before sending it. A longer entry would
+    // grade a prompt the app can never send.
+    expect(
+      g.results.length <= 6,
+      `${g.id}: ${g.results.length} results exceeds the app's 6-result prompt budget`,
+    ).toBe(true);
+    for (const r of g.results) {
+      expect(r.title.length, `${g.id}: empty result title`).toBeGreaterThan(0);
+      expect(r.snippet.length, `${g.id}: empty result snippet`).toBeGreaterThan(
+        0,
+      );
+      expect(r.url.length, `${g.id}: empty result url`).toBeGreaterThan(0);
     }
     for (const special of REPLACE_SPECIAL_SEQUENCES) {
       for (const r of g.results) {

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -117,8 +117,8 @@ describe("golden set", () => {
     // Score the golden set as a reranker that just preserves the input order
     // (the failure mode the retrieval eval exists to catch). If this mean
     // climbs to the eval's floors, the set no longer distinguishes a working
-    // reranker from a dead one - usually because an entry keeps both relevant
-    // results in the input top-3.
+    // reranker from a dead one - usually because an entry keeps its relevant
+    // results in the input top-K.
     const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
     const scored = goldenQueries.map((g) => {
       const urls = g.results.map((r) => r.url);

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -131,11 +131,11 @@ describe("golden set", () => {
 
     expect(
       mean(scored.map((s) => s.ndcg)),
-      "a golden entry keeps its relevant results in the input top-3",
+      `a golden entry keeps its relevant results in the input top-${K}`,
     ).toBeLessThanOrEqual(MAX_NOOP_MEAN_NDCG);
     expect(
       mean(scored.map((s) => s.recall)),
-      "a golden entry keeps its relevant results in the input top-3",
+      `a golden entry keeps its relevant results in the input top-${K}`,
     ).toBeLessThanOrEqual(MAX_NOOP_MEAN_RECALL);
   });
 });

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { goldenQueries } from "./goldenSet.ts";
+import { ndcgAtK, recallAtK } from "./metrics.ts";
 
 /**
  * Bumped deliberately whenever the golden set grows, so an edit to the set
@@ -7,6 +8,18 @@ import { goldenQueries } from "./goldenSet.ts";
  * retrieval.integration.test.ts.
  */
 const EXPECTED_QUERY_COUNT = 26;
+
+/**
+ * The identity-ranking (no-op reranker) baseline the retrieval eval's floors
+ * are placed against. If a golden entry keeps all its relevant results inside
+ * the top-K of the input order, a dead reranker scores as well as a working
+ * one and MIN_MEAN_NDCG / MIN_MEAN_RECALL in retrieval.integration.test.ts
+ * stop being falsifiable. These ceilings must stay below those floors
+ * (0.75 / 0.70); the current set sits at 0.587 / 0.500.
+ */
+const K = 3;
+const MAX_NOOP_MEAN_NDCG = 0.65;
+const MAX_NOOP_MEAN_RECALL = 0.6;
 
 // Sequences that String.replace treats as special. The app's getSystemPrompt
 // substitutes the search results into the prompt via String.replace, and
@@ -83,5 +96,31 @@ describe("golden set", () => {
 
   it("has the expected number of queries", () => {
     expect(goldenQueries).toHaveLength(EXPECTED_QUERY_COUNT);
+  });
+
+  it("stays falsifiable: a no-op reranker scores below the eval's floors", () => {
+    // Score the golden set as a reranker that just preserves the input order
+    // (the failure mode the retrieval eval exists to catch). If this mean
+    // climbs to the eval's floors, the set no longer distinguishes a working
+    // reranker from a dead one - usually because an entry keeps both relevant
+    // results in the input top-3.
+    const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+    const scored = goldenQueries.map((g) => {
+      const urls = g.results.map((r) => r.url);
+      const relevant = g.relevant.map((i) => urls[i]);
+      return {
+        ndcg: ndcgAtK(urls, relevant, K),
+        recall: recallAtK(urls, relevant, K),
+      };
+    });
+
+    expect(
+      mean(scored.map((s) => s.ndcg)),
+      "a golden entry keeps its relevant results in the input top-3",
+    ).toBeLessThanOrEqual(MAX_NOOP_MEAN_NDCG);
+    expect(
+      mean(scored.map((s) => s.recall)),
+      "a golden entry keeps its relevant results in the input top-3",
+    ).toBeLessThanOrEqual(MAX_NOOP_MEAN_RECALL);
   });
 });

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { goldenQueries } from "./goldenSet.ts";
+
+/**
+ * Bumped deliberately whenever the golden set grows, so an edit to the set
+ * forces the author to re-read (and re-tune if needed) the thresholds in
+ * retrieval.integration.test.ts.
+ */
+const EXPECTED_QUERY_COUNT = 26;
+
+// Sequences that String.replace treats as special. The app's getSystemPrompt
+// substitutes the search results into the prompt via String.replace, and
+// getFormattedSearchResults puts the title, url, and snippet of every result
+// into that replacement string. A field containing one of these would silently
+// corrupt the prompt (a pre-existing bug in client/modules/systemPrompt.ts).
+// Rejecting them here keeps the eval from ever grading a corrupted prompt.
+const REPLACE_SPECIAL_SEQUENCES = ["$&", "$`", "$'", "$$"];
+
+/** Structural checks on the golden set so a bad entry fails loudly. */
+function validateGoldenSet() {
+  const seenIds = new Set<string>();
+  for (const g of goldenQueries) {
+    const urls = g.results.map((r) => r.url);
+    const duplicate = urls.find((u, i) => urls.indexOf(u) !== i);
+    expect(
+      duplicate,
+      `${g.id}: duplicate result url ${duplicate} (breaks the nDCG <= 1 bound)`,
+    ).toBeUndefined();
+    expect(g.query.length, `${g.id}: empty query`).toBeGreaterThan(0);
+    expect(g.rubric.length, `${g.id}: empty rubric`).toBeGreaterThan(0);
+    expect(g.relevant.length, `${g.id}: no relevant labels`).toBeGreaterThan(0);
+    for (const i of g.relevant) {
+      expect(
+        i >= 0 && i < g.results.length,
+        `${g.id}: relevant index ${i} out of range (0..${g.results.length - 1})`,
+      ).toBe(true);
+    }
+    for (const special of REPLACE_SPECIAL_SEQUENCES) {
+      for (const r of g.results) {
+        for (const field of [r.title, r.snippet, r.url]) {
+          expect(
+            field.includes(special),
+            `${g.id}: a result field contains ${JSON.stringify(special)} (String.replace would corrupt the prompt)`,
+          ).toBe(false);
+        }
+      }
+    }
+    expect(seenIds.has(g.id), `${g.id}: duplicate golden id`).toBe(false);
+    seenIds.add(g.id);
+  }
+}
+
+describe("golden set", () => {
+  it("is well-formed", () => {
+    validateGoldenSet();
+  });
+
+  it("has the expected number of queries", () => {
+    expect(goldenQueries).toHaveLength(EXPECTED_QUERY_COUNT);
+  });
+});

--- a/eval/goldenSet.test.ts
+++ b/eval/goldenSet.test.ts
@@ -55,14 +55,18 @@ function validateGoldenSet() {
         `${g.id}: relevant index ${i} out of range (0..${g.results.length - 1})`,
       ).toBe(true);
     }
-    // Retrieval falsifiability, per entry: at least one relevant result must
-    // sit outside the input top-K, or a no-op reranker (which preserves input
-    // order) scores this entry as well as a working one. This is the per-entry
+    // Retrieval falsifiability, per entry: the input top-K must not already
+    // hold every relevant result it can fit, or a no-op reranker (which
+    // preserves input order) scores this entry as well as a working one.
+    // Comparing against min(K, relevant.length) rather than "some index >= K"
+    // also covers entries with more than K labels, where the input top-K can
+    // be saturated while a label still sits outside it. This is the per-entry
     // form of the "stays falsifiable" aggregate below; the aggregate alone
     // would let a single degenerate entry pass silently.
+    const relevantInTopK = g.relevant.filter((i) => i < K).length;
     expect(
-      g.relevant.some((i) => i >= K),
-      `${g.id}: every relevant result sits in the input top-${K}, so a no-op reranker scores it perfectly`,
+      relevantInTopK < Math.min(K, g.relevant.length),
+      `${g.id}: the input top-${K} already holds every relevant result it can fit, so a no-op reranker already scores it as well as a working one`,
     ).toBe(true);
     // The answer eval builds the prompt from these results, but the app slices
     // to searchResultsToConsider (6) before sending it. A longer entry would

--- a/eval/goldenSet.ts
+++ b/eval/goldenSet.ts
@@ -101,12 +101,6 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://css-tools.com/reset",
       },
       {
-        title: "CSS Flexbox - MDN Web Docs",
-        snippet:
-          "The flex container's main and cross axes let you center items with justify-content and align-items.",
-        url: "https://developer.mozilla.org/flexbox",
-      },
-      {
         title: "What is a div tag in HTML?",
         snippet:
           "The div element is a generic container for flow content with no required attributes.",
@@ -118,8 +112,14 @@ export const goldenQueries: GoldenQuery[] = [
           "Printable poster of all flexbox properties. Order now and master layout at a glance.",
         url: "https://printables.com/flexbox-poster",
       },
+      {
+        title: "CSS Flexbox - MDN Web Docs",
+        snippet:
+          "The flex container's main and cross axes let you center items with justify-content and align-items.",
+        url: "https://developer.mozilla.org/flexbox",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 4],
     referenceAnswer:
       "Set the parent to display: flex, then use justify-content: center (main axis) and align-items: center (cross axis) to center the child both horizontally and vertically.",
     rubric: [
@@ -145,19 +145,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://travel.com/sydney-things-to-do",
       },
       {
-        title: "Austrália - Wikipédia",
-        snippet:
-          "A capital da Austrália é Camberra, e a maior cidade é Sydney.",
-        url: "https://pt.wikipedia.org/wiki/Austrália",
-      },
-      {
         title: "Australian visa: eligibility and how to apply",
         snippet:
           "Check if you qualify for an Australian visitor, work or student visa and start your application.",
         url: "https://immigration.gov/australia-visa",
       },
+      {
+        title: "Austrália - Wikipédia",
+        snippet:
+          "A capital da Austrália é Camberra, e a maior cidade é Sydney.",
+        url: "https://pt.wikipedia.org/wiki/Austrália",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "A capital da Austrália é Camberra (Canberra). Sydney é a cidade mais populosa, mas não é a capital.",
     rubric: [
@@ -184,12 +184,6 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://gitkraken.com/download",
       },
       {
-        title: "git-rebase - Git documentation",
-        snippet:
-          "Rebase rewrites your branch's commits to sit on top of the upstream, producing a linear history.",
-        url: "https://git-scm.com/docs/git-rebase",
-      },
-      {
         title: "Git logo and brand assets",
         snippet:
           "Download the official Git logo in SVG and PNG for your site or slides.",
@@ -201,8 +195,14 @@ export const goldenQueries: GoldenQuery[] = [
           "Compare free, team and enterprise plans for private repositories and CI minutes.",
         url: "https://codehost.dev/pricing",
       },
+      {
+        title: "git-rebase - Git documentation",
+        snippet:
+          "Rebase rewrites your branch's commits to sit on top of the upstream, producing a linear history.",
+        url: "https://git-scm.com/docs/git-rebase",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 4],
     referenceAnswer:
       "git merge combines two branches into a new merge commit, preserving both histories. git rebase replays your commits on top of another branch, rewriting them for a linear history.",
     rubric: [
@@ -228,19 +228,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://boardgames.com/wwii-strategy",
       },
       {
-        title: "The end of World War II - History.com",
-        snippet:
-          "V-E Day in May 1945 and V-J Day in September 1945 marked the end of the war in Europe and the Pacific.",
-        url: "https://history.com/wwii-end",
-      },
-      {
         title: "Vintage WWII poster prints",
         snippet:
           "Restored wartime posters, ready to frame. A bold piece for any wall.",
         url: "https://prints.com/wwii-posters",
       },
+      {
+        title: "The end of World War II - History.com",
+        snippet:
+          "V-E Day in May 1945 and V-J Day in September 1945 marked the end of the war in Europe and the Pacific.",
+        url: "https://history.com/wwii-end",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "World War II ended in 1945 (Europe in May 1945, and globally with Japan's surrender in September 1945).",
     rubric: ["Gives 1945 as the end year.", "Does not give a wrong year."],
@@ -262,12 +262,6 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://tutorials.com/rest-101",
       },
       {
-        title: "JWT Security Best Practices - OWASP",
-        snippet:
-          "Validate alg, nbf and exp claims; never put secrets in the payload; rotate signing keys.",
-        url: "https://owasp.org/jwt-best-practices",
-      },
-      {
         title: "JWT logo vector download",
         snippet: "The official JWT wordmark as an SVG for your docs.",
         url: "https://logos.com/jwt-svg",
@@ -278,8 +272,14 @@ export const goldenQueries: GoldenQuery[] = [
           "Start free, then pay per monthly active user for hosted auth.",
         url: "https://authvendor.io/pricing",
       },
+      {
+        title: "JWT Security Best Practices - OWASP",
+        snippet:
+          "Validate alg, nbf and exp claims; never put secrets in the payload; rotate signing keys.",
+        url: "https://owasp.org/jwt-best-practices",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 4],
     referenceAnswer:
       "Use short-lived signed access tokens, validate the signature and claims (exp, nbf, aud) on every request, keep the signing secret strong and rotated, and use refresh tokens for re-authentication.",
     rubric: [
@@ -305,19 +305,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://cruises.com/south-pacific",
       },
       {
-        title: "Geografia: os cinco oceanos do planeta",
-        snippet:
-          "O Pacífico é o maior oceano, seguido do Atlântico, Índico, Ártico e Antártico.",
-        url: "https://geografia.br/os-oceanos",
-      },
-      {
         title: "Ocean life: meet the marine animals",
         snippet:
           "From jellyfish to blue whales, explore the creatures that live in the sea.",
         url: "https://nature.com/ocean-animals",
       },
+      {
+        title: "Geografia: os cinco oceanos do planeta",
+        snippet:
+          "O Pacífico é o maior oceano, seguido do Atlântico, Índico, Ártico e Antártico.",
+        url: "https://geografia.br/os-oceanos",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer: "O maior oceano do mundo é o Oceano Pacífico.",
     rubric: [
       "Names the Pacific (Pacífico) as the largest ocean.",
@@ -342,19 +342,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://theatre.com/hamlet-tickets",
       },
       {
-        title: "William Shakespeare: the Bard of Avon",
-        snippet:
-          "Shakespeare wrote 39 plays including Hamlet, Macbeth and Othello, defining the English language stage.",
-        url: "https://bard.org/william-shakespeare",
-      },
-      {
         title: "What is a hamlet (settlement)?",
         snippet:
           "A hamlet is a small rural settlement, typically smaller than a village and without a church.",
         url: "https://geography.com/hamlet-settlement",
       },
+      {
+        title: "William Shakespeare: the Bard of Avon",
+        snippet:
+          "Shakespeare wrote 39 plays including Hamlet, Macbeth and Othello, defining the English language stage.",
+        url: "https://bard.org/william-shakespeare",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer: "Hamlet was written by William Shakespeare.",
     rubric: [
       "Names William Shakespeare as the author.",
@@ -377,12 +377,6 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://reactjs.org/brand",
       },
       {
-        title: "Why does my useEffect run twice? - Stack Overflow",
-        snippet:
-          "Updating state that is in the dependency array (or returning a new reference each render) re-runs the effect, which updates state again.",
-        url: "https://stackoverflow.com/q/useeffect-twice",
-      },
-      {
         title: "React Native: build mobile apps",
         snippet:
           "Use the latest JavaScript to build native iOS and Android apps with a single codebase.",
@@ -394,8 +388,14 @@ export const goldenQueries: GoldenQuery[] = [
           "Lifetime access to 40 hours of React and TypeScript video lessons.",
         url: "https://course.dev/react-pricing",
       },
+      {
+        title: "Why does my useEffect run twice? - Stack Overflow",
+        snippet:
+          "Updating state that is in the dependency array (or returning a new reference each render) re-runs the effect, which updates state again.",
+        url: "https://stackoverflow.com/q/useeffect-twice",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 4],
     referenceAnswer:
       "A useEffect infinite loop is usually caused by a dependency that changes on every render (a new object/function reference) or by updating state that is itself in the dependency array, which re-runs the effect, which updates the state again. Stabilize the dependency (useMemo/useCallback) or restructure the effect.",
     rubric: [
@@ -421,19 +421,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://appliance.com/electric-kettle",
       },
       {
-        title: "Water properties reference - Chemistry LibreTexts",
-        snippet:
-          "At 1 atm, water boils at 100 °C; the point drops with altitude as pressure falls.",
-        url: "https://chem.libretexts.com/water-properties",
-      },
-      {
         title: "Industrial water boiler for process heat",
         snippet:
           "Steam generators rated to 15 bar for continuous industrial use.",
         url: "https://industrial.com/water-boiler",
       },
+      {
+        title: "Water properties reference - Chemistry LibreTexts",
+        snippet:
+          "At 1 atm, water boils at 100 °C; the point drops with altitude as pressure falls.",
+        url: "https://chem.libretexts.com/water-properties",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer: "At sea level (1 atm), water boils at 100 °C (212 °F).",
     rubric: [
       "Gives 100 °C or 212 °F.",
@@ -457,19 +457,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://sports.com/football-boots",
       },
       {
-        title: "Why free kicks bend - BBC Sport",
-        snippet:
-          "Striking the ball off-centre spins it; the resulting Magnus effect is what bends a free kick around the wall.",
-        url: "https://bbc.com/sport/free-kicks",
-      },
-      {
         title: "Football (soccer) rules overview",
         snippet:
           "The basic laws of the game: offside, fouls, corners and how a match is structured.",
         url: "https://rules.com/soccer-laws",
       },
+      {
+        title: "Why free kicks bend - BBC Sport",
+        snippet:
+          "Striking the ball off-centre spins it; the resulting Magnus effect is what bends a free kick around the wall.",
+        url: "https://bbc.com/sport/free-kicks",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "The curve is caused by the Magnus effect: a spinning ball creates a pressure difference in the surrounding air that pushes it sideways, bending its trajectory.",
     rubric: [
@@ -494,19 +494,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://gardening.com/plant-light",
       },
       {
-        title: "The equation of photosynthesis - Khan Academy",
-        snippet:
-          "Carbon dioxide plus water, using light energy, yields glucose and oxygen.",
-        url: "https://khanacademy.org/photosynthesis-equation",
-      },
-      {
         title: "Succulent care 101",
         snippet:
           "Water less often, use a gritty mix, and give bright indirect light.",
         url: "https://plants101.com/succulents",
       },
+      {
+        title: "The equation of photosynthesis - Khan Academy",
+        snippet:
+          "Carbon dioxide plus water, using light energy, yields glucose and oxygen.",
+        url: "https://khanacademy.org/photosynthesis-equation",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "6 CO2 + 6 H2O + light energy -> C6H12O6 (glucose) + 6 O2.",
     rubric: [
@@ -531,19 +531,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://home.com/led-bulbs",
       },
       {
-        title: "The constant c in physics - HyperPhysics",
-        snippet:
-          "c = 299792458 m/s is the invariant speed that sets the maximum speed of causality.",
-        url: "https://hyperphysics.com/speed-of-light",
-      },
-      {
         title: "Fiber internet: gigabit 'speed of light' plans",
         snippet:
           "Blazing-fast fiber up to 1 Gbps. Marketing calls it the speed of light.",
         url: "https://isp.com/fiber-gigabit",
       },
+      {
+        title: "The constant c in physics - HyperPhysics",
+        snippet:
+          "c = 299792458 m/s is the invariant speed that sets the maximum speed of causality.",
+        url: "https://hyperphysics.com/speed-of-light",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "The speed of light in a vacuum is exactly 299,792,458 metres per second (about 3.00 x 10^8 m/s).",
     rubric: [
@@ -568,19 +568,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://costumes.com/mona-lisa-mask",
       },
       {
-        title: "Mona Lisa - Wikipedia",
-        snippet:
-          "The Mona Lisa is a portrait painting by the Italian Renaissance artist Leonardo da Vinci.",
-        url: "https://wikipedia.org/wiki/Mona_Lisa",
-      },
-      {
         title: "Mona Lisa (singer): discography",
         snippet:
           "A French singer-songwriter's albums, singles and touring dates.",
         url: "https://music.com/mona-lisa-singer",
       },
+      {
+        title: "Mona Lisa - Wikipedia",
+        snippet:
+          "The Mona Lisa is a portrait painting by the Italian Renaissance artist Leonardo da Vinci.",
+        url: "https://wikipedia.org/wiki/Mona_Lisa",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer: "The Mona Lisa was painted by Leonardo da Vinci.",
     rubric: [
       "Names Leonardo da Vinci as the painter.",
@@ -604,18 +604,18 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://grocery.com/baking-soda-4lb",
       },
       {
+        title: "Classic lemon drizzle cake recipe",
+        snippet: "A moist lemon cake with a sweet drizzle topping. Serves 10.",
+        url: "https://recipes.com/lemon-drizzle",
+      },
+      {
         title: "What is the difference? - wikiHow",
         snippet:
           "Baking powder contains baking soda plus an acid and starch, so it leavens on its own.",
         url: "https://wikihow.com/baking-soda-vs-powder",
       },
-      {
-        title: "Classic lemon drizzle cake recipe",
-        snippet: "A moist lemon cake with a sweet drizzle topping. Serves 10.",
-        url: "https://recipes.com/lemon-drizzle",
-      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "Baking soda is sodium bicarbonate alone and needs an acid to leaven; baking powder is baking soda plus a built-in acid (and usually starch), so it leavens by itself.",
     rubric: [
@@ -640,18 +640,18 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://treks.com/everest-base-camp",
       },
       {
+        title: "Mountain bike sale: full-suspension",
+        snippet: "Trail-ready full-suspension mountain bikes, from $699.",
+        url: "https://cycles.com/mountain-bike",
+      },
+      {
         title: "Highest peaks on Earth - Britannica",
         snippet:
           "Mount Everest is the highest mountain above sea level at 8,848.86 m.",
         url: "https://britannica.com/highest-peaks",
       },
-      {
-        title: "Mountain bike sale: full-suspension",
-        snippet: "Trail-ready full-suspension mountain bikes, from $699.",
-        url: "https://cycles.com/mountain-bike",
-      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "Mount Everest is the tallest mountain in the world (highest above sea level), at about 8,849 m.",
     rubric: [
@@ -675,19 +675,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://tires.com/all-season-prices",
       },
       {
-        title: "Spare tire change step by step - YouTube",
-        snippet:
-          "A 3-minute video walking through jacking, swapping and tightening the lug nuts.",
-        url: "https://youtube.com/watch/change-flat",
-      },
-      {
         title: "Alloy wheel accessories and caps",
         snippet:
           "Decorative wheel covers and valve caps to finish off your rims.",
         url: "https://auto.com/wheel-caps",
       },
+      {
+        title: "Spare tire change step by step - YouTube",
+        snippet:
+          "A 3-minute video walking through jacking, swapping and tightening the lug nuts.",
+        url: "https://youtube.com/watch/change-flat",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "Park on level ground, set the handbrake, loosen the lug nuts, jack up the car, remove the flat, fit the spare, tighten the nuts, and lower the car.",
     rubric: [
@@ -713,19 +713,19 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://techreview.com/iphone-16-pro",
       },
       {
-        title: "Apple unveils iPhone - Apple Newsroom (2007)",
-        snippet:
-          "Today Apple reinvented the phone. The iPhone combines three revolutionary devices.",
-        url: "https://apple.com/newsroom/2007-iphone",
-      },
-      {
         title: "iPhone cases and screen protectors",
         snippet:
           "Shop rugged cases and tempered-glass protectors for every iPhone model.",
         url: "https://cases.com/iphone",
       },
+      {
+        title: "Apple unveils iPhone - Apple Newsroom (2007)",
+        snippet:
+          "Today Apple reinvented the phone. The iPhone combines three revolutionary devices.",
+        url: "https://apple.com/newsroom/2007-iphone",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "The first iPhone was released in 2007 (announced January 2007, released June 29, 2007).",
     rubric: [
@@ -750,18 +750,18 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://techreview.com/mesh-wifi",
       },
       {
+        title: "Cable modem and router bundles",
+        snippet: "Save with a combo modem-router for your home internet.",
+        url: "https://isp.com/modem-router-bundle",
+      },
+      {
         title: "How to factory reset any router - CNET",
         snippet:
           "Find the reset pinhole, hold it with a paperclip until the status light flashes, and reconfigure.",
         url: "https://cnet.com/router-factory-reset",
       },
-      {
-        title: "Cable modem and router bundles",
-        snippet: "Save with a combo modem-router for your home internet.",
-        url: "https://isp.com/modem-router-bundle",
-      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "Press and hold the router's recessed reset button (with a paperclip) for about 10 seconds until the lights blink, which restores factory defaults.",
     rubric: [
@@ -786,18 +786,18 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://jewelry.com/gold-rings",
       },
       {
+        title: "Gold Rewards credit card benefits",
+        snippet: "Earn points on every purchase with the Gold Rewards card.",
+        url: "https://bank.com/gold-card",
+      },
+      {
         title: "The Periodic Table: Au (gold)",
         snippet:
           "Au, atomic number 79, a transition metal widely used in electronics.",
         url: "https://periodic-table.com/au",
       },
-      {
-        title: "Gold Rewards credit card benefits",
-        snippet: "Earn points on every purchase with the Gold Rewards card.",
-        url: "https://bank.com/gold-card",
-      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "The chemical symbol for gold is Au (from the Latin 'aurum').",
     rubric: [
@@ -805,11 +805,6 @@ export const goldenQueries: GoldenQuery[] = [
       "Does not give the symbol for a different element.",
     ],
   },
-  // The three entries below list an IRRELEVANT result first. The app pins the
-  // original top result for text search (rankSearchResults' preserveTopResults),
-  // so these are the cases where that pin costs the ranking something. Without
-  // them every entry's pinned result is relevant and the eval can't tell a
-  // good pin from a bad one.
   {
     id: "remove-stain-white-shirt",
     query: "how to remove a stain from a white shirt",
@@ -915,12 +910,6 @@ export const goldenQueries: GoldenQuery[] = [
       "Does not answer with a repair service or an insurance plan.",
     ],
   },
-  // The three entries below are about fictional organizations and products. The
-  // specific facts (a founding year, a battery figure, a payload figure) exist
-  // ONLY in the snippets, so the model cannot answer them from parametric
-  // knowledge: this forces the search-results path, which is exactly what the
-  // answer eval is meant to guard. If getFormattedSearchResults broke and
-  // returned nothing, these would fail.
   {
     id: "halcyon-robotics-founding",
     query: "When was the Halcyon Robotics Institute founded?",
@@ -938,24 +927,24 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://careers.com/robotics-fair",
       },
       {
+        title: "Robot building kits for kids",
+        snippet: "Snap-together robot kits, ages 8 and up. Ships free.",
+        url: "https://toys.com/robot-kits",
+      },
+      {
         title: "Halcyon Robotics Institute - Wikipedia",
         snippet:
           "The Halcyon Robotics Institute (HRI) is a research organization founded in 1987.",
         url: "https://wikipedia.org/wiki/Halcyon_Robotics_Institute",
       },
-      {
-        title: "Robot building kits for kids",
-        snippet: "Snap-together robot kits, ages 8 and up. Ships free.",
-        url: "https://toys.com/robot-kits",
-      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer: "The Halcyon Robotics Institute was founded in 1987.",
-    snippetOnly: true,
     rubric: [
       "States 1987 as the founding year.",
       "Does not give a different year or say it is unknown.",
     ],
+    snippetOnly: true,
   },
   {
     id: "nimbus-t3-battery",
@@ -973,25 +962,25 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://gadgets.com/laptop-stands",
       },
       {
+        title: "USB-C chargers and adapters",
+        snippet: "65W and 100W GaN chargers for laptops and phones.",
+        url: "https://gadgets.com/usb-c-chargers",
+      },
+      {
         title: "Nimbus T3 specifications",
         snippet:
           "Battery: up to 22 hours of video playback on a single charge.",
         url: "https://nimbuspc.com/t3-specs",
       },
-      {
-        title: "USB-C chargers and adapters",
-        snippet: "65W and 100W GaN chargers for laptops and phones.",
-        url: "https://gadgets.com/usb-c-chargers",
-      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "The Nimbus T3 laptop has up to 22 hours of battery life on a single charge.",
-    snippetOnly: true,
     rubric: [
       "States 22 hours of battery life.",
       "Does not give a different battery figure.",
     ],
+    snippetOnly: true,
   },
   {
     id: "gale-7-drone-payload",
@@ -1009,23 +998,23 @@ export const goldenQueries: GoldenQuery[] = [
         url: "https://drones.com/insurance",
       },
       {
-        title: "Gale-7 review: built for surveying",
-        snippet: "The Gale-7 carries up to 6.2 kg of survey equipment.",
-        url: "https://geospatial.com/gale-7-review",
-      },
-      {
         title: "Camera gimbals for drones",
         snippet: "3-axis gimbals for 4K cameras, from $199.",
         url: "https://dronegear.com/gimbals",
       },
+      {
+        title: "Gale-7 review: built for surveying",
+        snippet: "The Gale-7 carries up to 6.2 kg of survey equipment.",
+        url: "https://geospatial.com/gale-7-review",
+      },
     ],
-    relevant: [0, 2],
+    relevant: [0, 3],
     referenceAnswer:
       "The Gale-7 survey drone carries a maximum payload of 6.2 kg.",
-    snippetOnly: true,
     rubric: [
       "States 6.2 kg as the maximum payload.",
       "Does not give a different payload figure.",
     ],
+    snippetOnly: true,
   },
 ];

--- a/eval/goldenSet.ts
+++ b/eval/goldenSet.ts
@@ -12,13 +12,12 @@
  * unambiguous (a result is clearly about the query or clearly not) so the
  * metric does not depend on a borderline call.
  *
- * Retrieval constraint: keep at least one relevant result OUTSIDE the top-3 of
- * the input order (the `results` array). If an entry keeps both relevant
- * results in the input top-3, a no-op reranker (which preserves input order)
- * scores it as well as a working one, and the retrieval eval's floors stop
- * being falsifiable. The "stays falsifiable" test in goldenSet.test.ts pins
- * this; re-tune the floors in retrieval.integration.test.ts if the set changes
- * substantially.
+ * Retrieval constraint: the input top-3 (the `results` array order) must not
+ * already hold every relevant result it can fit. If it does, a no-op reranker
+ * (which preserves input order) scores that entry as well as a working one,
+ * and the retrieval eval's floors stop being falsifiable. The per-entry
+ * validator and the "stays falsifiable" aggregate in goldenSet.test.ts pin
+ * this; re-tune the floors in thresholds.ts if the set changes substantially.
  */
 
 interface GoldenResult {

--- a/eval/goldenSet.ts
+++ b/eval/goldenSet.ts
@@ -1,0 +1,1031 @@
+/**
+ * The golden set for the offline eval: a fixed collection of queries, each with
+ * a realistic set of candidate results, the subset of those a human would call
+ * relevant, and (for the answer eval) a reference answer and a rubric.
+ *
+ * This is deliberately hand-curated and stable. It is a regression baseline,
+ * not a benchmark: the point is that a change to the reranker, the prompt, or
+ * the model moves these numbers in a direction a human can read, not that the
+ * numbers are absolute.
+ *
+ * To grow the set, add an entry with the same shape. Keep the relevant labels
+ * unambiguous (a result is clearly about the query or clearly not) so the
+ * metric does not depend on a borderline call.
+ */
+
+interface GoldenResult {
+  title: string;
+  snippet: string;
+  url: string;
+}
+
+export interface GoldenQuery {
+  /** Stable id used in reports. */
+  id: string;
+  query: string;
+  results: GoldenResult[];
+  /** Indices into `results` a human would consider relevant to `query`. */
+  relevant: number[];
+  /** Key facts a correct answer must contain (for the LLM judge). */
+  referenceAnswer: string;
+  /** What a good answer does, checked one point at a time by the judge. */
+  rubric: string[];
+  /**
+   * The answer's key fact exists only in the snippets, not in parametric
+   * knowledge or the result titles. These are the entries that fail if the
+   * search-results path breaks; the answer eval grades them as a group so a
+   * handful of them can't be drowned out by the rest of the set.
+   */
+  snippetOnly?: boolean;
+}
+
+export const goldenQueries: GoldenQuery[] = [
+  {
+    id: "apollo11-first-moonwalker",
+    query: "Who was the first person to walk on the moon?",
+    results: [
+      {
+        title: "Apollo 11: NASA's mission that put humans on the Moon",
+        snippet:
+          "On July 20, 1969, astronaut Neil Armstrong stepped onto the lunar surface, followed hours later by Buzz Aldrin.",
+        url: "https://nasa.gov/apollo-11",
+      },
+      {
+        title: "Neil Armstrong signed baseball cards for sale",
+        snippet:
+          "Buy a signed memorabilia card from the astronaut who first walked on the Moon. Ships free.",
+        url: "https://memorabilia.shop/armstrong-card",
+      },
+      {
+        title: "Moon Hotels: stay in a suite with a lunar view",
+        snippet:
+          "Luxury suites overlooking the crater. Book your once-in-a-lifetime stay on the Moon.",
+        url: "https://travel.com/moon-hotels",
+      },
+      {
+        title: "Apollo 11 - Wikipedia",
+        snippet:
+          "Apollo 11 was the spaceflight that landed the first humans, Neil Armstrong and Buzz Aldrin, on the Moon on 20 July 1969.",
+        url: "https://wikipedia.org/wiki/Apollo_11",
+      },
+      {
+        title: "Moon phase calendar for this month",
+        snippet:
+          "Track new moon, full moon and quarter phases with our interactive monthly calendar.",
+        url: "https://almanac.com/moon-phases",
+      },
+    ],
+    relevant: [0, 3],
+    referenceAnswer:
+      "Neil Armstrong was the first person to walk on the Moon, on 20 July 1969, during the Apollo 11 mission; Buzz Aldrin was the second.",
+    rubric: [
+      "Names Neil Armstrong as the first person on the Moon.",
+      "Gives the correct date (20 July 1969) or at least the correct mission (Apollo 11).",
+      "Does not name Buzz Aldrin as the first (Aldrin was second).",
+    ],
+  },
+  {
+    id: "css-flexbox-center",
+    query: "how do I center a div with CSS flexbox",
+    results: [
+      {
+        title: "A Complete Guide to Flexbox - CSS-Tricks",
+        snippet:
+          "Use display: flex with justify-content: center and align-items: center to center content both ways.",
+        url: "https://css-tricks.com/flexbox-guide",
+      },
+      {
+        title: "Free CSS Reset stylesheet download",
+        snippet:
+          "A minimal reset to normalize browser defaults. Copy, paste, ship.",
+        url: "https://css-tools.com/reset",
+      },
+      {
+        title: "CSS Flexbox - MDN Web Docs",
+        snippet:
+          "The flex container's main and cross axes let you center items with justify-content and align-items.",
+        url: "https://developer.mozilla.org/flexbox",
+      },
+      {
+        title: "What is a div tag in HTML?",
+        snippet:
+          "The div element is a generic container for flow content with no required attributes.",
+        url: "https://html-reference.com/div",
+      },
+      {
+        title: "Flexbox cheat sheet poster",
+        snippet:
+          "Printable poster of all flexbox properties. Order now and master layout at a glance.",
+        url: "https://printables.com/flexbox-poster",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "Set the parent to display: flex, then use justify-content: center (main axis) and align-items: center (cross axis) to center the child both horizontally and vertically.",
+    rubric: [
+      "Mentions setting the container to display: flex.",
+      "Names justify-content and/or align-items (the actual properties).",
+      "Does not present a float, margin, or absolute-positioning hack as the flexbox answer.",
+    ],
+  },
+  {
+    id: "australia-capital",
+    query: "Qual é a capital da Austrália?",
+    results: [
+      {
+        title: "Canberra: capital of Australia - Visit Canberra",
+        snippet:
+          "Canberra is the capital city of Australia and the seat of the federal government, in the Australian Capital Territory.",
+        url: "https://visitcanberra.com.au/",
+      },
+      {
+        title: "Sydney: top 10 things to do",
+        snippet:
+          "From the Opera House to Bondi Beach, here is how to spend a week in Australia's biggest city.",
+        url: "https://travel.com/sydney-things-to-do",
+      },
+      {
+        title: "Austrália - Wikipédia",
+        snippet:
+          "A capital da Austrália é Camberra, e a maior cidade é Sydney.",
+        url: "https://pt.wikipedia.org/wiki/Austrália",
+      },
+      {
+        title: "Australian visa: eligibility and how to apply",
+        snippet:
+          "Check if you qualify for an Australian visitor, work or student visa and start your application.",
+        url: "https://immigration.gov/australia-visa",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "A capital da Austrália é Camberra (Canberra). Sydney é a cidade mais populosa, mas não é a capital.",
+    rubric: [
+      "Names Canberra (Camberra) as the capital.",
+      "Does not name Sydney as the capital.",
+      "If it clarifies, correctly notes Sydney is the largest city but not the capital.",
+      "Replies in Portuguese, the language of the question.",
+    ],
+  },
+  {
+    id: "git-merge-vs-rebase",
+    query: "difference between git merge and git rebase",
+    results: [
+      {
+        title: "Git merge vs rebase - when to use which",
+        snippet:
+          "git merge creates a new commit joining two histories; git rebase replays your commits on top of another branch.",
+        url: "https://git-guides.com/merge-vs-rebase",
+      },
+      {
+        title: "GitKraken: visual Git client download",
+        snippet:
+          "A cross-platform Git GUI with a visual commit graph. Free for personal use.",
+        url: "https://gitkraken.com/download",
+      },
+      {
+        title: "git-rebase - Git documentation",
+        snippet:
+          "Rebase rewrites your branch's commits to sit on top of the upstream, producing a linear history.",
+        url: "https://git-scm.com/docs/git-rebase",
+      },
+      {
+        title: "Git logo and brand assets",
+        snippet:
+          "Download the official Git logo in SVG and PNG for your site or slides.",
+        url: "https://brandassets.com/git-logo",
+      },
+      {
+        title: "Git hosting pricing plans",
+        snippet:
+          "Compare free, team and enterprise plans for private repositories and CI minutes.",
+        url: "https://codehost.dev/pricing",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "git merge combines two branches into a new merge commit, preserving both histories. git rebase replays your commits on top of another branch, rewriting them for a linear history.",
+    rubric: [
+      "Explains that merge creates/joins histories (a merge commit or preserved branch point).",
+      "Explains that rebase replays/moves commits onto another base (linear history, rewrites).",
+      "Does not swap the two definitions.",
+    ],
+  },
+  {
+    id: "wwii-end-year",
+    query: "What year did World War II end?",
+    results: [
+      {
+        title: "World War II - Wikipedia",
+        snippet:
+          "World War II was a global conflict that lasted from 1939 to 1945, ending with the surrender of Japan in September 1945.",
+        url: "https://wikipedia.org/wiki/World_War_II",
+      },
+      {
+        title: "World War II strategy board game",
+        snippet:
+          "Command the armies of 1939-1945 in this award-winning turn-based strategy game.",
+        url: "https://boardgames.com/wwii-strategy",
+      },
+      {
+        title: "The end of World War II - History.com",
+        snippet:
+          "V-E Day in May 1945 and V-J Day in September 1945 marked the end of the war in Europe and the Pacific.",
+        url: "https://history.com/wwii-end",
+      },
+      {
+        title: "Vintage WWII poster prints",
+        snippet:
+          "Restored wartime posters, ready to frame. A bold piece for any wall.",
+        url: "https://prints.com/wwii-posters",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "World War II ended in 1945 (Europe in May 1945, and globally with Japan's surrender in September 1945).",
+    rubric: ["Gives 1945 as the end year.", "Does not give a wrong year."],
+  },
+  {
+    id: "jwt-secure-rest-api",
+    query: "how to secure a REST API with JWT",
+    results: [
+      {
+        title: "JSON Web Tokens: a practical guide - Auth0",
+        snippet:
+          "Sign tokens with a strong secret, keep access tokens short-lived, and validate the signature and expiry on every request.",
+        url: "https://auth0.com/jwt-guide",
+      },
+      {
+        title: "REST API tutorial for beginners",
+        snippet:
+          "Learn to build CRUD endpoints with HTTP verbs, status codes and JSON responses.",
+        url: "https://tutorials.com/rest-101",
+      },
+      {
+        title: "JWT Security Best Practices - OWASP",
+        snippet:
+          "Validate alg, nbf and exp claims; never put secrets in the payload; rotate signing keys.",
+        url: "https://owasp.org/jwt-best-practices",
+      },
+      {
+        title: "JWT logo vector download",
+        snippet: "The official JWT wordmark as an SVG for your docs.",
+        url: "https://logos.com/jwt-svg",
+      },
+      {
+        title: "Managed JWT authentication service pricing",
+        snippet:
+          "Start free, then pay per monthly active user for hosted auth.",
+        url: "https://authvendor.io/pricing",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "Use short-lived signed access tokens, validate the signature and claims (exp, nbf, aud) on every request, keep the signing secret strong and rotated, and use refresh tokens for re-authentication.",
+    rubric: [
+      "Mention validating the token signature on the server.",
+      "Mention expiry / short-lived tokens (or exp).",
+      "Does not claim the JWT payload is encrypted or secret by default.",
+    ],
+  },
+  {
+    id: "largest-ocean",
+    query: "qual o maior oceano do mundo",
+    results: [
+      {
+        title: "Oceanos - Wikipédia",
+        snippet:
+          "O Oceano Pacífico é o maior e mais profundo oceano da Terra, cobrindo cerca de um terço da superfície.",
+        url: "https://pt.wikipedia.org/wiki/Oceano_Pacífico",
+      },
+      {
+        title: "Cruise to the South Pacific: 12 nights",
+        snippet:
+          "Sail between island paradises with daily excursions and all-inclusive dining.",
+        url: "https://cruises.com/south-pacific",
+      },
+      {
+        title: "Geografia: os cinco oceanos do planeta",
+        snippet:
+          "O Pacífico é o maior oceano, seguido do Atlântico, Índico, Ártico e Antártico.",
+        url: "https://geografia.br/os-oceanos",
+      },
+      {
+        title: "Ocean life: meet the marine animals",
+        snippet:
+          "From jellyfish to blue whales, explore the creatures that live in the sea.",
+        url: "https://nature.com/ocean-animals",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer: "O maior oceano do mundo é o Oceano Pacífico.",
+    rubric: [
+      "Names the Pacific (Pacífico) as the largest ocean.",
+      "Does not name the Atlantic as the largest.",
+      "Replies in Portuguese, the language of the question.",
+    ],
+  },
+  {
+    id: "hamlet-author",
+    query: "Who wrote the play Hamlet?",
+    results: [
+      {
+        title: "Hamlet - Wikipedia",
+        snippet:
+          "Hamlet is a tragedy written by William Shakespeare between 1599 and 1601, one of his most performed works.",
+        url: "https://wikipedia.org/wiki/Hamlet",
+      },
+      {
+        title: "Hamlet at the Royal Court: tickets",
+        snippet:
+          "Book seats for the season's production of Shakespeare's Hamlet. Premium balcony available.",
+        url: "https://theatre.com/hamlet-tickets",
+      },
+      {
+        title: "William Shakespeare: the Bard of Avon",
+        snippet:
+          "Shakespeare wrote 39 plays including Hamlet, Macbeth and Othello, defining the English language stage.",
+        url: "https://bard.org/william-shakespeare",
+      },
+      {
+        title: "What is a hamlet (settlement)?",
+        snippet:
+          "A hamlet is a small rural settlement, typically smaller than a village and without a church.",
+        url: "https://geography.com/hamlet-settlement",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer: "Hamlet was written by William Shakespeare.",
+    rubric: [
+      "Names William Shakespeare as the author.",
+      "Does not confuse the play with the meaning of 'hamlet' (a settlement).",
+    ],
+  },
+  {
+    id: "react-useeffect-infinite-loop",
+    query: "react useEffect infinite loop cause",
+    results: [
+      {
+        title: "React useEffect: avoiding the infinite render loop",
+        snippet:
+          "A new object or function in the dependency array re-triggers the effect every render. Stabilize it or drop it from the deps.",
+        url: "https://react-patterns.com/useeffect-loop",
+      },
+      {
+        title: "React logo and brand guidelines",
+        snippet: "Use the official React atom logo in your slides and docs.",
+        url: "https://reactjs.org/brand",
+      },
+      {
+        title: "Why does my useEffect run twice? - Stack Overflow",
+        snippet:
+          "Updating state that is in the dependency array (or returning a new reference each render) re-runs the effect, which updates state again.",
+        url: "https://stackoverflow.com/q/useeffect-twice",
+      },
+      {
+        title: "React Native: build mobile apps",
+        snippet:
+          "Use the latest JavaScript to build native iOS and Android apps with a single codebase.",
+        url: "https://reactnative.dev/",
+      },
+      {
+        title: "Frontend course: React pricing",
+        snippet:
+          "Lifetime access to 40 hours of React and TypeScript video lessons.",
+        url: "https://course.dev/react-pricing",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "A useEffect infinite loop is usually caused by a dependency that changes on every render (a new object/function reference) or by updating state that is itself in the dependency array, which re-runs the effect, which updates the state again. Stabilize the dependency (useMemo/useCallback) or restructure the effect.",
+    rubric: [
+      "Identifies a changing/incorrect dependency array as the cause.",
+      "Mentions state updates that re-trigger the effect (the feedback loop).",
+      "Suggests a real fix (stabilize the dep, or restructure), not just 'add a key'.",
+    ],
+  },
+  {
+    id: "water-boiling-point",
+    query: "What is the boiling point of water at sea level?",
+    results: [
+      {
+        title: "Boiling point - Wikipedia",
+        snippet:
+          "The boiling point of water is 100 °C (212 °F) at standard atmospheric pressure (sea level).",
+        url: "https://wikipedia.org/wiki/Boiling_point",
+      },
+      {
+        title: "Electric kettle: 1.7L fast boil",
+        snippet:
+          "Boil a kettle of water in three minutes with rapid heat and an auto shut-off.",
+        url: "https://appliance.com/electric-kettle",
+      },
+      {
+        title: "Water properties reference - Chemistry LibreTexts",
+        snippet:
+          "At 1 atm, water boils at 100 °C; the point drops with altitude as pressure falls.",
+        url: "https://chem.libretexts.com/water-properties",
+      },
+      {
+        title: "Industrial water boiler for process heat",
+        snippet:
+          "Steam generators rated to 15 bar for continuous industrial use.",
+        url: "https://industrial.com/water-boiler",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer: "At sea level (1 atm), water boils at 100 °C (212 °F).",
+    rubric: [
+      "Gives 100 °C or 212 °F.",
+      "Ties it to sea level / standard pressure (or notes it changes with altitude).",
+    ],
+  },
+  {
+    id: "magnus-effect",
+    query: "what causes the curve of a spinning football (soccer)",
+    results: [
+      {
+        title: "The Magnus effect explained",
+        snippet:
+          "A spinning ball drags air around it, creating a pressure difference that pushes the ball sideways, curving its path.",
+        url: "https://physics-now.com/magnus-effect",
+      },
+      {
+        title: "Football boots: 2026 lineup",
+        snippet:
+          "Lightweight studs and a textured surface for grip and control on any pitch.",
+        url: "https://sports.com/football-boots",
+      },
+      {
+        title: "Why free kicks bend - BBC Sport",
+        snippet:
+          "Striking the ball off-centre spins it; the resulting Magnus effect is what bends a free kick around the wall.",
+        url: "https://bbc.com/sport/free-kicks",
+      },
+      {
+        title: "Football (soccer) rules overview",
+        snippet:
+          "The basic laws of the game: offside, fouls, corners and how a match is structured.",
+        url: "https://rules.com/soccer-laws",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "The curve is caused by the Magnus effect: a spinning ball creates a pressure difference in the surrounding air that pushes it sideways, bending its trajectory.",
+    rubric: [
+      "Names the Magnus effect or the underlying pressure difference from spin.",
+      "Does not attribute the curve to air 'pushing' it in a single direction with no spin mechanism.",
+    ],
+  },
+  {
+    id: "photosynthesis-equation",
+    query: "what is the chemical equation for photosynthesis",
+    results: [
+      {
+        title: "Photosynthesis - an overview",
+        snippet:
+          "6 CO2 + 6 H2O + light -> C6H12O6 + 6 O2: plants convert carbon dioxide and water into glucose and oxygen.",
+        url: "https://biology.com/photosynthesis",
+      },
+      {
+        title: "Garden sunlight: how much does your plant need?",
+        snippet:
+          "Most houseplants do well with a few hours of indirect light a day.",
+        url: "https://gardening.com/plant-light",
+      },
+      {
+        title: "The equation of photosynthesis - Khan Academy",
+        snippet:
+          "Carbon dioxide plus water, using light energy, yields glucose and oxygen.",
+        url: "https://khanacademy.org/photosynthesis-equation",
+      },
+      {
+        title: "Succulent care 101",
+        snippet:
+          "Water less often, use a gritty mix, and give bright indirect light.",
+        url: "https://plants101.com/succulents",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "6 CO2 + 6 H2O + light energy -> C6H12O6 (glucose) + 6 O2.",
+    rubric: [
+      "Includes CO2 and H2O as reactants and glucose (C6H12O6) and O2 as products.",
+      "Mentions light (energy) as a requirement.",
+    ],
+  },
+  {
+    id: "speed-of-light",
+    query: "What is the speed of light in a vacuum?",
+    results: [
+      {
+        title: "Speed of light - Wikipedia",
+        snippet:
+          "The speed of light in vacuum, usually denoted c, is exactly 299,792,458 metres per second.",
+        url: "https://wikipedia.org/wiki/Speed_of_light",
+      },
+      {
+        title: "LED light bulbs: energy-saving 6-pack",
+        snippet:
+          "Bright, long-lasting LED bulbs for your home. Save on your electricity bill.",
+        url: "https://home.com/led-bulbs",
+      },
+      {
+        title: "The constant c in physics - HyperPhysics",
+        snippet:
+          "c = 299792458 m/s is the invariant speed that sets the maximum speed of causality.",
+        url: "https://hyperphysics.com/speed-of-light",
+      },
+      {
+        title: "Fiber internet: gigabit 'speed of light' plans",
+        snippet:
+          "Blazing-fast fiber up to 1 Gbps. Marketing calls it the speed of light.",
+        url: "https://isp.com/fiber-gigabit",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "The speed of light in a vacuum is exactly 299,792,458 metres per second (about 3.00 x 10^8 m/s).",
+    rubric: [
+      "Gives 299,792,458 m/s or about 3.00 x 10^8 m/s.",
+      "Does not give the speed of light in air or glass as the vacuum value.",
+    ],
+  },
+  {
+    id: "mona-lisa-painter",
+    query: "Who painted the Mona Lisa?",
+    results: [
+      {
+        title: "Mona Lisa - The Louvre",
+        snippet:
+          "La Joconde, by Leonardo da Vinci, painted in the early 16th century, is the museum's most visited work.",
+        url: "https://louvre.fr/mona-lisa",
+      },
+      {
+        title: "Mona Lisa Halloween masks and costumes",
+        snippet:
+          "Be the enigma this Halloween with our best-selling Mona Lisa mask.",
+        url: "https://costumes.com/mona-lisa-mask",
+      },
+      {
+        title: "Mona Lisa - Wikipedia",
+        snippet:
+          "The Mona Lisa is a portrait painting by the Italian Renaissance artist Leonardo da Vinci.",
+        url: "https://wikipedia.org/wiki/Mona_Lisa",
+      },
+      {
+        title: "Mona Lisa (singer): discography",
+        snippet:
+          "A French singer-songwriter's albums, singles and touring dates.",
+        url: "https://music.com/mona-lisa-singer",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer: "The Mona Lisa was painted by Leonardo da Vinci.",
+    rubric: [
+      "Names Leonardo da Vinci as the painter.",
+      "Does not confuse the painting with a person or artist of the same name.",
+    ],
+  },
+  {
+    id: "baking-soda-vs-powder",
+    query: "difference between baking soda and baking powder",
+    results: [
+      {
+        title: "Baking soda vs baking powder, explained",
+        snippet:
+          "Baking soda is pure sodium bicarbonate and needs an acid to react; baking powder already has an acid added.",
+        url: "https://cooking-science.com/soda-vs-powder",
+      },
+      {
+        title: "Arm & Hammer baking soda, 4 lb",
+        snippet:
+          "Multipurpose baking soda for baking, cleaning and deodorizing.",
+        url: "https://grocery.com/baking-soda-4lb",
+      },
+      {
+        title: "What is the difference? - wikiHow",
+        snippet:
+          "Baking powder contains baking soda plus an acid and starch, so it leavens on its own.",
+        url: "https://wikihow.com/baking-soda-vs-powder",
+      },
+      {
+        title: "Classic lemon drizzle cake recipe",
+        snippet: "A moist lemon cake with a sweet drizzle topping. Serves 10.",
+        url: "https://recipes.com/lemon-drizzle",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "Baking soda is sodium bicarbonate alone and needs an acid to leaven; baking powder is baking soda plus a built-in acid (and usually starch), so it leavens by itself.",
+    rubric: [
+      "Notes baking soda needs an acid to react.",
+      "Notes baking powder already contains an acid (works on its own).",
+    ],
+  },
+  {
+    id: "tallest-mountain",
+    query: "What is the tallest mountain in the world?",
+    results: [
+      {
+        title: "Mount Everest - Wikipedia",
+        snippet:
+          "Everest, at 8,849 m, is Earth's highest mountain above sea level, on the Nepal-Tibet border.",
+        url: "https://wikipedia.org/wiki/Mount_Everest",
+      },
+      {
+        title: "Everest base camp trekking tours",
+        snippet:
+          "14-day guided trek to Everest base camp. Flights and guides included.",
+        url: "https://treks.com/everest-base-camp",
+      },
+      {
+        title: "Highest peaks on Earth - Britannica",
+        snippet:
+          "Mount Everest is the highest mountain above sea level at 8,848.86 m.",
+        url: "https://britannica.com/highest-peaks",
+      },
+      {
+        title: "Mountain bike sale: full-suspension",
+        snippet: "Trail-ready full-suspension mountain bikes, from $699.",
+        url: "https://cycles.com/mountain-bike",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "Mount Everest is the tallest mountain in the world (highest above sea level), at about 8,849 m.",
+    rubric: [
+      "Names Mount Everest as the tallest mountain.",
+      "Gives an elevation near 8,849 m (or 8,848 m), or at least identifies Everest correctly.",
+    ],
+  },
+  {
+    id: "change-car-tire",
+    query: "how to change a flat car tire",
+    results: [
+      {
+        title: "How to Change a Flat Tire - AAA",
+        snippet:
+          "Park safely, put on the handbrake, loosen the lug nuts, jack up the car, and swap in the spare.",
+        url: "https://aaa.com/change-a-flat",
+      },
+      {
+        title: "All-season tires: price comparison",
+        snippet: "Compare prices for popular all-season tires in your size.",
+        url: "https://tires.com/all-season-prices",
+      },
+      {
+        title: "Spare tire change step by step - YouTube",
+        snippet:
+          "A 3-minute video walking through jacking, swapping and tightening the lug nuts.",
+        url: "https://youtube.com/watch/change-flat",
+      },
+      {
+        title: "Alloy wheel accessories and caps",
+        snippet:
+          "Decorative wheel covers and valve caps to finish off your rims.",
+        url: "https://auto.com/wheel-caps",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "Park on level ground, set the handbrake, loosen the lug nuts, jack up the car, remove the flat, fit the spare, tighten the nuts, and lower the car.",
+    rubric: [
+      "Mentions jacking the car up.",
+      "Mentions loosening/removing the lug nuts and fitting the spare.",
+      "Mentions a safety step (handbrake / parking on level ground).",
+    ],
+  },
+  {
+    id: "first-iphone-year",
+    query: "What year did the first iPhone release?",
+    results: [
+      {
+        title: "iPhone - Wikipedia",
+        snippet:
+          "The original iPhone was announced in January 2007 and released in the United States on June 29, 2007.",
+        url: "https://wikipedia.org/wiki/IPhone",
+      },
+      {
+        title: "iPhone 16 Pro review: is it worth it?",
+        snippet:
+          "Our full review of the latest flagship, two years after its launch.",
+        url: "https://techreview.com/iphone-16-pro",
+      },
+      {
+        title: "Apple unveils iPhone - Apple Newsroom (2007)",
+        snippet:
+          "Today Apple reinvented the phone. The iPhone combines three revolutionary devices.",
+        url: "https://apple.com/newsroom/2007-iphone",
+      },
+      {
+        title: "iPhone cases and screen protectors",
+        snippet:
+          "Shop rugged cases and tempered-glass protectors for every iPhone model.",
+        url: "https://cases.com/iphone",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "The first iPhone was released in 2007 (announced January 2007, released June 29, 2007).",
+    rubric: [
+      "Gives 2007 as the release year.",
+      "Does not give a different year.",
+    ],
+  },
+  {
+    id: "reset-wifi-router",
+    query: "how do I reset my Wi-Fi router to factory settings",
+    results: [
+      {
+        title: "Factory reset your router - ISP support",
+        snippet:
+          "Press and hold the recessed reset button for about 10 seconds until the lights blink.",
+        url: "https://isp.com/factory-reset-router",
+      },
+      {
+        title: "Mesh Wi-Fi system review: 3-pack",
+        snippet:
+          "Whole-home coverage from three nodes. Our verdict after a month.",
+        url: "https://techreview.com/mesh-wifi",
+      },
+      {
+        title: "How to factory reset any router - CNET",
+        snippet:
+          "Find the reset pinhole, hold it with a paperclip until the status light flashes, and reconfigure.",
+        url: "https://cnet.com/router-factory-reset",
+      },
+      {
+        title: "Cable modem and router bundles",
+        snippet: "Save with a combo modem-router for your home internet.",
+        url: "https://isp.com/modem-router-bundle",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "Press and hold the router's recessed reset button (with a paperclip) for about 10 seconds until the lights blink, which restores factory defaults.",
+    rubric: [
+      "Mentions the physical reset button (pinhole / recessed).",
+      "Mentions holding it for several (about 10) seconds.",
+      "Notes that it restores factory defaults / requires reconfiguration.",
+    ],
+  },
+  {
+    id: "gold-chemical-symbol",
+    query: "What is the chemical symbol for gold?",
+    results: [
+      {
+        title: "Gold - Wikipedia",
+        snippet:
+          "Gold is a chemical element with symbol Au and atomic number 79.",
+        url: "https://wikipedia.org/wiki/Gold",
+      },
+      {
+        title: "14k gold jewelry: rings and chains",
+        snippet: "Shop fine 14k gold jewelry. Free shipping on all orders.",
+        url: "https://jewelry.com/gold-rings",
+      },
+      {
+        title: "The Periodic Table: Au (gold)",
+        snippet:
+          "Au, atomic number 79, a transition metal widely used in electronics.",
+        url: "https://periodic-table.com/au",
+      },
+      {
+        title: "Gold Rewards credit card benefits",
+        snippet: "Earn points on every purchase with the Gold Rewards card.",
+        url: "https://bank.com/gold-card",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "The chemical symbol for gold is Au (from the Latin 'aurum').",
+    rubric: [
+      "Gives Au as the chemical symbol for gold.",
+      "Does not give the symbol for a different element.",
+    ],
+  },
+  // The three entries below list an IRRELEVANT result first. The app pins the
+  // original top result for text search (rankSearchResults' preserveTopResults),
+  // so these are the cases where that pin costs the ranking something. Without
+  // them every entry's pinned result is relevant and the eval can't tell a
+  // good pin from a bad one.
+  {
+    id: "remove-stain-white-shirt",
+    query: "how to remove a stain from a white shirt",
+    results: [
+      {
+        title: "Stains: A History of Dirt and Cleanliness",
+        snippet:
+          "A cultural history of why we care about clean clothes. Hardcover, 320 pages.",
+        url: "https://books.com/stains-history",
+      },
+      {
+        title: "How to Remove Common Stains from Clothes - wikiHow",
+        snippet:
+          "Treat ink, wine, grass and grease stains with the right solvent before washing.",
+        url: "https://wikihow.com/remove-clothing-stains",
+      },
+      {
+        title: "Dry cleaning services near you",
+        snippet: "Book a same-week dry clean and press for your garments.",
+        url: "https://cleaners.com/near-you",
+      },
+      {
+        title: "Removing ink, wine, and oil from white fabric",
+        snippet:
+          "Step-by-step for white shirts: dab, don't rub, and pre-treat before the wash.",
+        url: "https://fabriccare.com/white-shirt-stains",
+      },
+    ],
+    relevant: [1, 3],
+    referenceAnswer:
+      "Dab (don't rub) the stain, pre-treat it with a suitable solvent or stain remover, then wash; for white cotton you can also use oxygen bleach.",
+    rubric: [
+      "Recommends treating/pre-treating the stain before washing.",
+      "Gives a concrete method (dabbing, a solvent/remover, or oxygen bleach for whites).",
+    ],
+  },
+  {
+    id: "capital-of-canada",
+    query: "what is the capital of canada",
+    results: [
+      {
+        title: "Canada: the ultimate travel guide",
+        snippet: "Top 20 places to visit, from the Rockies to the East Coast.",
+        url: "https://travel.com/canada-guide",
+      },
+      {
+        title: "Capital of Canada - Wikipedia",
+        snippet: "Ottawa is the capital city of Canada.",
+        url: "https://wikipedia.org/wiki/Capital_of_Canada",
+      },
+      {
+        title: "Apply for a Canadian passport",
+        snippet: "Start or renew your passport application online.",
+        url: "https://canada.ca/passport",
+      },
+      {
+        title: "Ottawa, the capital of Canada",
+        snippet: "Ottawa, in Ontario, has been Canada's capital since 1859.",
+        url: "https://ottawa.ca/capital",
+      },
+    ],
+    relevant: [1, 3],
+    referenceAnswer: "The capital of Canada is Ottawa.",
+    rubric: [
+      "Names Ottawa as the capital of Canada.",
+      "Does not name a non-capital Canadian city (e.g. Toronto or Vancouver).",
+    ],
+  },
+  {
+    id: "budget-laptop-students",
+    query: "best budget laptop for students 2024",
+    results: [
+      {
+        title: "Laptop repair and parts store",
+        snippet:
+          "Fix your broken laptop. Screens, keyboards and batteries in stock.",
+        url: "https://repairs.com/laptop-parts",
+      },
+      {
+        title: "Best budget laptops for students in 2024",
+        snippet:
+          "Our top affordable picks for note-taking and streaming, under $600.",
+        url: "https://techreview.com/budget-laptops-students",
+      },
+      {
+        title: "Laptop insurance plans compared",
+        snippet:
+          "Protect your device against accidental damage. From $9 a month.",
+        url: "https://insurance.com/laptop",
+      },
+      {
+        title: "Top 5 affordable laptops for college",
+        snippet:
+          "Long battery life and a comfortable keyboard matter most to students.",
+        url: "https://collegegear.com/affordable-laptops",
+      },
+    ],
+    relevant: [1, 3],
+    referenceAnswer:
+      "For students on a budget in 2024, pick a sub-$600 laptop with at least 8 GB of RAM, an SSD, and long battery life, as in the budget-student roundups.",
+    rubric: [
+      "Recommends a budget/affordable laptop or gives budget-laptop criteria (price, RAM, battery).",
+      "Does not answer with a repair service or an insurance plan.",
+    ],
+  },
+  // The three entries below are about fictional organizations and products. The
+  // specific facts (a founding year, a battery figure, a payload figure) exist
+  // ONLY in the snippets, so the model cannot answer them from parametric
+  // knowledge: this forces the search-results path, which is exactly what the
+  // answer eval is meant to guard. If getFormattedSearchResults broke and
+  // returned nothing, these would fail.
+  {
+    id: "halcyon-robotics-founding",
+    query: "When was the Halcyon Robotics Institute founded?",
+    results: [
+      {
+        title: "Halcyon Robotics Institute - About Us",
+        snippet:
+          "Founded in 1987, the Halcyon Robotics Institute develops autonomous systems and robotics research.",
+        url: "https://halcyonrobotics.org/about",
+      },
+      {
+        title: "Robotics career fair 2024",
+        snippet:
+          "Meet employers in robotics and AI. Register for the fall career fair.",
+        url: "https://careers.com/robotics-fair",
+      },
+      {
+        title: "Halcyon Robotics Institute - Wikipedia",
+        snippet:
+          "The Halcyon Robotics Institute (HRI) is a research organization founded in 1987.",
+        url: "https://wikipedia.org/wiki/Halcyon_Robotics_Institute",
+      },
+      {
+        title: "Robot building kits for kids",
+        snippet: "Snap-together robot kits, ages 8 and up. Ships free.",
+        url: "https://toys.com/robot-kits",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer: "The Halcyon Robotics Institute was founded in 1987.",
+    snippetOnly: true,
+    rubric: [
+      "States 1987 as the founding year.",
+      "Does not give a different year or say it is unknown.",
+    ],
+  },
+  {
+    id: "nimbus-t3-battery",
+    query: "how many hours of battery life does the Nimbus T3 laptop have",
+    results: [
+      {
+        title: "Nimbus T3 review: all-day and then some",
+        snippet:
+          "The Nimbus T3 gets 22 hours of battery life on a single charge in our tests.",
+        url: "https://techreview.com/nimbus-t3",
+      },
+      {
+        title: "Laptop stands and cooling pads",
+        snippet: "Ergonomic aluminum laptop stands, from $29.",
+        url: "https://gadgets.com/laptop-stands",
+      },
+      {
+        title: "Nimbus T3 specifications",
+        snippet:
+          "Battery: up to 22 hours of video playback on a single charge.",
+        url: "https://nimbuspc.com/t3-specs",
+      },
+      {
+        title: "USB-C chargers and adapters",
+        snippet: "65W and 100W GaN chargers for laptops and phones.",
+        url: "https://gadgets.com/usb-c-chargers",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "The Nimbus T3 laptop has up to 22 hours of battery life on a single charge.",
+    snippetOnly: true,
+    rubric: [
+      "States 22 hours of battery life.",
+      "Does not give a different battery figure.",
+    ],
+  },
+  {
+    id: "gale-7-drone-payload",
+    query: "what is the maximum payload of the Gale-7 survey drone",
+    results: [
+      {
+        title: "Gale-7 specifications",
+        snippet: "Maximum payload 6.2 kg; flight time up to 40 minutes.",
+        url: "https://galeaero.com/gale-7-specs",
+      },
+      {
+        title: "Drone insurance and registration",
+        snippet:
+          "Register your drone and get liability coverage from $15 a month.",
+        url: "https://drones.com/insurance",
+      },
+      {
+        title: "Gale-7 review: built for surveying",
+        snippet: "The Gale-7 carries up to 6.2 kg of survey equipment.",
+        url: "https://geospatial.com/gale-7-review",
+      },
+      {
+        title: "Camera gimbals for drones",
+        snippet: "3-axis gimbals for 4K cameras, from $199.",
+        url: "https://dronegear.com/gimbals",
+      },
+    ],
+    relevant: [0, 2],
+    referenceAnswer:
+      "The Gale-7 survey drone carries a maximum payload of 6.2 kg.",
+    snippetOnly: true,
+    rubric: [
+      "States 6.2 kg as the maximum payload.",
+      "Does not give a different payload figure.",
+    ],
+  },
+];

--- a/eval/goldenSet.ts
+++ b/eval/goldenSet.ts
@@ -11,6 +11,14 @@
  * To grow the set, add an entry with the same shape. Keep the relevant labels
  * unambiguous (a result is clearly about the query or clearly not) so the
  * metric does not depend on a borderline call.
+ *
+ * Retrieval constraint: keep at least one relevant result OUTSIDE the top-3 of
+ * the input order (the `results` array). If an entry keeps both relevant
+ * results in the input top-3, a no-op reranker (which preserves input order)
+ * scores it as well as a working one, and the retrieval eval's floors stop
+ * being falsifiable. The "stays falsifiable" test in goldenSet.test.ts pins
+ * this; re-tune the floors in retrieval.integration.test.ts if the set changes
+ * substantially.
  */
 
 interface GoldenResult {

--- a/eval/metrics.test.ts
+++ b/eval/metrics.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { dcgAtK, ndcgAtK, recallAtK } from "./metrics";
+
+describe("dcgAtK", () => {
+  it("discounts relevance by position", () => {
+    // A single relevant result at rank 1 scores higher than at rank 2.
+    expect(dcgAtK([1, 0], 2)).toBe(1 / Math.log2(2));
+    expect(dcgAtK([0, 1], 2)).toBeCloseTo(1 / Math.log2(3));
+  });
+
+  it("ignores gains beyond k", () => {
+    expect(dcgAtK([1, 1, 1], 1)).toBe(dcgAtK([1], 1));
+  });
+});
+
+describe("ndcgAtK", () => {
+  it("is 1 when the relevant urls occupy the top ranks", () => {
+    const relevant = ["a", "b"];
+    expect(ndcgAtK(["a", "b", "c"], relevant, 3)).toBeCloseTo(1);
+    expect(ndcgAtK(["b", "a", "c"], relevant, 3)).toBeCloseTo(1);
+  });
+
+  it("decreases as relevant urls sink", () => {
+    const relevant = ["a", "b"];
+    const perfect = ndcgAtK(["a", "b", "c", "d"], relevant, 4);
+    const half = ndcgAtK(["c", "a", "b", "d"], relevant, 4);
+    const worst = ndcgAtK(["d", "c", "a", "b"], relevant, 4);
+    expect(perfect).toBeCloseTo(1);
+    expect(perfect).toBeGreaterThan(half);
+    expect(half).toBeGreaterThan(worst);
+    expect(worst).toBeGreaterThan(0);
+  });
+
+  it("is 0 when no relevant url is ranked at all", () => {
+    expect(ndcgAtK(["c", "d"], ["a", "b"], 2)).toBe(0);
+  });
+
+  it("scores against an ideal top-k when there are more relevant urls than k", () => {
+    // Three relevant urls, k=2: ideal top-2 is two relevant urls.
+    const relevant = ["a", "b", "c"];
+    const topTwoRelevant = ndcgAtK(["a", "b", "c"], relevant, 2);
+    const oneRelevantInTopTwo = ndcgAtK(["c", "d", "a"], relevant, 2);
+    expect(topTwoRelevant).toBeCloseTo(1);
+    expect(topTwoRelevant).toBeGreaterThan(oneRelevantInTopTwo);
+  });
+
+  it("is 0 when there are no relevant urls to recall", () => {
+    expect(ndcgAtK(["a", "b"], [], 2)).toBe(0);
+  });
+
+  it("returns 0 for a non-positive k", () => {
+    expect(ndcgAtK(["a"], ["a"], 0)).toBe(0);
+  });
+
+  it("never exceeds 1 when a url is listed twice", () => {
+    // A duplicate relevant url must not earn gain twice, which would push
+    // nDCG above 1 and mask a regression.
+    const ndcg = ndcgAtK(["u", "u", "x"], ["u"], 3);
+    expect(ndcg).toBeLessThanOrEqual(1);
+    expect(ndcg).toBeGreaterThan(0);
+  });
+});
+
+describe("recallAtK", () => {
+  it("is the fraction of relevant urls in the top-k", () => {
+    const relevant = ["a", "b", "c"];
+    expect(recallAtK(["a", "b", "d"], relevant, 3)).toBeCloseTo(2 / 3);
+    expect(recallAtK(["a", "b", "c", "d"], relevant, 4)).toBe(1);
+  });
+
+  it("counts a relevant url only once even if it repeats", () => {
+    expect(recallAtK(["a", "a", "a"], ["a", "b"], 3)).toBeCloseTo(0.5);
+  });
+
+  it("is 0 when there are no relevant urls", () => {
+    expect(recallAtK(["a"], [], 1)).toBe(0);
+  });
+});

--- a/eval/metrics.test.ts
+++ b/eval/metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dcgAtK, ndcgAtK, recallAtK } from "./metrics";
+import { dcgAtK, ndcgAtK, recallAtK } from "./metrics.ts";
 
 describe("dcgAtK", () => {
   it("discounts relevance by position", () => {

--- a/eval/metrics.ts
+++ b/eval/metrics.ts
@@ -1,0 +1,82 @@
+/**
+ * Retrieval quality metrics for the offline eval. Pure functions, no I/O, so
+ * they are unit-testable without loading the reranker model.
+ *
+ * Relevance is binary: a url is either in the ground-truth relevant set or it
+ * is not. This matches how the golden set is labeled and keeps the metrics
+ * stable enough to act as a regression signal.
+ */
+
+/**
+ * Discounted Cumulative Gain at rank k for a ranked, 0/1 relevance list.
+ *
+ * `gains` is in ranked order (index 0 is rank 1). Positions are discounted
+ * with log2(rank + 1), the standard IR discounting.
+ */
+export function dcgAtK(gains: number[], k: number): number {
+  return gains
+    .slice(0, k)
+    .reduce((sum, gain, i) => sum + gain / Math.log2(i + 2), 0);
+}
+
+/**
+ * Normalized DCG at rank k for binary relevance.
+ *
+ * `rankedUrls` is the ranked output under test; `relevantUrls` is the
+ * ground-truth set of relevant urls. Returns a value in [0, 1]: 1 when every
+ * relevant url that fits in the top-k is placed there, 0 when none are.
+ *
+ * The ideal ranking places as many relevant urls as possible at the very top
+ * (capped at k), so a result set with more relevant urls than k is scored
+ * against an ideal top-k that is entirely relevant.
+ */
+export function ndcgAtK(
+  rankedUrls: string[],
+  relevantUrls: Iterable<string>,
+  k: number,
+): number {
+  const relevant = new Set(relevantUrls);
+  if (relevant.size === 0 || k <= 0) return 0;
+
+  // Count each url at most once: a duplicate listing of the same url must not
+  // earn gain twice, or nDCG could exceed 1. The first occurrence keeps the
+  // url's rank; later duplicates are ignored.
+  const seen = new Set<string>();
+  const gains = rankedUrls.map((url) => {
+    if (seen.has(url)) return 0;
+    seen.add(url);
+    return relevant.has(url) ? 1 : 0;
+  });
+  const actualDcg = dcgAtK(gains, k);
+
+  const idealRelevant = Math.min(k, relevant.size);
+  const idealDcg = dcgAtK(
+    Array.from({ length: idealRelevant }, () => 1),
+    k,
+  );
+
+  return idealDcg === 0 ? 0 : actualDcg / idealDcg;
+}
+
+/**
+ * Recall at rank k for binary relevance: the fraction of the relevant urls
+ * that appear in the top-k of `rankedUrls`.
+ *
+ * This is the metric that catches the reranker's score filter dropping a
+ * relevant result: a relevant url removed from the ranked output can never be
+ * recalled.
+ */
+export function recallAtK(
+  rankedUrls: string[],
+  relevantUrls: Iterable<string>,
+  k: number,
+): number {
+  const relevant = new Set(relevantUrls);
+  if (relevant.size === 0 || k <= 0) return 0;
+
+  const foundInTopK = new Set(
+    rankedUrls.slice(0, k).filter((url) => relevant.has(url)),
+  );
+
+  return foundInTopK.size / relevant.size;
+}

--- a/eval/promptConstruction.test.ts
+++ b/eval/promptConstruction.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { goldenQueries } from "./goldenSet.ts";
+
+/**
+ * Prompt-construction tests for the answer eval. These run in the default
+ * (jsdom) suite because they make no network calls and load no model: they
+ * only build the prompt the app would send, using the real
+ * getFormattedSearchResults + getDefaultChatMessages + systemPrompt (with the
+ * pubSub state mocked to a golden query, the same way the client unit tests
+ * do). The LLM-judged tests live in answer.integration.test.ts.
+ *
+ * buildMessagesForGolden is shared with that file (eval/goldenPrompt.ts) so
+ * the prompt is built identically in both.
+ */
+
+const state = vi.hoisted(() => ({
+  query: "",
+  searchResults: [] as [string, string, string][],
+  pageContents: {} as Record<string, string>,
+  settings: {
+    systemPrompt: "",
+    inferenceType: "openai",
+    openAiContextLength: 4096,
+  } as {
+    systemPrompt: string;
+    inferenceType?: string;
+    openAiContextLength?: number;
+  },
+}));
+
+vi.mock("../client/modules/pubSub", () => ({
+  getSettings: () => state.settings,
+  getLlmTextSearchResults: () => state.searchResults,
+  getPageContents: () => state.pageContents,
+  getQuery: () => state.query,
+  getSearchPromise: vi.fn(),
+  updateTextGenerationState: vi.fn(),
+}));
+
+import { buildMessagesForGolden } from "./goldenPrompt.ts";
+
+describe("answer eval: prompt construction", () => {
+  it("builds a non-empty prompt that embeds the query and the results", () => {
+    const golden = goldenQueries[0];
+    const messages = buildMessagesForGolden(state, golden.id);
+
+    // The app's shape: system prompt as a user turn, an "Ok!" acknowledgement,
+    // then the question.
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe("user");
+    expect(messages[1].content).toBe("Ok!");
+    expect(messages[2].content).toBe(golden.query);
+
+    const systemTurn = messages[0].content;
+    // The {{searchResults}} and {{currentDate}} placeholders are filled.
+    expect(systemTurn).not.toContain("{{searchResults}}");
+    expect(systemTurn).not.toContain("{{currentDate}}");
+    // Every candidate result is present in the prompt.
+    for (const { url } of golden.results) {
+      expect(systemTurn).toContain(url);
+    }
+  });
+
+  it("embeds a distinct prompt for every golden query", () => {
+    const first = buildMessagesForGolden(state, goldenQueries[0].id);
+    const second = buildMessagesForGolden(state, goldenQueries[1].id);
+    expect(first[2].content).not.toBe(second[2].content);
+    expect(first[0].content).not.toBe(second[0].content);
+  });
+});

--- a/eval/promptConstruction.test.ts
+++ b/eval/promptConstruction.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { defaultSettings } from "../client/modules/settings.ts";
+import { DEFAULT_SYSTEM_PROMPT } from "../shared/defaultSystemPrompt.ts";
 import { goldenQueries } from "./goldenSet.ts";
 
 /**
@@ -40,6 +42,12 @@ vi.mock("../client/modules/pubSub", () => ({
 import { buildMessagesForGolden } from "./goldenPrompt.ts";
 
 describe("answer eval: prompt construction", () => {
+  it("keeps the client's default system prompt in sync with the shared source", () => {
+    // The eval grades against DEFAULT_SYSTEM_PROMPT; if the client's default
+    // drifted from it, the eval would grade a prompt the app never sends.
+    expect(defaultSettings.systemPrompt).toBe(DEFAULT_SYSTEM_PROMPT);
+  });
+
   it("builds a non-empty prompt that embeds the query and the results", () => {
     const golden = goldenQueries[0];
     const messages = buildMessagesForGolden(state, golden.id);

--- a/eval/retrieval.integration.test.ts
+++ b/eval/retrieval.integration.test.ts
@@ -75,6 +75,14 @@ describe("retrieval eval (real reranker)", () => {
       const ranked = await rankSearchResults(golden.query, candidates, true);
       expect(ranked.length, `${golden.id}: empty ranking`).toBeGreaterThan(0);
 
+      // The pin is the point of the [1,3] entries: the first candidate must
+      // stay first regardless of the model's scores. A floor-only assert can't
+      // catch a broken pin (it would raise the mean), so pin it directly.
+      expect(
+        ranked[0][2],
+        `${golden.id}: preserveTopResults did not pin the first candidate`,
+      ).toBe(golden.results[0].url);
+
       const rankedUrls = ranked.map(([, , url]) => url);
       const relevantUrls = golden.relevant.map((i) => golden.results[i].url);
 

--- a/eval/retrieval.integration.test.ts
+++ b/eval/retrieval.integration.test.ts
@@ -32,16 +32,9 @@ import { goldenQueries } from "./goldenSet.ts";
 import { ndcgAtK, recallAtK } from "./metrics.ts";
 import { K, MIN_MEAN_NDCG, MIN_MEAN_RECALL } from "./thresholds.ts";
 
-// The floors are set in the middle of the band between a working reranker
-// (0.950 / 0.981) and a no-op reranker (0.587 / 0.500) on this golden set, so
-// a dead or no-op reranker fails and a working one passes with margin. The
-// headroom (the working reranker clears the floors by ~0.2) is intentional:
-// the reranker is a quantized ONNX graph whose scores drift and can reorder
-// results across execution providers (see server/rerankerService.ts), so a
-// floor pinned to the measured baseline would be flaky on a different CPU.
-// Re-tune if the golden set changes substantially. The no-op ceilings that
-// keep these floors falsifiable live in thresholds.ts and are pinned by
-// goldenSet.test.ts.
+// The floors (MIN_MEAN_NDCG / MIN_MEAN_RECALL) and the no-op ceilings that
+// keep them falsifiable live in thresholds.ts; see that file for the band
+// they're set in and why the headroom is intentional.
 
 interface PerQueryScore {
   id: string;

--- a/eval/retrieval.integration.test.ts
+++ b/eval/retrieval.integration.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+/**
+ * Offline retrieval eval: runs the real reranker through rankSearchResults on
+ * the fixed golden set and scores the ranking with nDCG and recall against the
+ * human-labeled relevant results.
+ *
+ * It calls rankSearchResults with preserveTopResults=true, exactly the way the
+ * app does for text search (searchEndpointServerHook.ts), so the pinned-first
+ * result branch is exercised. The golden set therefore includes entries whose
+ * first candidate is irrelevant: that is the case where the pin costs the
+ * ranking, and without it the eval could not tell a good pin from a bad one.
+ *
+ * This is the regression signal for changes to the reranker or to
+ * rankSearchResults (the score filter, the top-result preservation, the sort).
+ * Golden-set structure is validated in goldenSet.test.ts (default suite).
+ *
+ *   npx vitest run --config vitest.eval.config.ts retrieval
+ *
+ * Loads the real ONNX model, so it is excluded from the default suite and from
+ * CI (which has no model on disk); it is a local signal, matching the server
+ * integration-test house style.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { rankSearchResults } from "../server/rankSearchResults.ts";
+import {
+  startRerankerService,
+  stopRerankerService,
+} from "../server/rerankerService.ts";
+import { goldenQueries } from "./goldenSet.ts";
+import { ndcgAtK, recallAtK } from "./metrics.ts";
+
+const K = 3;
+
+/**
+ * Regression thresholds, set with explicit headroom rather than pinned to the
+ * measured baseline. Baseline (this machine, 26 queries): mean nDCG@3 0.947,
+ * mean recall@3 0.981. The floors below tolerate roughly three or four queries
+ * losing a relevant result from the top-3 (recall) before failing. That
+ * headroom is intentional: the reranker is a quantized ONNX graph whose scores
+ * drift and can reorder results across execution providers (see
+ * server/rerankerService.ts), so a floor measured to two decimals would be
+ * flaky on a different CPU. Re-tune if the golden set changes substantially.
+ */
+const MIN_MEAN_NDCG = 0.88;
+const MIN_MEAN_RECALL = 0.9;
+
+interface PerQueryScore {
+  id: string;
+  ndcg: number;
+  recall: number;
+}
+
+describe("retrieval eval (real reranker)", () => {
+  const scores: PerQueryScore[] = [];
+
+  beforeAll(async () => {
+    await startRerankerService();
+  }, 600_000);
+
+  afterAll(async () => {
+    await stopRerankerService();
+  });
+
+  for (const golden of goldenQueries) {
+    it(`scores ${golden.id}`, async () => {
+      const candidates: [title: string, content: string, url: string][] =
+        golden.results.map(({ title, snippet, url }) => [title, snippet, url]);
+
+      // preserveTopResults=true matches the app's text-search call.
+      const ranked = await rankSearchResults(golden.query, candidates, true);
+      expect(ranked.length, `${golden.id}: empty ranking`).toBeGreaterThan(0);
+
+      const rankedUrls = ranked.map(([, , url]) => url);
+      const relevantUrls = golden.relevant.map((i) => golden.results[i].url);
+
+      const ndcg = ndcgAtK(rankedUrls, relevantUrls, K);
+      const recall = recallAtK(rankedUrls, relevantUrls, K);
+      // Bounds that also catch a metric regression (e.g. nDCG > 1 from a
+      // duplicate url).
+      expect(ndcg, `${golden.id}: nDCG out of range`).toBeGreaterThanOrEqual(0);
+      expect(ndcg, `${golden.id}: nDCG out of range`).toBeLessThanOrEqual(1);
+      expect(
+        recall,
+        `${golden.id}: recall out of range`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(recall, `${golden.id}: recall out of range`).toBeLessThanOrEqual(
+        1,
+      );
+
+      scores.push({ id: golden.id, ndcg, recall });
+    }, 120_000);
+  }
+
+  it("meets the aggregate regression thresholds", () => {
+    expect(scores).toHaveLength(goldenQueries.length);
+
+    const meanNdcg = scores.reduce((sum, s) => sum + s.ndcg, 0) / scores.length;
+    const meanRecall =
+      scores.reduce((sum, s) => sum + s.recall, 0) / scores.length;
+
+    console.table(
+      scores.map((s) => ({
+        id: s.id,
+        [`nDCG@${K}`]: s.ndcg.toFixed(3),
+        [`recall@${K}`]: s.recall.toFixed(3),
+      })),
+    );
+    console.log(
+      `mean nDCG@${K}=${meanNdcg.toFixed(3)}  mean recall@${K}=${meanRecall.toFixed(3)}`,
+    );
+
+    expect(meanNdcg, `mean nDCG@${K} regressed`).toBeGreaterThanOrEqual(
+      MIN_MEAN_NDCG,
+    );
+    expect(meanRecall, `mean recall@${K} regressed`).toBeGreaterThanOrEqual(
+      MIN_MEAN_RECALL,
+    );
+  });
+});

--- a/eval/retrieval.integration.test.ts
+++ b/eval/retrieval.integration.test.ts
@@ -34,17 +34,20 @@ import { ndcgAtK, recallAtK } from "./metrics.ts";
 const K = 3;
 
 /**
- * Regression thresholds, set with explicit headroom rather than pinned to the
- * measured baseline. Baseline (this machine, 26 queries): mean nDCG@3 0.947,
- * mean recall@3 0.981. The floors below tolerate roughly three or four queries
- * losing a relevant result from the top-3 (recall) before failing. That
- * headroom is intentional: the reranker is a quantized ONNX graph whose scores
- * drift and can reorder results across execution providers (see
- * server/rerankerService.ts), so a floor measured to two decimals would be
- * flaky on a different CPU. Re-tune if the golden set changes substantially.
+ * Regression thresholds, set in the middle of the band between a working
+ * reranker and a no-op (identity) reranker, with headroom on both sides. On
+ * this golden set a no-op reranker (which preserves the input order) scores
+ * mean nDCG@3 0.587 / recall@3 0.500, while the working reranker scores
+ * 0.950 / 0.981. The floors below sit between the two, so a dead or no-op
+ * reranker fails and a working one passes with margin. The headroom (the
+ * working reranker clears the floors by ~0.2) is intentional: the reranker is
+ * a quantized ONNX graph whose scores drift and can reorder results across
+ * execution providers (see server/rerankerService.ts), so a floor pinned to
+ * the measured baseline would be flaky on a different CPU. Re-tune if the
+ * golden set changes substantially.
  */
-const MIN_MEAN_NDCG = 0.88;
-const MIN_MEAN_RECALL = 0.9;
+const MIN_MEAN_NDCG = 0.75;
+const MIN_MEAN_RECALL = 0.7;
 
 interface PerQueryScore {
   id: string;
@@ -94,11 +97,16 @@ describe("retrieval eval (real reranker)", () => {
   }
 
   it("meets the aggregate regression thresholds", () => {
-    expect(scores).toHaveLength(goldenQueries.length);
-
-    const meanNdcg = scores.reduce((sum, s) => sum + s.ndcg, 0) / scores.length;
+    // Print the breakdown before asserting, so a per-query failure still shows
+    // which queries scored what (the diagnostic you need when a regression fires).
+    const meanNdcg =
+      scores.length > 0
+        ? scores.reduce((sum, s) => sum + s.ndcg, 0) / scores.length
+        : 0;
     const meanRecall =
-      scores.reduce((sum, s) => sum + s.recall, 0) / scores.length;
+      scores.length > 0
+        ? scores.reduce((sum, s) => sum + s.recall, 0) / scores.length
+        : 0;
 
     console.table(
       scores.map((s) => ({
@@ -111,6 +119,7 @@ describe("retrieval eval (real reranker)", () => {
       `mean nDCG@${K}=${meanNdcg.toFixed(3)}  mean recall@${K}=${meanRecall.toFixed(3)}`,
     );
 
+    expect(scores).toHaveLength(goldenQueries.length);
     expect(meanNdcg, `mean nDCG@${K} regressed`).toBeGreaterThanOrEqual(
       MIN_MEAN_NDCG,
     );

--- a/eval/retrieval.integration.test.ts
+++ b/eval/retrieval.integration.test.ts
@@ -30,24 +30,18 @@ import {
 } from "../server/rerankerService.ts";
 import { goldenQueries } from "./goldenSet.ts";
 import { ndcgAtK, recallAtK } from "./metrics.ts";
+import { K, MIN_MEAN_NDCG, MIN_MEAN_RECALL } from "./thresholds.ts";
 
-const K = 3;
-
-/**
- * Regression thresholds, set in the middle of the band between a working
- * reranker and a no-op (identity) reranker, with headroom on both sides. On
- * this golden set a no-op reranker (which preserves the input order) scores
- * mean nDCG@3 0.587 / recall@3 0.500, while the working reranker scores
- * 0.950 / 0.981. The floors below sit between the two, so a dead or no-op
- * reranker fails and a working one passes with margin. The headroom (the
- * working reranker clears the floors by ~0.2) is intentional: the reranker is
- * a quantized ONNX graph whose scores drift and can reorder results across
- * execution providers (see server/rerankerService.ts), so a floor pinned to
- * the measured baseline would be flaky on a different CPU. Re-tune if the
- * golden set changes substantially.
- */
-const MIN_MEAN_NDCG = 0.75;
-const MIN_MEAN_RECALL = 0.7;
+// The floors are set in the middle of the band between a working reranker
+// (0.950 / 0.981) and a no-op reranker (0.587 / 0.500) on this golden set, so
+// a dead or no-op reranker fails and a working one passes with margin. The
+// headroom (the working reranker clears the floors by ~0.2) is intentional:
+// the reranker is a quantized ONNX graph whose scores drift and can reorder
+// results across execution providers (see server/rerankerService.ts), so a
+// floor pinned to the measured baseline would be flaky on a different CPU.
+// Re-tune if the golden set changes substantially. The no-op ceilings that
+// keep these floors falsifiable live in thresholds.ts and are pinned by
+// goldenSet.test.ts.
 
 interface PerQueryScore {
   id: string;

--- a/eval/thresholds.ts
+++ b/eval/thresholds.ts
@@ -1,0 +1,26 @@
+/**
+ * The retrieval eval's thresholds, shared by the integration test (which
+ * asserts the working reranker clears the floors) and goldenSet.test.ts (which
+ * asserts the no-op baseline stays below the ceilings). Keeping them in one
+ * place means the ceiling-below-floor relation is checked, not just commented:
+ * if a floor were lowered to or below its ceiling, the premise inverts and a
+ * dead reranker would pass.
+ */
+
+/** The rank at which nDCG / recall are measured. */
+export const K = 3;
+
+/**
+ * Floors the working reranker must clear. Set in the middle of the band
+ * between a working reranker (0.950 / 0.981) and a no-op reranker (0.587 /
+ * 0.500), with headroom on both sides for cross-CPU score drift.
+ */
+export const MIN_MEAN_NDCG = 0.75;
+export const MIN_MEAN_RECALL = 0.7;
+
+/**
+ * Ceilings the no-op (identity) baseline must stay below. These sit below the
+ * floors above; the gap is what makes the floors falsifiable.
+ */
+export const MAX_NOOP_MEAN_NDCG = 0.65;
+export const MAX_NOOP_MEAN_RECALL = 0.6;

--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
     "start": "vite preview",
     "build": "vite build",
     "dev": "vite",
-    "lint": "biome check && tsc && tsc -p tsconfig.node.json --noEmit && knip && jscpd client server --ignore-pattern \"**/dist/**\" && node scripts/architectural-linter.cjs && node scripts/doc-gardening.cjs && node scripts/documentation-validator.cjs",
+    "lint": "biome check && tsc && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.eval.json --noEmit && knip && jscpd client server --ignore-pattern \"**/dist/**\" && node scripts/architectural-linter.cjs && node scripts/doc-gardening.cjs && node scripts/documentation-validator.cjs",
     "format": "biome check --write",
     "format:check": "biome check",
     "prepare": "husky",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "eval": "vitest run --config vitest.eval.config.ts",
+    "eval:retrieval": "vitest run --config vitest.eval.config.ts retrieval",
+    "eval:answer": "vitest run --config vitest.eval.config.ts answer"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.0",

--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -55,9 +55,13 @@ describe("rankSearchResults", () => {
   });
 
   it("should preserve top result when preserveTopResults is true", async () => {
+    // Index 0 has the LOWER score, so a plain descending sort would put
+    // "Other" first; only the pin keeps "Top" first. (A vacuous version gives
+    // index 0 the highest score, which plain sort satisfies too, so it would
+    // pass even with the pin deleted.)
     mockRerank.mockResolvedValue([
-      { index: 0, relevance_score: 0.95 },
-      { index: 1, relevance_score: 0.8 },
+      { index: 0, relevance_score: 0.1 },
+      { index: 1, relevance_score: 0.9 },
     ] as { index: number; relevance_score: number }[]);
     const { rankSearchResults } = await import("./rankSearchResults");
     const result = await rankSearchResults(

--- a/shared/defaultSystemPrompt.ts
+++ b/shared/defaultSystemPrompt.ts
@@ -1,0 +1,23 @@
+/**
+ * The default system prompt template, kept in a side-effect-free module so
+ * that both the client (client/modules/settings.ts) and the offline eval
+ * (eval/) use the exact same text. The eval imports this directly; a stale
+ * copy there would let prompt regressions ship green, which is the point the
+ * eval exists to prevent.
+ *
+ * The {{searchResults}} and {{currentDate}} placeholders are filled by
+ * client/modules/systemPrompt.ts.
+ */
+export const DEFAULT_SYSTEM_PROMPT = `Answer the question using the search results below. Reply in the same language as the question.
+
+Cite each fact with a Markdown link right after it, using the site's domain as the link text. Example: [youtube.com](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
+
+If you answer from your own knowledge because the results do not cover it, say so.
+
+Use only these Markdown elements: link, bold, italic, code, quote, table.
+
+Today's date is {{currentDate}}. Use it for relative dates such as "yesterday".
+
+Search results:
+
+{{searchResults}}`;

--- a/tsconfig.eval.json
+++ b/tsconfig.eval.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
+  },
+  "include": ["eval", "shared"]
+}

--- a/tsconfig.eval.json
+++ b/tsconfig.eval.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
+    "types": ["vitest/globals", "node"]
   },
   "include": ["eval", "shared"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,11 +7,13 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: resolve(__dirname, "client/setupTests.ts"),
     // Loads the real model; runs via vitest.integration.config.ts instead.
+    // The offline eval integration tests run via vitest.eval.config.ts.
     exclude: [
       "**/node_modules/**",
       "**/dist/**",
       "e2e/**",
       "server/**/*.integration.test.ts",
+      "eval/**/*.integration.test.ts",
     ],
     alias: {
       "@": resolve(__dirname, "client"),

--- a/vitest.eval.config.ts
+++ b/vitest.eval.config.ts
@@ -1,0 +1,37 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Runs the offline eval integration tests in the node environment. Kept
+ * separate from vitest.config.ts because the retrieval eval loads the real
+ * ONNX reranker (and the answer eval makes network calls) and must not load
+ * the jsdom-only client setup file.
+ *
+ * The alias block mirrors vitest.config.ts so module resolution matches what
+ * `tsc -p tsconfig.eval.json` (which reads `paths` from the base tsconfig)
+ * already validated. Without it the eval could type-check green and then fail
+ * at runtime on an alias it can't resolve.
+ *
+ *   npx vitest run --config vitest.eval.config.ts            # all eval tests
+ *   npx vitest run --config vitest.eval.config.ts retrieval  # retrieval only
+ *   npx vitest run --config vitest.eval.config.ts answer     # answer only
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["eval/**/*.integration.test.ts"],
+    testTimeout: 600_000,
+    hookTimeout: 900_000,
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "client"),
+      "@/modules": resolve(__dirname, "client/modules"),
+      "@/components": resolve(__dirname, "client/components"),
+      "@/hooks": resolve(__dirname, "client/hooks"),
+      "@shared": resolve(__dirname, "shared"),
+      "@root": resolve(__dirname),
+    },
+  },
+});


### PR DESCRIPTION
## Description

Closes #2192.

There was no eval harness, so a change to the prompt, the reranker, or the model shipped blind: nothing measured whether the ranking or the answer got better or worse.

This PR adds a small offline eval in `eval/`, driven by a fixed golden set of 26 queries. It is a regression baseline, not a benchmark.

### Retrieval

Runs the real ONNX reranker through `rankSearchResults` (with `preserveTopResults=true`, the same call the app makes for text search) and scores the ranking with nDCG@3 and recall@3 against the labeled relevant results. It fails if the mean drops below a floor set in the middle of the band between a working reranker and a no-op (identity) reranker, with headroom on both sides: the golden set is curated so a no-op reranker scores 0.587 / 0.500 while a working one scores 0.950 / 0.981, and the floors (0.75 / 0.70) sit between them. A "stays falsifiable" test pins the no-op baseline below the floors, so a future edit to the set that breaks the premise (both relevant results in the input top-3) fails loudly. The headroom is intentional: the reranker is a quantized model whose scores drift across execution providers.

### Answer

Builds the exact prompt the app sends (the real `getFormattedSearchResults` + `getDefaultChatMessages`, with pubSub mocked to the golden query), asks a chosen LLM backend for an answer, and grades it with a separate LLM judge against a rubric. It also checks a deterministic citation rate and a snippet-only-facts aggregate. It is gated on `EVAL_LLM_API_KEY` and skips cleanly without one.

### What changed

| Area | Change |
|---|---|
| `eval/goldenSet.ts` | 26 hand-curated queries: labeled relevant results, reference answers, rubrics. Includes fictional snippet-only facts (the model cannot know them) and entries whose first candidate is irrelevant, so the pinned-first branch can cost the ranking. |
| `eval/metrics.ts` | Pure nDCG@k / recall@k (binary relevance). |
| `eval/retrieval.integration.test.ts` | Real reranker on the golden set; fails below the floor. |
| `eval/answer.integration.test.ts` | App prompt + LLM judge, plus citation-rate and snippet-only checks. Key-gated. |
| `eval/goldenSet.test.ts`, `eval/promptConstruction.test.ts`, `eval/metrics.test.ts` | Default suite: golden-set structure, prompt construction, metrics. |
| `eval/goldenPrompt.ts` | Shared prompt builder used by both prompt tests, so they cannot drift. |
| `shared/defaultSystemPrompt.ts` | The default system prompt, extracted so the client and the eval share one source (a stale copy would let prompt regressions ship green). |
| `client/modules/settings.ts` | Uses the shared prompt constant. |
| `tsconfig.eval.json`, `vitest.eval.config.ts` | Type-check and run the model/network tests separately (node env, no jsdom setup). |
| `package.json` | `eval`, `eval:retrieval`, `eval:answer` scripts; `lint` now type-checks the eval. |
| `docs/development-commands.md`, `eval/README.md` | Docs. |

## How to test

1. `npm run lint` (clean, including the new `tsc -p tsconfig.eval.json`).
2. `npm test` (the golden-set, prompt-construction, and metrics tests run here, so they are covered in CI).
3. `npm run eval:retrieval` (needs the model in `server/models/`; local only, CI has no model on disk). Baseline on my machine: mean nDCG@3 0.950, mean recall@3 0.981 (floors 0.75 / 0.70).
4. `npm run eval:answer` (needs `EVAL_LLM_API_KEY`; I could not run it here, no key).

## Known limitations

- The answer eval's LLM-judged path is not exercised here (no API key). On a first keyed run it is worth confirming that deleting the citation paragraph from `DEFAULT_SYSTEM_PROMPT` drops the printed citation rate under 0.8 (the results block shows markdown links in-context, so the model may still cite).
- The prompt is built for the no-page-content case (`pageContents = {}`), so `allocatePageExcerpts` / `formatExcerpt` never appear in a graded prompt even though `enablePageContentFetch` defaults to true. "The exact prompt the app sends" holds for the no-page-content case.
- The answer eval hardcodes `temperature: 0` (deliberate, for determinism) and `max_tokens: 4096` rather than the app's `getDefaultChatCompletionCreateParamsStreaming()` (`temperature: 0.35`), so a change to the app's sampling params is invisible to it. `max_tokens` / `temperature` are also rejected by o-series / GPT-5-style endpoints (`max_completion_tokens`, fixed temperature); the documented default is `gpt-4o-mini`.
- Roughly a third of the rubric points are negative ("does not give a wrong year"), which LLM judges pass by default; that is a judge-variance source, so the citation rate and the snippet-only aggregate do the real work. The snippet-only floor (0.8) spans 3 entries x 2 rubric points = 6 binary decisions, so it is effectively "at least 5 of 6".
- No retry on transient LLM errors (a single 429 / 5xx fails the run); the answer eval is local-only and key-gated, so this is a false-red source rather than a correctness one.

Note: the golden-set validator rejects `$&` / `` $` `` / `$'` / `$$` in result fields, which fences the eval off from the pre-existing `String.replace` bug in `systemPrompt.ts`. That bug stays separate and out of scope here.

