### PR TITLE
fix(keyboard): skip submit during IME composition

### DIFF
--- a/client/components/AiResponse/ChatInputArea.tsx
+++ b/client/components/AiResponse/ChatInputArea.tsx
@@ -37,11 +37,17 @@ function ChatInputArea({ onKeyDown, handleSend }: ChatInputAreaProps) {
   const handleKeyDownWithPlaceholder = (
     event: React.KeyboardEvent<HTMLTextAreaElement>,
   ) => {
+    // Same IME guard as handleEnterKeyDown: the Enter that confirms a
+    // composition candidate must not fire the follow-up question while the
+    // composition text has not reached the input value yet.
+    const isComposing = event.nativeEvent.isComposing || event.keyCode === 229;
+
     if (
       input.trim() === "" &&
       followUpQuestion &&
       !isRestoringFromHistory &&
-      !suppressNextFollowUp
+      !suppressNextFollowUp &&
+      !isComposing
     ) {
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();

--- a/client/modules/keyboard.test.ts
+++ b/client/modules/keyboard.test.ts
@@ -2,12 +2,16 @@ import type { KeyboardEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { handleEnterKeyDown } from "./keyboard";
 
-function mockEvent(shift: boolean): Partial<KeyboardEvent> {
+function mockEvent(
+  shift: boolean,
+): Partial<KeyboardEvent<HTMLTextAreaElement>> {
   return {
     code: "Enter",
     shiftKey: shift,
+    keyCode: 13,
     preventDefault: vi.fn(),
-  } as Partial<KeyboardEvent>;
+    nativeEvent: { isComposing: false },
+  } as unknown as Partial<KeyboardEvent<HTMLTextAreaElement>>;
 }
 
 describe("handleEnterKeyDown", () => {
@@ -57,5 +61,47 @@ describe("handleEnterKeyDown", () => {
     );
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when Enter confirms an IME composition candidate", () => {
+    const onSubmit = vi.fn();
+    const event = {
+      ...mockEvent(false),
+      nativeEvent: { isComposing: true },
+    };
+    handleEnterKeyDown(
+      event as KeyboardEvent<HTMLTextAreaElement>,
+      { enterToSubmit: true },
+      onSubmit,
+    );
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when the composition is only flagged by keyCode 229", () => {
+    const onSubmit = vi.fn();
+    const event = {
+      ...mockEvent(false),
+      keyCode: 229,
+    };
+    handleEnterKeyDown(
+      event as KeyboardEvent<HTMLTextAreaElement>,
+      { enterToSubmit: true },
+      onSubmit,
+    );
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("still submits a normal Enter after a composition has ended", () => {
+    const onSubmit = vi.fn();
+    const event = mockEvent(false);
+    handleEnterKeyDown(
+      event as KeyboardEvent<HTMLTextAreaElement>,
+      { enterToSubmit: true },
+      onSubmit,
+    );
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 });

--- a/client/modules/keyboard.ts
+++ b/client/modules/keyboard.ts
@@ -11,6 +11,16 @@ export const handleEnterKeyDown = (
   settings: { enterToSubmit: boolean },
   onSubmit: () => void,
 ) => {
+  // The Enter that confirms an IME composition candidate fires while the
+  // composition is still in progress, so the textarea's value does not yet
+  // contain the confirmed text — submitting then runs the search or sends
+  // the chat message with stale or partial input. Chrome, Edge, and Firefox
+  // flag the confirming keydown with isComposing; Safari reports it as
+  // keyCode 229 instead, so both signals are checked.
+  if (event.nativeEvent.isComposing || event.keyCode === 229) {
+    return;
+  }
+
   if (
     (event.code === "Enter" && !event.shiftKey && settings.enterToSubmit) ||
     (event.code === "Enter" && event.shiftKey && !settings.enterToSubmit)


### PR DESCRIPTION
## What & why

With a CJK IME (Chinese, Japanese, Korean), pressing Enter to confirm a composition candidate fires a `keydown` whose `code` is `"Enter"` — and both the search box and the chat input treated it as a submit. The result: the search runs (or the chat message sends) with stale or partial text, because the composition hasn't committed to the textarea's value yet at that point.

Repro with a Chinese/Japanese IME:
1. Focus the search box, start composing a query (or type in chat with a follow-up question shown).
2. Press Enter to select the candidate from the IME dropdown.
3. The search starts / the message sends before the candidate text ever lands in the input — with whatever was in the box before.

Affected paths:
- `client/modules/keyboard.ts` — `handleEnterKeyDown` (used by the search form and the chat send path)
- `client/components/AiResponse/ChatInputArea.tsx` — the follow-up-question quick-send path, which reads `input.trim() === ""` and can fire while a composition's text hasn't reached the controlled value yet

Fix: bail out of the submit handling when the keydown is part of an IME composition. Chrome/Edge/Firefox flag the confirming keydown with `isComposing`; Safari reports it as `keyCode 229` instead, so both signals are checked. A normal Enter after the composition ends is unaffected.

## Test plan

- 3 new tests in `client/modules/keyboard.test.ts`: `isComposing` true blocks submit; `keyCode 229` alone blocks submit; a normal Enter still submits
- `npx vitest run client/modules/keyboard.test.ts` → 7 pass
- `npx tsc` and `npx biome check` pass on the changed files

No UI screenshot — behavior is keyboard-only; the repro above is the verification.
