### PR TITLE
test(main-page): drop stale value-proposition assertions

### DIFF
--- a/client/components/Pages/Main/MainPage.test.tsx
+++ b/client/components/Pages/Main/MainPage.test.tsx
@@ -122,22 +122,6 @@ describe("MainPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows the value proposition in the empty state", async () => {
-    await renderMainPage(createPageState());
-
-    expect(
-      screen.getByText(/answers with sources, on your own instance/),
-    ).toBeInTheDocument();
-  });
-
-  it("does not show the value proposition once a query is present", async () => {
-    await renderMainPage(createPageState({ query: "cats" }));
-
-    expect(
-      screen.queryByText(/answers with sources, on your own instance/),
-    ).not.toBeInTheDocument();
-  });
-
   it("shows the AI opt-in in the empty state before searching", async () => {
     await renderMainPage(
       createPageState({ settings: { showEnableAiResponsePrompt: true } }),


### PR DESCRIPTION
## What & why

`48267e5` ("Remove unnecessary headline") removed the empty-state headline from `MainPage.tsx`:

```diff
-        {isQueryEmpty && (
-          <Text ta="center" size="sm">
-            Private AI search: answers with sources, on your own instance.
-          </Text>
-        )}
```

but left the two tests that assert that text behind. The positive one ("shows the value proposition in the empty state") has been failing consistently since — locally and in CI (`build-test` on `main` is red for it) — and the negative one now tests a feature that no longer exists, so it passes only because the text is never rendered.

This removes both stale test cases.

## Test plan

- `npx vitest run client/components/Pages/Main/MainPage.test.tsx` → 12 pass (was 13 pass + 1 fail)
- Full `npx vitest run` → no new failures (the only 2 remaining failures locally are the doc-validator/doc-gardening script tests, which fail on this Windows checkout regardless of any change — they pass on CI)

Nothing else references the removed text.
