### PR TITLE
fix(follow-up): keep non-Latin follow-up questions intact

### DIFF
--- a/client/modules/followUpQuestions.test.ts
+++ b/client/modules/followUpQuestions.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateFollowUpQuestion } from "./followUpQuestions";
+
+vi.mock("./pubSub", () => ({
+  getSuppressNextFollowUp: vi.fn(() => false),
+}));
+
+vi.mock("./textGeneration", () => ({
+  generateChatResponse: vi.fn(),
+}));
+
+import { getSuppressNextFollowUp } from "./pubSub";
+import { generateChatResponse } from "./textGeneration";
+
+const mockedGenerateChatResponse = vi.mocked(generateChatResponse);
+const mockedGetSuppressNextFollowUp = vi.mocked(getSuppressNextFollowUp);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetSuppressNextFollowUp.mockReturnValue(false);
+});
+
+describe("generateFollowUpQuestion", () => {
+  it("keeps an English question with leading numbering", async () => {
+    mockedGenerateChatResponse.mockResolvedValue(
+      "1. What about the alternatives?",
+    );
+
+    const question = await generateFollowUpQuestion({
+      topic: "cats",
+      currentContent: "Cats are independent.",
+    });
+
+    expect(question).toBe("What about the alternatives?");
+  });
+
+  it("keeps a Chinese question ending in a fullwidth question mark", async () => {
+    mockedGenerateChatResponse.mockResolvedValue("你觉得这个方案怎么样？");
+
+    const question = await generateFollowUpQuestion({
+      topic: "方案",
+      currentContent: "方案可行。",
+    });
+
+    expect(question).toBe("你觉得这个方案怎么样？");
+  });
+
+  it("strips a leading bullet from a Japanese question without touching the text", async () => {
+    mockedGenerateChatResponse.mockResolvedValue(
+      "- この案についてどう思いますか？",
+    );
+
+    const question = await generateFollowUpQuestion({
+      topic: "案",
+      currentContent: "案は実行可能です。",
+    });
+
+    expect(question).toBe("この案についてどう思いますか？");
+  });
+
+  it("keeps an Arabic question ending in an Arabic question mark", async () => {
+    mockedGenerateChatResponse.mockResolvedValue("ما رأيك في البدائل؟");
+
+    const question = await generateFollowUpQuestion({
+      topic: "البدائل",
+      currentContent: "البدائل متاحة.",
+    });
+
+    expect(question).toBe("ما رأيك في البدائل؟");
+  });
+
+  it("returns an empty string when no line ends with a question mark", async () => {
+    mockedGenerateChatResponse.mockResolvedValue("No questions here.");
+
+    const question = await generateFollowUpQuestion({
+      topic: "cats",
+      currentContent: "Cats are independent.",
+    });
+
+    expect(question).toBe("");
+  });
+
+  it("returns an empty string when follow-up questions are suppressed", async () => {
+    mockedGetSuppressNextFollowUp.mockReturnValue(true);
+
+    const question = await generateFollowUpQuestion({
+      topic: "cats",
+      currentContent: "Cats are independent.",
+    });
+
+    expect(mockedGenerateChatResponse).not.toHaveBeenCalled();
+    expect(question).toBe("");
+  });
+});

--- a/client/modules/followUpQuestions.ts
+++ b/client/modules/followUpQuestions.ts
@@ -91,14 +91,22 @@ Respond with just the question, no additional text or explanations.`,
       .split("\n")
       .map((line) => line.trim())
       .reverse()
-      .find((line) => line.endsWith("?"));
+      .find(
+        (line) =>
+          line.endsWith("?") || line.endsWith("？") || line.endsWith("؟"),
+      );
 
     if (!lines) {
       addLogEntry("No valid follow-up question generated");
       return "";
     }
 
-    let questionLine = lines.replace(/^[^a-zA-Z]+/, "");
+    // Strips leading bullets, numbering, and quotes without touching the
+    // question text itself. The old [^a-zA-Z] class matched every character
+    // of a non-Latin question (Chinese, Japanese, Korean, Arabic, ...) and
+    // wiped it to an empty string, even though the prompt above requires the
+    // follow-up question to be in the same language as the original.
+    let questionLine = lines.replace(/^[^\p{L}]+/u, "");
 
     questionLine = questionLine.charAt(0).toUpperCase() + questionLine.slice(1);
 


### PR DESCRIPTION
## What & why

Follow-up question generation is documented as language-matching ("The follow-up question must be written in the exact same language as both the original question and response") — but two places in `generateFollowUpQuestion` only understand Latin scripts, so questions in Chinese, Japanese, Korean, Arabic, and any other non-Latin script come back **empty**:

1. The line search only matches an ASCII `?` at the end of the line, so a question ending in the fullwidth `？` (or Arabic `؟`) is never found and the function returns `""` early.
2. The leading-punctuation strip uses `/^[^a-zA-Z]+/`, which matches every character of a non-Latin question — the whole question gets replaced with an empty string.

Verified against the current code:

```js
"你觉得这个方案怎么样？".endsWith("?")            // false → never found
"你觉得这个方案怎么样？".replace(/^[^a-zA-Z]+/, "")  // "" → wiped
"1. What about the alternatives?".replace(/^[^a-zA-Z]+/, "") // "What about the alternatives?" (unchanged behavior)
```

Fix:
- Find the question line by any of `?`, `？`, `؟`.
- Strip leading bullets/numbering/quotes with `/^[^\p{L}]+/u` — letters in every script survive, so the strip now only removes what it was meant to remove.

English behavior is unchanged (the new regex still strips leading digits and punctuation).

## Test plan

New `client/modules/followUpQuestions.test.ts` (6 tests): English numbering, fullwidth `？`, a Japanese bulleted line, Arabic `؟`, a line with no question mark, and the suppressed path. `npx vitest run client/modules/followUpQuestions.test.ts` → 6 pass. `npx tsc` and `npx biome check` pass on the changed files.
