### PR TITLE
test(main-page): drop assertions for the removed empty-state headline

### DIFF
--- a/client/components/Pages/Main/MainPage.test.tsx
+++ b/client/components/Pages/Main/MainPage.test.tsx
@@ -122,22 +122,6 @@ describe("MainPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows the value proposition in the empty state", async () => {
-    await renderMainPage(createPageState());
-
-    expect(
-      screen.getByText(/answers with sources, on your own instance/),
-    ).toBeInTheDocument();
-  });
-
-  it("does not show the value proposition once a query is present", async () => {
-    await renderMainPage(createPageState({ query: "cats" }));
-
-    expect(
-      screen.queryByText(/answers with sources, on your own instance/),
-    ).not.toBeInTheDocument();
-  });
-
   it("shows the AI opt-in in the empty state before searching", async () => {
     await renderMainPage(
       createPageState({ settings: { showEnableAiResponsePrompt: true } }),


### PR DESCRIPTION
## What & why

Commit `48267e53` ("Remove unnecessary headline") removed the visible value-proposition text ("Private AI search: answers with sources, on your own instance.") from the MainPage empty state, but left the two tests asserting it behind. They have been failing on every PR since (the text only ever existed in the test itself), including the current IME fix PR #2385 and the eval PR #2382.

The remaining value proposition is the visually-hidden h1 ("MiniSearch — Private AI search with sources"), which is already covered by the "renders a visually-hidden h1" test in this same file.

## Test plan

```
npx vitest run client/components/Pages/Main/MainPage.test.tsx
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Removed 2 obsolete assertions; the 12 remaining tests all pass.
