### PR TITLE
docs: prune redundant comments and improve TSDoc blocks

### DIFF
--- a/client/components/AiResponse/hooks/useReasoningContent.ts
+++ b/client/components/AiResponse/hooks/useReasoningContent.ts
@@ -3,9 +3,9 @@ import { useCallback } from "react";
 import { settingsPubSub } from "@/modules/pubSub";
 
 /**
- * Hook for extracting reasoning content from AI responses
- * @param text - The full text response from the AI
- * @returns Object containing separated reasoning and main content
+ * Splits a streamed AI response into the part between the reasoning markers
+ * and the rest, flagging `isGenerating` while the closing marker has not
+ * arrived yet.
  */
 export function useReasoningContent(text: string) {
   const [settings] = usePubSub(settingsPubSub);

--- a/client/components/App/App.tsx
+++ b/client/components/App/App.tsx
@@ -32,9 +32,6 @@ const AccessPage = lazy(() => import("../Pages/AccessPage"));
 /** The server config while it is being fetched, or after the fetch failed. */
 type ConfigState = ServerConfig | "loading" | "unavailable";
 
-/**
- * Main application component with access key validation and routing
- */
 function App() {
   const config = useServerConfig();
   useInitializeSettings(config);
@@ -88,9 +85,6 @@ function FullScreenMessage({
 
 export default App;
 
-/**
- * Fetches the runtime server config once on mount.
- */
 function useServerConfig(): ConfigState {
   const [config, setConfig] = useState<ConfigState>("loading");
 
@@ -138,8 +132,6 @@ function useInitializeSettings(config: ConfigState) {
  * @remarks
  * Starts out unvalidated and stays that way while the config is missing, so an
  * unreachable server can never be mistaken for "access keys are disabled".
- *
- * @returns An object containing the validation state and loading state
  */
 function useAccessKeyValidation(config: ConfigState) {
   const [state, setState] = useState({

--- a/client/components/Pages/Main/Menu/AISettings/components/BrowserSettings.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/components/BrowserSettings.tsx
@@ -7,18 +7,11 @@ const WllamaModelSelect = lazy(
   () => import("@/components/AiResponse/WllamaModelSelect"),
 );
 
-/**
- * Props for the BrowserSettings component
- */
 interface BrowserSettingsProps {
-  /** Form instance for managing browser AI settings */
   form: UseFormReturnType<typeof defaultSettings>;
 }
 
-/**
- * Component for managing browser-based AI settings.
- * Provides controls for model selection and CPU thread configuration.
- */
+/** Browser inference settings: the model to run (lazy-loaded) and its CPU threads. */
 export const BrowserSettings = ({ form }: BrowserSettingsProps) => (
   <>
     <Suspense fallback={<Skeleton height={50} />}>

--- a/client/components/Pages/Main/Menu/AISettings/components/HordeSettings.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/components/HordeSettings.tsx
@@ -4,22 +4,13 @@ import type { defaultSettings } from "@/modules/settings";
 import { aiHordeDefaultApiKey } from "@/modules/textGenerationWithHorde";
 import type { HordeUserInfo, ModelOption } from "../types";
 
-/**
- * Props for the HordeSettings component
- */
 interface HordeSettingsProps {
-  /** Form instance for managing Horde AI settings */
   form: UseFormReturnType<typeof defaultSettings>;
-  /** User information from AI Horde, or null if not logged in */
   hordeUserInfo: HordeUserInfo | null;
-  /** Available models from AI Horde */
   hordeModels: ModelOption[];
 }
 
-/**
- * Component for managing AI Horde settings.
- * Provides controls for API key input and model selection.
- */
+/** AI Horde settings: the API key (with the anonymous-mode hint) and an optional model pin. */
 export const HordeSettings = ({
   form,
   hordeUserInfo,

--- a/client/components/Pages/Main/Menu/AISettings/components/OpenAISettings.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/components/OpenAISettings.tsx
@@ -4,22 +4,13 @@ import { IconInfoCircle } from "@tabler/icons-react";
 import { defaultSettings } from "@/modules/settings";
 import type { ModelOption } from "../types";
 
-/**
- * Props for the OpenAISettings component
- */
 interface OpenAISettingsProps {
-  /** Form instance for managing OpenAI API settings */
   form: UseFormReturnType<typeof defaultSettings>;
-  /** Available OpenAI-compatible models */
   openAiModels: ModelOption[];
-  /** Whether to use text input instead of select for model */
   useTextInput: boolean;
 }
 
-/**
- * Component for managing OpenAI API settings.
- * Provides controls for API base URL, API key, model selection, and context length.
- */
+/** OpenAI-compatible API settings: base URL, key, model, and context length. */
 export const OpenAISettings = ({
   form,
   openAiModels,

--- a/client/components/Pages/Main/Menu/AISettings/components/SystemPromptInput.tsx
+++ b/client/components/Pages/Main/Menu/AISettings/components/SystemPromptInput.tsx
@@ -2,25 +2,15 @@ import { Text, Textarea } from "@mantine/core";
 import type { UseFormReturnType } from "@mantine/form";
 import { defaultSettings } from "@/modules/settings";
 
-/**
- * Props for the SystemPromptInput component
- */
 interface SystemPromptInputProps {
-  /** Form instance for managing system prompt settings */
   form: UseFormReturnType<typeof defaultSettings>;
 }
 
-/**
- * Component for managing system prompt/instructions for AI.
- * Provides a textarea for customizing AI behavior with examples and restore functionality.
- */
+/** Custom system prompt editor, with an inline action to restore the default. */
 export const SystemPromptInput = ({ form }: SystemPromptInputProps) => {
   const isUsingCustomInstructions =
     form.values.systemPrompt !== defaultSettings.systemPrompt;
 
-  /**
-   * Handles restoring the default system prompt instructions
-   */
   const handleRestoreDefaultInstructions = () => {
     form.setFieldValue("systemPrompt", defaultSettings.systemPrompt);
   };

--- a/client/components/Pages/Main/Menu/AISettings/hooks/useHordeModels.ts
+++ b/client/components/Pages/Main/Menu/AISettings/hooks/useHordeModels.ts
@@ -4,23 +4,13 @@ import type { defaultSettings } from "@/modules/settings";
 import { fetchHordeModels } from "@/modules/textGenerationWithHorde";
 import type { ModelOption } from "../types";
 
-/**
- * Type alias for the settings object
- */
 type Settings = typeof defaultSettings;
 
-/**
- * Hook for fetching and managing AI Horde models
- * @param settings - Application settings object
- * @returns Array of available AI Horde models formatted as ModelOption[]
- */
+/** AI Horde models as select options; only fetched while Horde is the selected backend. */
 export const useHordeModels = (settings: Settings) => {
   const [hordeModels, setHordeModels] = useState<ModelOption[]>([]);
 
   useEffect(() => {
-    /**
-     * Fetches available models from AI Horde and formats them for UI
-     */
     async function fetchAvailableHordeModels() {
       try {
         const models = await fetchHordeModels();

--- a/client/components/Pages/Main/Menu/AISettings/hooks/useHordeUserInfo.ts
+++ b/client/components/Pages/Main/Menu/AISettings/hooks/useHordeUserInfo.ts
@@ -7,25 +7,15 @@ import {
 } from "@/modules/textGenerationWithHorde";
 import type { HordeUserInfo } from "../types";
 
-/**
- * Type alias for the settings object
- */
 type Settings = typeof defaultSettings;
 
-/**
- * Hook for fetching and managing AI Horde user information
- * @param settings - Application settings object
- * @returns Horde user information or null if not authenticated
- */
+/** The logged-in Horde user, or null when the key is empty or the anonymous one. */
 export const useHordeUserInfo = (settings: Settings) => {
   const [hordeUserInfo, setHordeUserInfo] = useState<HordeUserInfo | null>(
     null,
   );
 
   useEffect(() => {
-    /**
-     * Fetches user information from AI Horde API
-     */
     async function fetchUserInfo() {
       try {
         if (

--- a/client/components/Pages/Main/Menu/AISettings/hooks/useOpenAiModels.ts
+++ b/client/components/Pages/Main/Menu/AISettings/hooks/useOpenAiModels.ts
@@ -4,24 +4,17 @@ import { addLogEntry } from "@/modules/logEntries";
 import type { defaultSettings } from "@/modules/settings";
 import type { ModelOption } from "../types";
 
-/**
- * Type alias for the settings object
- */
 type Settings = typeof defaultSettings;
 
 /**
- * Hook for fetching and managing OpenAI-compatible models
- * @param settings - Application settings object
- * @returns Object containing available models and whether to use text input
+ * Falls back to a free-text model input when the API does not list its models
+ * or cannot be reached, so the setting stays usable either way.
  */
 export const useOpenAiModels = (settings: Settings) => {
   const [openAiModels, setOpenAiModels] = useState<ModelOption[]>([]);
   const [useTextInput, setUseTextInput] = useState(false);
 
   useEffect(() => {
-    /**
-     * Fetches available models from OpenAI-compatible API
-     */
     async function fetchOpenAiModels() {
       try {
         const models = await listOpenAiCompatibleModels(

--- a/client/components/Pages/Main/Menu/AISettings/types.ts
+++ b/client/components/Pages/Main/Menu/AISettings/types.ts
@@ -1,19 +1,10 @@
-/**
- * Represents a model option for select components
- */
+/** A label/value pair for the model selects in the settings forms. */
 export interface ModelOption {
-  /** Display label for the model */
   label: string;
-  /** Internal value for the model */
   value: string;
 }
 
-/**
- * Represents user information from AI Horde
- */
 export interface HordeUserInfo {
-  /** Username of the Horde user */
   username: string;
-  /** Number of kudos (credits) the user has */
   kudos: number;
 }

--- a/client/hooks/useHistoryRestore.ts
+++ b/client/hooks/useHistoryRestore.ts
@@ -27,12 +27,7 @@ import {
 } from "../modules/pubSub";
 import type { ImageSearchResults, TextSearchResults } from "../modules/types";
 
-/**
- * Hook for restoring search history and navigating to previous searches
- * @param updateQuery - Function to update the query state
- * @param textAreaRef - Optional ref to the textarea element
- * @returns Object containing restoreSearch function
- */
+/** Restores a full search (results, AI response, chat) from a history entry and navigates to it. */
 export function useHistoryRestore(
   updateQuery: (query: string) => void,
   textAreaRef?: React.RefObject<HTMLTextAreaElement | null>,

--- a/client/hooks/useSearchHistory.ts
+++ b/client/hooks/useSearchHistory.ts
@@ -14,52 +14,26 @@ import {
   searchWithFuzzy,
 } from "../modules/stringFormatters";
 
-/**
- * Options for configuring search history behavior
- */
 interface UseSearchHistoryOptions {
-  /** Maximum number of searches to retrieve */
   limit?: number;
-  /** Fuzzy search threshold for filtering */
   threshold?: number;
-  /** Whether to group searches by date */
   enableGrouping?: boolean;
-  /** Whether to enable pagination */
   enablePagination?: boolean;
-  /** Number of items per page */
   pageSize?: number;
 }
 
-/**
- * Return value for useSearchHistory hook
- */
 interface UseSearchHistoryReturn {
-  /** All recent searches from history */
   recentSearches: SearchEntry[];
-  /** Searches filtered by current query */
   filteredSearches: SearchEntry[];
-  /** Searches grouped by date (if enabled) */
   groupedSearches: Record<string, SearchEntry[]>;
-
-  /** Loading state for operations */
   isLoading: boolean;
-  /** Error message if operation failed */
   error: string | null;
-
-  /** Current page number */
   currentPage: number;
-  /** Total number of pages */
   totalPages: number;
-  /** Whether there's a next page */
   hasNextPage: boolean;
-  /** Whether there's a previous page */
   hasPreviousPage: boolean;
-
-  /** Function to retry last failed operation */
   retryLastOperation: () => Promise<void>;
-  /** Function to clear current error */
   clearError: () => void;
-
   searchHistory: (query: string) => void;
   addToHistory: (
     query: string,
@@ -76,11 +50,7 @@ interface UseSearchHistoryReturn {
   goToPage: (page: number) => void;
 }
 
-/**
- * Hook for managing search history with filtering, grouping, and pagination
- * @param options - Configuration options for search history behavior
- * @returns Object containing search history state and management functions
- */
+/** Search history with fuzzy filtering, date grouping, and optional pagination. */
 export function useSearchHistory(
   options: UseSearchHistoryOptions = {},
 ): UseSearchHistoryReturn {

--- a/client/modules/accessKey.ts
+++ b/client/modules/accessKey.ts
@@ -27,9 +27,8 @@ async function hashAccessKey(accessKey: string): Promise<string> {
 }
 
 /**
- * Validates an access key by hashing it and sending it to the server for validation
- * @param accessKey - The plain text access key to validate
- * @returns Promise<boolean> - True if the access key is valid, false otherwise
+ * Validates the key against the server; on success the hash is stored locally
+ * so later loads can go through `verifyStoredAccessKey`.
  */
 export async function validateAccessKey(accessKey: string): Promise<boolean> {
   try {
@@ -64,9 +63,8 @@ export async function validateAccessKey(accessKey: string): Promise<boolean> {
 }
 
 /**
- * Verifies a stored access key hash against the server
- * @param timeoutHours - How long a validated key stays usable; 0 requires validation on every load
- * @returns Promise<boolean> - True if the stored access key is still valid, false otherwise
+ * Re-validates the stored hash, still usable for `timeoutHours` since it was
+ * first validated; 0 means every load asks for the key again.
  */
 export async function verifyStoredAccessKey(
   timeoutHours: number,

--- a/client/modules/appInfo.ts
+++ b/client/modules/appInfo.ts
@@ -1,13 +1,7 @@
 import { repository } from "@root/package.json";
 import { getSemanticVersion } from "@/modules/stringFormatters";
 
-/**
- * Application name extracted from repository URL
- */
 export const appName = repository.url.split("/").pop();
-/**
- * Full repository URL
- */
 export const appRepository = repository.url;
 /**
  * Application version with build timestamp and, when the build had a git

--- a/client/modules/history.ts
+++ b/client/modules/history.ts
@@ -7,10 +7,6 @@ function generateSearchRunId(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
 }
 
-/**
- * Gets the current search run ID, generating one if it doesn't exist
- * @returns The current search run ID
- */
 export function getCurrentSearchRunId(): string {
   if (!currentSearchRunId) {
     currentSearchRunId = generateSearchRunId();
@@ -18,17 +14,10 @@ export function getCurrentSearchRunId(): string {
   return currentSearchRunId;
 }
 
-/**
- * Sets the current search run ID
- * @param id - The search run ID to set
- */
 export function setCurrentSearchRunId(id: string): void {
   currentSearchRunId = id;
 }
 
-/**
- * Resets the current search run ID to null
- */
 export function resetSearchRunId(): void {
   currentSearchRunId = null;
 }
@@ -58,9 +47,6 @@ function measurePerformance<T>(
   );
 }
 
-/**
- * Text search results structure
- */
 export interface TextResults {
   type: "text";
   items: Array<{
@@ -70,9 +56,6 @@ export interface TextResults {
   }>;
 }
 
-/**
- * Image search results structure
- */
 export interface ImageResults {
   type: "image";
   items: Array<{
@@ -83,9 +66,7 @@ export interface ImageResults {
   }>;
 }
 
-/**
- * Search history entry structure
- */
+/** One saved search; `results` is kept for entries written before the split text/image fields. */
 export interface SearchEntry {
   id?: number;
   searchRunId?: string;
@@ -201,32 +182,16 @@ class HistoryDatabase extends Dexie {
   }
 }
 
-/**
- * History database instance for search history management
- */
 export const historyDatabase = new HistoryDatabase();
 
-/**
- * Helper function to get results from a search entry with backward compatibility
- * @param entry - The search entry
- * @returns The appropriate results object (text or image) or null
- */
 export function getResultsFromEntry(
   entry: SearchEntry,
 ): TextResults | ImageResults | null {
-  // First try new structure
   if (entry.textResults) return entry.textResults;
   if (entry.imageResults) return entry.imageResults;
-
-  // Fallback to legacy structure
   return entry.results || null;
 }
 
-/**
- * Helper function to check if an entry has text results
- * @param entry - The search entry
- * @returns True if the entry has text results
- */
 export function hasTextResults(entry: SearchEntry): boolean {
   return !!(
     entry.textResults ||
@@ -234,11 +199,6 @@ export function hasTextResults(entry: SearchEntry): boolean {
   );
 }
 
-/**
- * Helper function to check if an entry has image results
- * @param entry - The search entry
- * @returns True if the entry has image results
- */
 export function hasImageResults(entry: SearchEntry): boolean {
   return !!(
     entry.imageResults ||
@@ -246,11 +206,6 @@ export function hasImageResults(entry: SearchEntry): boolean {
   );
 }
 
-/**
- * Updates search results for a given search run ID
- * @param searchRunId - The search run ID to update
- * @param results - The search results to update (text or image)
- */
 export async function updateSearchResults(
   searchRunId: string,
   results: TextResults | ImageResults,
@@ -277,13 +232,6 @@ export async function updateSearchResults(
   }
 }
 
-/**
- * Adds a search entry to the history
- * @param query - The search query
- * @param results - The search results (text or image)
- * @param source - The source of the search (user, followup, or suggestion)
- * @returns Promise resolving to the ID of the added entry
- */
 export async function addSearchToHistory(
   query: string,
   results: TextResults | ImageResults,
@@ -293,7 +241,7 @@ export async function addSearchToHistory(
     return await historyDatabase.searches.add({
       searchRunId: getCurrentSearchRunId(),
       query,
-      results, // Store in legacy field for backward compatibility
+      results,
       ...(results.type === "text"
         ? { textResults: results }
         : { imageResults: results }),
@@ -307,11 +255,6 @@ export async function addSearchToHistory(
   });
 }
 
-/**
- * Gets recent searches from history
- * @param limit - Maximum number of searches to retrieve
- * @returns Promise resolving to array of recent search entries
- */
 export async function getRecentSearches(
   limit: number = 10,
 ): Promise<SearchEntry[]> {

--- a/client/modules/keyboard.ts
+++ b/client/modules/keyboard.ts
@@ -1,11 +1,6 @@
 import type { KeyboardEvent } from "react";
 
-/**
- * Handles Enter key press events for form submission
- * @param event - The keyboard event from the textarea
- * @param settings - Object containing enterToSubmit setting
- * @param onSubmit - Callback function to execute when Enter key should submit
- */
+/** Submits on Enter when the setting allows, ignoring the Enter that confirms an IME composition. */
 export const handleEnterKeyDown = (
   event: KeyboardEvent<HTMLTextAreaElement>,
   settings: { enterToSubmit: boolean },

--- a/client/modules/logEntries.ts
+++ b/client/modules/logEntries.ts
@@ -1,28 +1,16 @@
 import { createPubSub } from "create-pubsub";
 
-/**
- * Represents a single log entry with timestamp and message
- */
 type LogEntry = {
-  /** ISO timestamp of when the log entry was created */
   timestamp: string;
-  /** The log message content */
   message: string;
-  /** Unique identifier for the log entry */
   id: string;
 };
 
-/**
- * PubSub instance for managing log entries across the application
- */
 export const logEntriesPubSub = createPubSub<LogEntry[]>([]);
 
 const [updateLogEntries, , getLogEntries] = logEntriesPubSub;
 
-/**
- * Adds a new log entry with the current timestamp
- * @param message - The log message to add
- */
+/** Appends a timestamped entry to the in-app log. */
 export function addLogEntry(message: string) {
   updateLogEntries([
     ...getLogEntries(),

--- a/client/modules/notifications.ts
+++ b/client/modules/notifications.ts
@@ -8,8 +8,7 @@ export const REQUEST_PERMISSION_TIMEOUT_MS = 8000;
  * Requests permission to show browser notifications. Some browsers can
  * silently never resolve this request (e.g. Brave has been observed doing
  * this on localhost), so it falls back to "default" after a timeout instead
- * of leaving the caller waiting forever
- * @returns Promise resolving to the notification permission state
+ * of leaving the caller waiting forever.
  */
 export async function requestNotificationPermission(): Promise<NotificationPermission> {
   if (!("Notification" in window)) {
@@ -38,9 +37,8 @@ export async function requestNotificationPermission(): Promise<NotificationPermi
 }
 
 /**
- * Shows a browser notification when AI generation is complete, unless the
- * user already has this page focused
- * @param query - The search query that triggered the AI generation
+ * Shows a browser notification that the AI answer is ready, unless this page
+ * already has the focus.
  */
 export function showAiCompleteNotification(query: string) {
   if (!("Notification" in window)) {

--- a/client/modules/parentWindow.ts
+++ b/client/modules/parentWindow.ts
@@ -1,7 +1,4 @@
-/**
- * Posts a message to the parent window if it exists
- * @param message - The message to send to the parent window
- */
+/** Forwards a message to the embedding parent window, targeting the origin from `ancestorOrigins`. */
 export function postMessageToParentWindow(message: unknown) {
   const parentWindow = self.parent;
   const targetOrigin = parentWindow?.[0]?.location?.ancestorOrigins?.[0];

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -26,12 +26,6 @@ function isSameJsonKind(value: unknown, reference: unknown): boolean {
   return typeof value === typeof reference;
 }
 
-/**
- * Creates a PubSub instance that persists data to localStorage
- * @param localStorageKey - The key to use for localStorage storage
- * @param defaultValue - The default value if no localStorage value exists
- * @returns A PubSub instance with localStorage persistence
- */
 function createLocalStoragePubSub<T>(localStorageKey: string, defaultValue: T) {
   const localStorageValue = localStorage.getItem(localStorageKey);
   let initialValue: T = defaultValue;
@@ -65,70 +59,40 @@ function createLocalStoragePubSub<T>(localStorageKey: string, defaultValue: T) {
   return localStoragePubSub;
 }
 
-/**
- * PubSub instance for managing query suggestions with localStorage persistence
- */
 const querySuggestionsPubSub = createLocalStoragePubSub<string[]>(
   "querySuggestions",
   [],
 );
 
-/**
- * PubSub instance for managing the last search token hash with localStorage persistence
- */
 const lastSearchTokenHashPubSub = createLocalStoragePubSub(
   "lastSearchTokenHash",
   "",
 );
 
-/**
- * Updates the last search token hash
- */
 export const [updateLastSearchTokenHash, , getLastSearchTokenHash] =
   lastSearchTokenHashPubSub;
 
-/**
- * Updates query suggestions
- */
 export const [updateQuerySuggestions, , getQuerySuggestions] =
   querySuggestionsPubSub;
 
-/**
- * PubSub instance for managing the current search query
- */
 export const queryPubSub = createPubSub(
   new URLSearchParams(self.location.search).get("q") ?? "",
 );
 
 export const [, , getQuery] = queryPubSub;
 
-/**
- * PubSub instance for managing the AI response content
- */
 export const responsePubSub = createPubSub("");
 
-/**
- * Throttled function to update the response content (12 updates per second)
- */
 export const updateResponse = throttle(responsePubSub[0], 1000 / 12);
 export const [, , getResponse] = responsePubSub;
 
-/**
- * PubSub instance for managing the search promise
- */
 export const [updateSearchPromise, , getSearchPromise] = createPubSub<
   Promise<SearchResults>
 >(Promise.resolve({ textResults: [], imageResults: [] }));
 
-/**
- * PubSub instance for managing text generation state
- */
 export const textGenerationStatePubSub =
   createPubSub<TextGenerationState>("idle");
 
-/**
- * Updates the text generation state
- */
 export const [updateTextGenerationState, , getTextGenerationState] =
   textGenerationStatePubSub;
 
@@ -138,19 +102,10 @@ listenToTextGenerationStateChanges((textGenerationState) => {
   addLogEntry(`Text generation state changed to '${textGenerationState}'`);
 });
 
-/**
- * PubSub instance for managing model loading progress
- */
 export const modelLoadingProgressPubSub = createPubSub(0);
 
-/**
- * Updates the model loading progress
- */
 export const [updateModelLoadingProgress] = modelLoadingProgressPubSub;
 
-/**
- * PubSub instance for managing application settings with localStorage persistence
- */
 export const settingsPubSub = createLocalStoragePubSub(
   SETTINGS_STORAGE_KEY,
   defaultSettings,
@@ -158,28 +113,13 @@ export const settingsPubSub = createLocalStoragePubSub(
 
 export const [, listenToSettingsChanges, getSettings] = settingsPubSub;
 
-/**
- * PubSub instance for managing model size in megabytes
- */
 export const modelSizeInMegabytesPubSub = createPubSub(0);
 
-/**
- * Updates the model size in megabytes
- */
 export const [updateModelSizeInMegabytes] = modelSizeInMegabytesPubSub;
 
-/**
- * PubSub instance for managing text search state
- */
 export const textSearchStatePubSub = createPubSub<SearchState>("idle");
-/**
- * PubSub instance for managing image search state
- */
 export const imageSearchStatePubSub = createPubSub<SearchState>("idle");
 
-/**
- * Updates the text search state
- */
 export const [updateTextSearchState] = textSearchStatePubSub;
 
 const [, subscribeToTextSearchState] = textSearchStatePubSub;
@@ -188,9 +128,6 @@ subscribeToTextSearchState((textSearchState) => {
   addLogEntry(`Text search state changed to '${textSearchState}'`);
 });
 
-/**
- * Updates the image search state
- */
 export const [updateImageSearchState] = imageSearchStatePubSub;
 
 const [, subscribeToImageSearchState] = imageSearchStatePubSub;
@@ -199,50 +136,23 @@ subscribeToImageSearchState((imageSearchState) => {
   addLogEntry(`Image search state changed to '${imageSearchState}'`);
 });
 
-/**
- * PubSub instance for managing text search results
- */
 export const textSearchResultsPubSub = createPubSub<TextSearchResults>([]);
 
-/**
- * PubSub instance for managing LLM-generated text search results
- */
 const llmTextSearchResultsPubSub = createPubSub<TextSearchResults>([]);
 
-/**
- * PubSub instance for managing image search results
- */
 export const imageSearchResultsPubSub = createPubSub<ImageSearchResults>([]);
 
-/**
- * Updates text search results
- */
 export const [updateTextSearchResults] = textSearchResultsPubSub;
 
-/**
- * Updates LLM text search results
- */
 export const [updateLlmTextSearchResults, , getLlmTextSearchResults] =
   llmTextSearchResultsPubSub;
 
-/**
- * Updates image search results
- */
 export const [updateImageSearchResults] = imageSearchResultsPubSub;
 
-/**
- * PubSub instance for managing text extracted from result pages
- */
 const pageContentsPubSub = createPubSub<PageContents>({});
 
-/**
- * Updates the text extracted from result pages
- */
 export const [updatePageContents, , getPageContents] = pageContentsPubSub;
 
-/**
- * PubSub instance for managing expanded menu accordions with localStorage persistence
- */
 export const menuExpandedAccordionsPubSub = createLocalStoragePubSub<string[]>(
   "menuExpandedAccordions",
   [],
@@ -259,77 +169,38 @@ export const showFeatureTipsPubSub = createLocalStoragePubSub(
   true,
 );
 
-/**
- * PubSub instance for managing chat input content
- */
 export const chatInputPubSub = createPubSub("");
 
-/**
- * Updates chat input content
- */
 export const [updateChatInput] = chatInputPubSub;
 
-/**
- * PubSub instance for managing chat generation state
- */
 export const chatGenerationStatePubSub = createPubSub({
   isGeneratingResponse: false,
   isGeneratingFollowUpQuestion: false,
 });
 
-/**
- * PubSub instance for managing follow-up questions
- */
 export const followUpQuestionPubSub = createPubSub("");
 
-/**
- * Updates follow-up question
- */
 export const [updateFollowUpQuestion] = followUpQuestionPubSub;
 
-/**
- * PubSub instance for managing conversation summary
- */
 const conversationSummaryPubSub = createPubSub({
   conversationId: "",
   summary: "",
 });
 
-/**
- * Updates conversation summary
- */
 export const [updateConversationSummary, , getConversationSummary] =
   conversationSummaryPubSub;
 
-/**
- * PubSub instance for managing chat messages
- */
 export const chatMessagesPubSub = createPubSub<
   Array<{ role: "user" | "assistant"; content: string }>
 >([]);
 
-/**
- * Updates chat messages
- */
 export const [updateChatMessages] = chatMessagesPubSub;
 
-/**
- * PubSub instance for managing history restoration state
- */
 export const isRestoringFromHistoryPubSub = createPubSub(false);
 
-/**
- * Updates history restoration state
- */
 export const [updateIsRestoringFromHistory] = isRestoringFromHistoryPubSub;
 
-/**
- * PubSub instance for managing follow-up question suppression
- */
 export const suppressNextFollowUpPubSub = createPubSub(false);
 
-/**
- * Updates follow-up question suppression state
- */
 export const [updateSuppressNextFollowUp, , getSuppressNextFollowUp] =
   suppressNextFollowUpPubSub;

--- a/client/modules/querySuggestions.ts
+++ b/client/modules/querySuggestions.ts
@@ -1,10 +1,6 @@
 import { addLogEntry } from "./logEntries";
 import { getQuerySuggestions, updateQuerySuggestions } from "./pubSub";
 
-/**
- * Gets a random query suggestion from the available suggestions
- * @returns Promise<string> - A random query suggestion
- */
 export async function getRandomQuerySuggestion() {
   if (getQuerySuggestions().length === 0) await refillQuerySuggestions(25);
 

--- a/client/modules/search.ts
+++ b/client/modules/search.ts
@@ -4,23 +4,13 @@ import { addLogEntry } from "./logEntries";
 import { getSearchTokenHash } from "./searchTokenHash";
 import type { ImageSearchResults, TextSearchResults } from "./types";
 
-/**
- * Configuration constants for search caching
- */
 const CACHE_CONFIG = {
-  /** Time to live for cache entries in milliseconds */
   TTL: 15 * 60 * 1000,
-  /** Maximum number of entries to cache */
   MAX_ENTRIES: 100,
-  /** Whether caching is enabled */
   ENABLED: true,
-  /** Cache write operations before pruning */
   PRUNE_INTERVAL: 10,
-  /** Metrics logging interval */
   METRICS_LOG_INTERVAL: 10,
-  /** Request timeout in milliseconds */
   REQUEST_TIMEOUT: 30000,
-  /** Maximum query length */
   MAX_QUERY_LENGTH: 2000,
 } as const;
 
@@ -29,17 +19,11 @@ const cacheConfig: {
   maxEntries: number;
   enabled: boolean;
 } = {
-  /** Time to live for cache entries in milliseconds */
   ttl: CACHE_CONFIG.TTL,
-  /** Maximum number of entries to cache */
   maxEntries: CACHE_CONFIG.MAX_ENTRIES,
-  /** Whether caching is enabled */
   enabled: CACHE_CONFIG.ENABLED,
 };
 
-/**
- * Metrics for tracking cache performance
- */
 const cacheMetrics = {
   textHits: 0,
   textMisses: 0,
@@ -48,27 +32,16 @@ const cacheMetrics = {
   totalOperations: 0,
   maxMetricsValue: Number.MAX_SAFE_INTEGER - 1000,
 
-  /**
-   * Calculates the text search cache hit rate
-   * @returns Hit rate as a percentage between 0 and 1
-   */
   getTextHitRate(): number {
     const total = this.textHits + this.textMisses;
     return total > 0 ? this.textHits / total : 0;
   },
 
-  /**
-   * Calculates the image search cache hit rate
-   * @returns Hit rate as a percentage between 0 and 1
-   */
   getImageHitRate(): number {
     const total = this.imageHits + this.imageMisses;
     return total > 0 ? this.imageHits / total : 0;
   },
 
-  /**
-   * Logs current cache performance metrics
-   */
   logPerformance(): void {
     addLogEntry(
       `Cache performance - Text: ${(this.getTextHitRate() * 100).toFixed(1)}% hits, ` +
@@ -76,9 +49,6 @@ const cacheMetrics = {
     );
   },
 
-  /**
-   * Resets all metrics to prevent overflow
-   */
   resetMetrics(): void {
     this.textHits = 0;
     this.textMisses = 0;
@@ -87,16 +57,10 @@ const cacheMetrics = {
     this.totalOperations = 0;
   },
 
-  /**
-   * Increments total operations counter
-   */
   incrementTotalOperations(): void {
     this.totalOperations = this.safeIncrement(this.totalOperations);
   },
 
-  /**
-   * Checks if metrics should be logged and potentially reset
-   */
   shouldLogAndReset(): boolean {
     return (
       this.totalOperations % CACHE_CONFIG.METRICS_LOG_INTERVAL === 0 &&
@@ -104,9 +68,6 @@ const cacheMetrics = {
     );
   },
 
-  /**
-   * Safely increments a metric value, preventing overflow
-   */
   safeIncrement(current: number, increment: number = 1): number {
     const maxValue = this.maxMetricsValue;
     if (current >= maxValue) {
@@ -204,35 +165,19 @@ async function executeCachedSearch<T extends SearchResults>(
   return results;
 }
 
-/**
- * Base interface for search cache entries
- */
 interface SearchCacheEntry {
-  /** Unique key for the cache entry */
   key: string;
-  /** Timestamp when the entry was created */
   timestamp: number;
 }
 
-/**
- * Interface for text search cache entries
- */
 interface TextSearchCache extends SearchCacheEntry {
-  /** Cached text search results */
   results: TextSearchResults;
 }
 
-/**
- * Interface for image search cache entries
- */
 interface ImageSearchCache extends SearchCacheEntry {
-  /** Cached image search results */
   results: ImageSearchResults;
 }
 
-/**
- * IndexedDB database for search cache management
- */
 class SearchCacheDatabase extends Dexie {
   textSearchHistory!: Table<TextSearchCache, string>;
   imageSearchHistory!: Table<ImageSearchCache, string>;
@@ -246,9 +191,6 @@ class SearchCacheDatabase extends Dexie {
     });
   }
 
-  /**
-   * Resets the cache write counter
-   */
   resetCacheWriteCount(): void {
     this._cacheWriteCount = 0;
   }
@@ -414,14 +356,12 @@ const searchService = {
     query: string,
     limit?: number,
   ): Promise<T> {
-    // Validate endpoint type
     if (!["text", "images"].includes(endpoint)) {
       throw new Error(
         `Invalid endpoint type: ${endpoint}. Must be "text" or "images"`,
       );
     }
 
-    // Validate query
     if (!query || query.trim() === "") {
       throw new Error("Query cannot be empty or whitespace only");
     }
@@ -535,19 +475,10 @@ const searchService = {
 
   async clearSearchCache(): Promise<void> {
     try {
-      // Close existing connection before deletion
       await db.close();
-
-      // Delete and recreate database
       await db.delete();
-
-      // Reset cache write counter
       db.resetCacheWriteCount();
-
-      // Reopen database with same schema
       await db.open();
-
-      // Reset metrics
       cacheMetrics.resetMetrics();
 
       addLogEntry("Search cache cleared successfully");
@@ -571,7 +502,6 @@ const searchService = {
   },
 
   updateCacheConfig(newConfig: Partial<typeof cacheConfig>) {
-    // Validate configuration values
     if (newConfig.ttl !== undefined && newConfig.ttl < 0) {
       throw new Error(
         `Invalid TTL value: ${newConfig.ttl}. TTL must be non-negative`,

--- a/client/modules/settings.ts
+++ b/client/modules/settings.ts
@@ -71,18 +71,12 @@ addLogEntry(
   }`,
 );
 
-/**
- * Core inference types that are always available.
- */
 const coreInferenceTypes = [
   { value: "browser", label: "In the browser" },
   { value: "openai", label: "Remote server (OpenAI-compatible API)" },
   { value: "horde", label: "AI Horde" },
 ] as const;
 
-/**
- * Returns the full list of inference types based on runtime server config.
- */
 export function getInferenceTypes(config: ServerConfig) {
   return [
     ...coreInferenceTypes,

--- a/client/modules/shiki.ts
+++ b/client/modules/shiki.ts
@@ -1,9 +1,5 @@
 import { createShikiAdapter } from "@mantine/code-highlight";
 
-/**
- * Loads and configures Shiki syntax highlighter
- * @returns Promise resolving to a configured Shiki highlighter
- */
 async function loadShiki() {
   const { createHighlighter, bundledLanguages } = await import(
     "shiki/bundle/full"
@@ -15,7 +11,5 @@ async function loadShiki() {
   });
 }
 
-/**
- * Mantine adapter for Shiki syntax highlighting
- */
+/** Mantine CodeHighlighter adapter backed by the full bundled Shiki language set. */
 export const shikiAdapter = createShikiAdapter(loadShiki);

--- a/client/modules/sleep.ts
+++ b/client/modules/sleep.ts
@@ -1,18 +1,10 @@
-/**
- * Pauses execution for a specified number of milliseconds
- * @param milliseconds - The number of milliseconds to sleep
- * @returns Promise that resolves after the specified time
- */
+/** Pauses for the given number of milliseconds; 0 yields to the event loop. */
 export async function sleep(milliseconds: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, milliseconds);
   });
 }
 
-/**
- * Yields control to the browser until the next event loop cycle
- * @returns Promise that resolves on the next tick
- */
 export function sleepUntilIdle() {
   return sleep(0);
 }

--- a/client/modules/stringFormatters.ts
+++ b/client/modules/stringFormatters.ts
@@ -1,10 +1,5 @@
 import uFuzzy from "@leeoniya/ufuzzy";
 
-/**
- * Extracts hostname from a URL, removing www. prefix
- * @param url - The URL to extract hostname from
- * @returns The hostname without www. prefix, or the original string if parsing fails
- */
 export function getHostname(url: string) {
   try {
     return new URL(url).hostname.replace("www.", "");
@@ -13,11 +8,6 @@ export function getHostname(url: string) {
   }
 }
 
-/**
- * Converts a date to semantic version format (YYYY.MM.DD)
- * @param date - The date to convert
- * @returns Semantic version string
- */
 export function getSemanticVersion(date: number | string | Date) {
   const targetDate =
     typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
@@ -26,11 +16,6 @@ export function getSemanticVersion(date: number | string | Date) {
   return `${targetDate.getUTCFullYear()}.${targetDate.getUTCMonth() + 1}.${targetDate.getUTCDate()}`;
 }
 
-/**
- * Formats a timestamp as relative time (e.g., "2h ago", "3d ago")
- * @param timestamp - The timestamp to format
- * @returns Relative time string
- */
 export function formatRelativeTime(timestamp: number): string {
   const now = Date.now();
   const diff = now - timestamp;
@@ -58,14 +43,7 @@ const uf = new uFuzzy({
 
 const infoThresh = 1000;
 
-/**
- * Fuzzy search implementation using uFuzzy library
- * @param items - Array of items to search through
- * @param query - Search query string
- * @param extractText - Function to extract searchable text from each item
- * @param limit - Maximum number of results to return
- * @returns Array of items with their search scores
- */
+/** Fuzzy-matches the items with uFuzzy and returns the ranked matches with a 0..1 score. */
 export function searchWithFuzzy<T>(
   items: T[],
   query: string,
@@ -98,11 +76,6 @@ export function searchWithFuzzy<T>(
   }));
 }
 
-/**
- * Groups search results by date categories (Today, Yesterday, This Week, etc.)
- * @param items - Array of items with timestamps to group
- * @returns Object with date group keys as properties and arrays of items as values
- */
 export function groupSearchResultsByDate<T>(
   items: Array<{ item: T; timestamp: number }>,
 ): Record<string, Array<{ item: T; timestamp: number }>> {

--- a/client/modules/systemPrompt.ts
+++ b/client/modules/systemPrompt.ts
@@ -1,10 +1,6 @@
 import { getSettings } from "./pubSub";
 
-/**
- * Generates a system prompt by replacing placeholders with actual values
- * @param searchResults - The search results to inject into the prompt
- * @returns The formatted system prompt with current date and search results
- */
+/** Replaces the `{{searchResults}}` and date placeholders in the configured prompt. */
 export function getSystemPrompt(searchResults: string) {
   const currentDate = new Intl.DateTimeFormat("en-CA", {
     year: "numeric",

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -95,7 +95,6 @@ const inferenceStrategyLoaders: Record<
   },
 };
 
-/** Returns the resolved strategy for the current inference type. */
 async function getCurrentInferenceStrategy(): Promise<InferenceStrategy> {
   const type = getSettings().inferenceType as string;
   const effective: InferenceType =
@@ -103,7 +102,6 @@ async function getCurrentInferenceStrategy(): Promise<InferenceStrategy> {
   return inferenceStrategyLoaders[effective]();
 }
 
-/** Returns true when the effective inference type needs the model-download gate. */
 function needsModelDownloadGate(): boolean {
   const type = getSettings().inferenceType as string;
   return (
@@ -217,9 +215,8 @@ function summarizeDroppedMessages(
 }
 
 /**
- * Initiates a search and generates an AI response for the current query.
- * Updates the document title, clears previous responses, and starts text search.
- * If AI responses are enabled, generates a response using the configured inference type.
+ * Runs the search for the current query and, when AI responses are enabled,
+ * generates an answer with the configured backend after it completes.
  */
 export async function searchAndRespond() {
   if (getQuery() === "") return;
@@ -287,11 +284,6 @@ export async function searchAndRespond() {
   );
 }
 
-/**
- * Generates a chat response using AI for the given messages.
- * @param newMessages - Array of chat messages to generate response for
- * @param onUpdate - Callback function called with partial response updates
- */
 export async function generateChatResponse(
   newMessages: ChatMessage[],
   onUpdate: (partialResponse: string) => void,
@@ -522,9 +514,6 @@ function canDownloadModels(): Promise<void> {
   });
 }
 
-/**
- * Collection of text generation utility functions for external use.
- */
 export const textGenerationFunctions = {
   getCurrentModelName,
   getConversationId,

--- a/client/modules/textGenerationUtilities.ts
+++ b/client/modules/textGenerationUtilities.ts
@@ -10,19 +10,10 @@ import {
 import { getSystemPrompt } from "./systemPrompt";
 import type { ChatMessage } from "./types";
 
-/**
- * Default context size for text generation in tokens
- */
 export const defaultContextSize = 4096;
 
-/**
- * Number of top text search results included in the AI context
- */
 export const searchResultsToConsider = 6;
 
-/**
- * Custom error class for chat generation failures
- */
 export class ChatGenerationError extends Error {
   constructor(message: string) {
     super(message);
@@ -56,9 +47,6 @@ function getPageContentTokenBudget() {
  * Pages are served shortest-first, each taking at most an equal share of what
  * is left, so a single long article cannot crowd out the others and whatever
  * short pages leave unused rolls over to the ones that need it.
- *
- * @param contents - Extracted text per result, in result order; empty strings for results without page content
- * @returns Excerpts in the same order, trimmed to fit
  */
 export function allocatePageExcerpts(
   contents: string[],
@@ -116,10 +104,8 @@ function formatExcerpt(excerpt: string) {
 }
 
 /**
- * Formats search results for inclusion in chat prompts, appending the excerpt
- * read from each page when page content is available for it
- * @param shouldIncludeUrl - Whether to include URLs in the formatted output
- * @returns Formatted search results string
+ * Formats the results for the prompt, appending the excerpt read from each
+ * page when one is available for it.
  */
 export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
   const searchResults = getLlmTextSearchResults();
@@ -147,18 +133,11 @@ export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
     : formattedResults;
 }
 
-/**
- * Waits for search results if they are required before starting response generation
- */
 export async function canStartResponding() {
   updateTextGenerationState("awaitingSearchResults");
   await getSearchPromise();
 }
 
-/**
- * Gets default parameters for streaming chat completion requests
- * @returns Default chat completion parameters
- */
 export function getDefaultChatCompletionCreateParamsStreaming() {
   const settings = getSettings();
   return {

--- a/client/modules/textGenerationWithHorde.ts
+++ b/client/modules/textGenerationWithHorde.ts
@@ -16,77 +16,39 @@ import {
 } from "./textGenerationUtilities";
 import type { ChatMessage } from "./types";
 
-/**
- * Response from AI Horde API
- */
 interface HordeResponse {
-  /** Request ID */
   id: string;
-  /** Kudos cost for the request */
   kudos: number;
 }
 
-/**
- * Status response from AI Horde API
- */
 interface HordeStatusResponse {
-  /** Generated text results */
   generations?: { text: string; model: string }[];
-  /** Whether generation is complete */
   done?: boolean;
-  /** Whether generation failed */
   faulted?: boolean;
-  /** Whether generation is still possible */
   is_possible?: boolean;
 }
 
-/**
- * Model information from AI Horde
- */
 interface HordeModelInfo {
-  /** Model performance rating */
   performance: number;
-  /** Number of queued requests */
   queued: number;
-  /** Number of active jobs */
   jobs: number;
-  /** Estimated time to completion */
   eta: number;
-  /** Model type */
   type: string;
-  /** Model name */
   name: string;
-  /** Number of available instances */
   count: number;
 }
 
-/**
- * User information from AI Horde
- */
 interface HordeUserInfo {
-  /** Username */
   username: string;
-  /** Available kudos */
   kudos: number;
 }
 
-/**
- * Base URL for the public AI Horde API (browser-safe)
- */
 const AI_HORDE_BASE_URL = "https://aihorde.net/api/v2";
 
-/**
- * Client agent identifier for AI Horde API
- */
 const aiHordeClientAgent = `${appName}:${appVersion}:${appRepository}`;
-/**
- * Marker for user messages in chat history */
 const userMarker = "**USER**:";
-/**
- * Marker for assistant messages in chat history */
 const assistantMarker = "**ASSISTANT**:";
 
-// HTTP header constants for consistency
 const HTTP_HEADERS = {
   CONTENT_TYPE: "Content-Type",
   CLIENT_AGENT: "Client-Agent",
@@ -98,6 +60,7 @@ function buildHordeUrl(path: string) {
   return `${AI_HORDE_BASE_URL}${path}`;
 }
 
+/** Anonymous AI Horde API key; the lowest-priority tier when the horde is busy. */
 export const aiHordeDefaultApiKey = "0000000000";
 
 function getEffectiveHordeApiKey(
@@ -363,12 +326,10 @@ async function executeHordeGeneration(
       handleGenerationStatus(
         generation.id,
         (text: string) => {
-          // Atomic check and set to prevent race conditions
           if (!raceState.hasWinner) {
             raceState.winnerId = generation.id;
             raceState.hasWinner = true;
           }
-          // Only update if this generation is the winner
           if (raceState.winnerId === generation.id) {
             onUpdate(text);
           }
@@ -380,8 +341,9 @@ async function executeHordeGeneration(
     const winner = await Promise.race(statusPromises);
 
     await Promise.all(
-      generations.map(async (generation) => {
-        if (generation.id !== winner.generationId) {
+      generations
+        .filter((generation) => generation.id !== winner.generationId)
+        .map((generation) => {
           try {
             generation.ctrl.abort();
           } catch (abortError) {
@@ -389,15 +351,12 @@ async function executeHordeGeneration(
               `Failed to abort generation ${generation.id}: ${abortError}`,
             );
           }
-          try {
-            await cancelGeneration(generation.id);
-          } catch (cancelError) {
+          return cancelGeneration(generation.id).catch((cancelError: Error) => {
             addLogEntry(
               `Failed to cancel generation ${generation.id}: ${cancelError}`,
             );
-          }
-        }
-      }),
+          });
+        }),
     );
 
     return winner.result;

--- a/client/modules/types.ts
+++ b/client/modules/types.ts
@@ -1,19 +1,10 @@
-/**
- * Represents a chat message with role and content
- */
 export type ChatMessage = {
-  /** Role of the message sender */
   role: "system" | "user" | "assistant";
-  /** Content of the message */
   content: string;
 };
-/**
- * Represents a text search result tuple
- */
+
 export type TextSearchResult = [title: string, snippet: string, url: string];
-/**
- * Represents an image search result tuple
- */
+
 export type ImageSearchResult = [
   title: string,
   url: string,
@@ -21,38 +12,20 @@ export type ImageSearchResult = [
   sourceUrl: string,
 ];
 
-/**
- * Array of text search results
- */
 export type TextSearchResults = TextSearchResult[];
-/**
- * Array of image search results
- */
+
 export type ImageSearchResults = ImageSearchResult[];
 
-/**
- * Text extracted from result pages, keyed by the URL it was read from
- */
+/** Text extracted from result pages, keyed by the URL it was read from. */
 export type PageContents = Record<string, string>;
 
-/**
- * Possible states for search operations
- */
 export type SearchState = "idle" | "running" | "failed" | "completed";
 
-/**
- * Combined search results containing both text and image results
- */
 export type SearchResults = {
-  /** Array of text search results */
   textResults: TextSearchResult[];
-  /** Array of image search results */
   imageResults: ImageSearchResult[];
 };
 
-/**
- * Possible states for text generation operations
- */
 export type TextGenerationState =
   | "idle"
   | "awaitingModelDownloadAllowance"

--- a/server/cacheServerHook.ts
+++ b/server/cacheServerHook.ts
@@ -1,9 +1,6 @@
 import type { PreviewServer, ViteDevServer } from "vite";
 
-/**
- * Vite server hook for configuring cache control headers
- * @param server - Vite dev server or preview server instance
- */
+/** Cache-Control per asset class: immutable for hashed assets, no-cache for HTML. */
 export function cacheServerHook<T extends ViteDevServer | PreviewServer>(
   server: T,
 ) {

--- a/server/compressionServerHook.ts
+++ b/server/compressionServerHook.ts
@@ -1,10 +1,7 @@
 import compression from "http-compression";
 import type { PreviewServer, ViteDevServer } from "vite";
 
-/**
- * Vite server hook for enabling HTTP compression
- * @param server - Vite dev server or preview server instance
- */
+/** Enables gzip/brotli compression on all responses. */
 export function compressionServerHook<T extends ViteDevServer | PreviewServer>(
   server: T,
 ) {

--- a/server/handleTokenVerification.ts
+++ b/server/handleTokenVerification.ts
@@ -1,7 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { verifyTokenAndRateLimit } from "./verifyTokenAndRateLimit.ts";
 
-/** Handles token verification and sends appropriate error responses if needed. */
 export async function handleTokenVerification(
   token: string | null,
   response: ServerResponse,

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -30,36 +30,18 @@ const chatCompletionRequestSchema = z.object({
   max_tokens: z.number().optional(),
 });
 
-/**
- * Chat completion chunk for streaming responses
- */
 interface ChatCompletionChunk {
-  /** Chunk ID */
   id: string;
-  /** Object type */
   object: string;
-  /** Creation timestamp */
   created: number;
-  /** Model name */
   model?: string;
-  /** Array of choices */
   choices: Array<{
-    /** Choice index */
     index: number;
-    /** Delta content */
     delta: { content?: string };
-    /** Finish reason */
     finish_reason: string | null;
   }>;
 }
 
-/**
- * Creates a chat completion chunk payload
- * @param model - Model name
- * @param content - Chunk content
- * @param finish_reason - Finish reason
- * @returns Chat completion chunk
- */
 function createChunkPayload(
   model: string,
   content?: string,
@@ -131,6 +113,7 @@ function hasJsonContentType(request: IncomingMessage): boolean {
   return contentType.toLowerCase().includes("application/json");
 }
 
+/** Self-hosted `/inference` endpoint: streams an OpenAI-compatible chat completion from the internal API, retrying across models. */
 export function internalApiEndpointServerHook<
   T extends ViteDevServer | PreviewServer,
 >(server: T) {

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -124,11 +124,8 @@ async function handleRanking(
 }
 
 /**
- * Sets up search endpoint middleware for the Vite server.
- * Handles both text and image search requests with token verification, result ranking, and thumbnail processing.
- *
- * @param server - The Vite dev server or preview server instance
- * @returns void - Modifies the server middleware in place
+ * Serves `/search/text` and `/search/images`: verified requests go through
+ * SearXNG, with reranking, score filtering, and thumbnail data-URLs.
  */
 export function searchEndpointServerHook<
   T extends ViteDevServer | PreviewServer,

--- a/server/searchToken.ts
+++ b/server/searchToken.ts
@@ -3,26 +3,16 @@ import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import temporaryDirectory from "temp-dir";
 
-/**
- * Gets the file path for the search token storage
- * @returns Full path to the token file
- */
 function getSearchTokenFilePath() {
   return path.resolve(temporaryDirectory, "minisearch-token");
 }
 
-/**
- * Gets the current search token, generating one if it doesn't exist
- * @returns The search token string
- */
+/** The shared search token, generated on first use and kept across restarts with 0600 permissions. */
 export const getSearchToken = () => {
   if (!existsSync(getSearchTokenFilePath())) regenerateSearchToken();
   return readFileSync(getSearchTokenFilePath(), "utf8");
 };
 
-/**
- * Generates and saves a new search token
- */
 export function regenerateSearchToken() {
   const filePath = getSearchTokenFilePath();
   const newToken = randomBytes(32).toString("hex");

--- a/server/searchesSinceLastRestart.ts
+++ b/server/searchesSinceLastRestart.ts
@@ -1,38 +1,19 @@
-/**
- * Counter for textual searches since server restart
- */
 let textualSearchesSinceLastRestart = 0;
-/**
- * Counter for graphical searches since server restart
- */
 let graphicalSearchesSinceLastRestart = 0;
 
-/**
- * Gets the number of textual searches since last restart
- * @returns Number of textual searches
- */
+/** Textual searches since the last restart; the counter stands in for a log line and the query is never recorded. */
 export function getTextualSearchesSinceLastRestart() {
   return textualSearchesSinceLastRestart;
 }
 
-/**
- * Increments the textual search counter
- */
 export function incrementTextualSearchesSinceLastRestart() {
   textualSearchesSinceLastRestart++;
 }
 
-/**
- * Gets the number of graphical searches since last restart
- * @returns Number of graphical searches
- */
 export function getGraphicalSearchesSinceLastRestart() {
   return graphicalSearchesSinceLastRestart;
 }
 
-/**
- * Increments the graphical search counter
- */
 export function incrementGraphicalSearchesSinceLastRestart() {
   graphicalSearchesSinceLastRestart++;
 }
@@ -41,41 +22,21 @@ export function incrementGraphicalSearchesSinceLastRestart() {
 // carry the query text: how often either case happens is what anyone acts on,
 // and that survives without recording what was searched for.
 
-/**
- * Counter for searches SearXNG answered with zero results
- */
 let searchesWithoutResultsSinceLastRestart = 0;
-/**
- * Counter for searches whose results were all dropped during processing
- */
 let searchesWithAllResultsDiscardedSinceLastRestart = 0;
 
-/**
- * Gets the number of searches SearXNG answered with zero results
- * @returns Number of empty searches
- */
 export function getSearchesWithoutResultsSinceLastRestart() {
   return searchesWithoutResultsSinceLastRestart;
 }
 
-/**
- * Increments the empty-search counter
- */
 export function incrementSearchesWithoutResultsSinceLastRestart() {
   searchesWithoutResultsSinceLastRestart++;
 }
 
-/**
- * Gets the number of searches whose results were all dropped during processing
- * @returns Number of fully discarded searches
- */
 export function getSearchesWithAllResultsDiscardedSinceLastRestart() {
   return searchesWithAllResultsDiscardedSinceLastRestart;
 }
 
-/**
- * Increments the fully-discarded-search counter
- */
 export function incrementSearchesWithAllResultsDiscardedSinceLastRestart() {
   searchesWithAllResultsDiscardedSinceLastRestart++;
 }

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -11,15 +11,9 @@ import {
 import { getVerifiedTokensAmount } from "./verifiedTokens.ts";
 import { getWebSearchStatus } from "./webSearchService.ts";
 
-/**
- * Server start time for uptime calculation
- */
 const serverStartTime = Date.now();
 
-/**
- * Vite server hook for providing status endpoint
- * @param server - Vite dev server or preview server instance
- */
+/** Serves `/status`: uptime, search counters, and the health of the reranker and SearXNG. */
 export function statusEndpointServerHook<
   T extends ViteDevServer | PreviewServer,
 >(server: T) {
@@ -42,6 +36,18 @@ export function statusEndpointServerHook<
       ? "healthy"
       : "unhealthy";
 
+    // `vite.config.ts` sets this define with `JSON.stringify`, so in a Vite
+    // build it is always a valid JSON string literal; the guard only fires if
+    // a non-Vite consumer sets it to something malformed.
+    let gitCommit: string;
+    try {
+      gitCommit = JSON.parse(
+        server.config.define?.VITE_COMMIT_SHORT_HASH || '""',
+      );
+    } catch {
+      throw new Error("Malformed VITE_COMMIT_SHORT_HASH build define");
+    }
+
     const status = {
       uptime: prettyMilliseconds(Date.now() - serverStartTime, {
         verbose: true,
@@ -61,9 +67,7 @@ export function statusEndpointServerHook<
         timestamp: new Date(
           server.config.define?.VITE_BUILD_DATE_TIME || "",
         ).toISOString(),
-        gitCommit: JSON.parse(
-          server.config.define?.VITE_COMMIT_SHORT_HASH || '""',
-        ),
+        gitCommit,
       },
     };
 

--- a/server/utils/circuitBreaker.ts
+++ b/server/utils/circuitBreaker.ts
@@ -27,12 +27,7 @@ export class CircuitBreaker {
     this.options = { ...defaultOptions, ...options };
   }
 
-  /**
-   * Execute a function with circuit breaker protection
-   * @param key - Unique identifier for the circuit (e.g., model name)
-   * @param fn - Function to execute
-   * @returns Promise that resolves with the function result or rejects with an error
-   */
+  /** Runs `fn` under the named circuit, tripping it after repeated failures. */
   async execute<T>(key: string, fn: () => Promise<T>): Promise<T> {
     const metrics = this.getOrCreateMetrics(key);
 
@@ -54,11 +49,6 @@ export class CircuitBreaker {
     }
   }
 
-  /**
-   * Get the current state of a circuit
-   * @param key - Circuit identifier
-   * @returns Current circuit state
-   */
   getState(key: string): CircuitState {
     return this.metrics.get(key)?.state || "CLOSED";
   }

--- a/server/utils/streamUtils.ts
+++ b/server/utils/streamUtils.ts
@@ -5,10 +5,6 @@ import type { ServerResponse } from "node:http";
  * upstream must not be able to pin the server's memory, and callers that only
  * need the head of a document (page text, thumbnails) gain nothing from the
  * tail anyway.
- *
- * @param response - The response whose body should be read
- * @param maxBytes - Upper bound on how many bytes to read
- * @returns The bytes read, and whether the body was truncated by the cap
  */
 export async function readCappedBytes(
   response: Response,
@@ -48,13 +44,7 @@ export async function readCappedBytes(
   return { bytes, truncated: !reachedEnd };
 }
 
-/**
- * Calculate backoff time with exponential jitter
- * @param attempt - Current attempt number (1-based)
- * @param baseDelayMs - Base delay in milliseconds (default: 100ms)
- * @param maxDelayMs - Maximum delay in milliseconds (default: 5000ms)
- * @returns Calculated delay in milliseconds
- */
+/** Calculates the backoff delay for a retry attempt, with jitter. */
 export function calculateBackoffTime(
   attempt: number,
   baseDelayMs = 100,
@@ -64,21 +54,10 @@ export function calculateBackoffTime(
   return delay * (0.7 + Math.random() * 0.3);
 }
 
-/**
- * Check if a response is still writable
- * @param response - The HTTP response object
- * @returns boolean indicating if the response can still be written to
- */
 export function isResponseWritable(response: ServerResponse): boolean {
   return !response.writableEnded && !response.destroyed;
 }
 
-/**
- * Safely write to a response stream
- * @param response - The HTTP response object
- * @param data - Data to write
- * @returns boolean indicating if the write was successful
- */
 export function safeWriteResponse(
   response: ServerResponse,
   data: string,
@@ -93,11 +72,6 @@ export function safeWriteResponse(
   }
 }
 
-/**
- * Safely end a response
- * @param response - The HTTP response object
- * @param data - Optional data to write before ending
- */
 export function safeEndResponse(response: ServerResponse, data?: string): void {
   if (response.writableEnded || response.destroyed) return;
 

--- a/server/validateAccessKeyServerHook.ts
+++ b/server/validateAccessKeyServerHook.ts
@@ -1,10 +1,7 @@
 import { argon2Verify } from "hash-wasm";
 import type { PreviewServer, ViteDevServer } from "vite";
 
-/**
- * Vite server hook for validating access keys
- * @param server - Vite dev server or preview server instance
- */
+/** POST /api/validate-access-key: checks an argon2id hash against the configured `ACCESS_KEYS`. */
 export function validateAccessKeyServerHook<
   T extends ViteDevServer | PreviewServer,
 >(server: T) {


### PR DESCRIPTION
## Description
The codebase carried a lot of mechanical TSDoc (name-restating blocks like "Props for the X component" or "PubSub instance for managing Y") and inline comments that just narrate the code.

This PR does 4 things:

- Removes redundant inline comments and mechanical TSDoc (42 files, -735/+69 lines).
- Trims the TSDoc blocks that have substance, keeping the behavior contracts, the security/privacy rationale and the non-obvious algorithms, and dropping the boilerplate `@param`/`@returns` tags.
- Adds one concise TSDoc per public API where the cleanup left a file undocumented (the architectural linter requires at least one TSDoc per exported file).
- Two small code fixes: the `JSON.parse` of the `VITE_COMMIT_SHORT_HASH` define in `server/statusEndpointServerHook.ts` now throws an explicit error if a non-Vite consumer sets it to something malformed (vite always `JSON.stringify`s it), and the AI Horde race cleanup in `client/modules/textGenerationWithHorde.ts` became a `filter().map()` so every callback path returns (same concurrency).

Note: all the "why" comments (IME composition guards, the outage-vs-empty-results distinction, the SSRF guards, the token-budget algorithm) stay.

## How to test
1. Run `npm run lint` (biome, tsc x3, knip, jscpd, architectural linter, doc gates). It's green.
2. Run `npm test`. All 633 tests pass.
