### PR TITLE
fix(ai-response): show the model size while it downloads

### DIFF
--- a/client/components/AiResponse/LoadingModelContent.test.tsx
+++ b/client/components/AiResponse/LoadingModelContent.test.tsx
@@ -1,0 +1,31 @@
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import LoadingModelContent from "./LoadingModelContent";
+
+function renderContent(props: {
+  modelLoadingProgress: number;
+  modelSizeInMegabytes: number;
+}) {
+  return render(
+    <MantineProvider>
+      <LoadingModelContent {...props} />
+    </MantineProvider>,
+  );
+}
+
+describe("LoadingModelContent", () => {
+  it("omits the size while it is still unknown, keeping the percentage", () => {
+    renderContent({ modelLoadingProgress: 70, modelSizeInMegabytes: 0 });
+
+    expect(screen.queryByText(/MB/)).not.toBeInTheDocument();
+    expect(screen.getByText("70.0%")).toBeInTheDocument();
+  });
+
+  it("shows how much of the model was downloaded once the size is known", () => {
+    renderContent({ modelLoadingProgress: 70, modelSizeInMegabytes: 250 });
+
+    expect(screen.getByText("175 MB / 250 MB")).toBeInTheDocument();
+    expect(screen.getByText("70.0%")).toBeInTheDocument();
+  });
+});

--- a/client/components/AiResponse/LoadingModelContent.tsx
+++ b/client/components/AiResponse/LoadingModelContent.tsx
@@ -12,6 +12,7 @@ export default function LoadingModelContent({
   const percent =
     isLoadingComplete || isLoadingStarting ? 100 : modelLoadingProgress;
   const strokeColor = percent === 100 ? "#52c41a" : "#3385ff";
+  const isModelSizeKnown = modelSizeInMegabytes > 0;
   const downloadedSize = (modelSizeInMegabytes * modelLoadingProgress) / 100;
   const sizeText = `${downloadedSize.toFixed(0)} MB / ${modelSizeInMegabytes.toFixed(0)} MB`;
 
@@ -24,11 +25,13 @@ export default function LoadingModelContent({
         <Stack gap="xs">
           <Progress color={strokeColor} value={percent} animated />
           {!isLoadingStarting && (
-            <Group justify="space-between">
-              <Text size="sm" c="dimmed">
-                {sizeText}
-              </Text>
-              <Text size="sm" c="dimmed">
+            <Group>
+              {isModelSizeKnown && (
+                <Text size="sm" c="dimmed">
+                  {sizeText}
+                </Text>
+              )}
+              <Text size="sm" c="dimmed" ml="auto">
                 {percent.toFixed(1)}%
               </Text>
             </Group>

--- a/client/modules/textGenerationWithWllama.test.ts
+++ b/client/modules/textGenerationWithWllama.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  updateModelLoadingProgress,
+  updateModelSizeInMegabytes,
+} from "./pubSub";
+import { generateTextWithWllama } from "./textGenerationWithWllama";
+import { initializeWllama } from "./wllama";
+
+vi.mock("./logEntries", () => ({ addLogEntry: vi.fn() }));
+
+vi.mock("./pubSub", () => ({
+  getQuery: vi.fn().mockReturnValue("what is a cave?"),
+  getSettings: vi.fn().mockReturnValue({
+    enableAiResponse: true,
+    wllamaModelId: "test-model",
+    cpuThreads: 1,
+  }),
+  getTextGenerationState: vi.fn().mockReturnValue("generating"),
+  updateModelLoadingProgress: vi.fn(),
+  updateModelSizeInMegabytes: vi.fn(),
+  updateResponse: vi.fn(),
+  updateTextGenerationState: vi.fn(),
+}));
+
+vi.mock("./systemPrompt", () => ({
+  getSystemPrompt: vi.fn().mockReturnValue("system"),
+}));
+
+vi.mock("./textGenerationUtilities", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./textGenerationUtilities")>();
+  return {
+    ...actual,
+    canStartResponding: vi.fn().mockResolvedValue(undefined),
+    getFormattedSearchResults: vi.fn().mockReturnValue("None."),
+  };
+});
+
+vi.mock("./webGpu", () => ({ isWebGPUAvailable: false }));
+
+const megabyte = 1024 * 1024;
+
+vi.mock("./wllama", () => ({
+  initializeWllama: vi.fn(),
+  wllamaModels: {
+    "test-model": {
+      label: "Test Model",
+      hfRepoId: "repo",
+      hfFilePath: "model.gguf",
+      contextSize: 512,
+      // Deliberately different from the size the download reports, so the
+      // assertions can tell the estimate apart from the measured size.
+      fileSizeInMegabytes: 999,
+      shouldIncludeUrlsOnPrompt: false,
+      getSampling: () => ({}),
+    },
+  },
+}));
+
+async function* singleChunkStream() {
+  yield { choices: [{ delta: { content: "Hello" } }] };
+}
+
+/** Drives the download progress callback wllama would call while fetching. */
+function mockDownload(steps: { loaded: number; total: number }[]) {
+  vi.mocked(initializeWllama).mockImplementation(
+    async (_repoId, _filePath, config) => {
+      for (const step of steps) config?.model?.progressCallback?.(step);
+      return {
+        createChatCompletion: vi.fn().mockResolvedValue(singleChunkStream()),
+        exit: vi.fn().mockResolvedValue(undefined),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal Wllama stub
+      } as any;
+    },
+  );
+}
+
+describe("generateTextWithWllama", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the downloaded size alongside every progress update", async () => {
+    mockDownload([
+      { loaded: 50 * megabyte, total: 250 * megabyte },
+      { loaded: 175 * megabyte, total: 250 * megabyte },
+    ]);
+
+    await generateTextWithWllama();
+
+    expect(updateModelLoadingProgress).toHaveBeenCalledTimes(2);
+    expect(updateModelLoadingProgress).toHaveBeenLastCalledWith(70);
+    expect(vi.mocked(updateModelSizeInMegabytes).mock.calls).toEqual([
+      [999], // catalog estimate, published before the download starts
+      [250], // measured size, republished with each progress update
+      [250],
+    ]);
+  });
+
+  it("keeps the last known size when the total is not available yet", async () => {
+    mockDownload([{ loaded: 0, total: 0 }]);
+
+    await generateTextWithWllama();
+
+    expect(updateModelLoadingProgress).not.toHaveBeenCalled();
+    expect(updateModelSizeInMegabytes).not.toHaveBeenCalledWith(0);
+  });
+});

--- a/client/modules/textGenerationWithWllama.ts
+++ b/client/modules/textGenerationWithWllama.ts
@@ -94,9 +94,13 @@ async function generateWithWllama({
   try {
     const progressCallback: ProgressCallback | undefined = shouldCheckCanRespond
       ? ({ loaded, total }) => {
+          if (total <= 0) return;
           const progressPercentage = Math.round((loaded / total) * 100);
           if (loadingPercentage !== progressPercentage) {
             loadingPercentage = progressPercentage;
+            // Republished on every step so the size is never missed by a
+            // subscriber that mounted after the initial estimate.
+            updateModelSizeInMegabytes(total / 1024 / 1024);
             updateModelLoadingProgress(progressPercentage);
           }
         }

--- a/client/modules/wllama.ts
+++ b/client/modules/wllama.ts
@@ -134,12 +134,7 @@ const createDefaultModelConfig = (): Omit<
   flash_attn: true,
   contextSize: defaultContextSize,
   shouldIncludeUrlsOnPrompt: true,
-  getSampling: () => ({
-    samplers: "top_k;temperature",
-    temperature: 0.35,
-    dynatemp_range: 0.15,
-    top_k: 40,
-  }),
+  getSampling: () => ({}),
 });
 
 export const wllamaModels: Readonly<Record<string, WllamaModel>> = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mantine/hooks": "^9.0.0",
         "@mantine/notifications": "^9.0.0",
         "@tabler/icons-react": "^3.16.0",
-        "@wllama/wllama": "^3.1.0",
+        "@wllama/wllama": "^3.6.0",
         "ai": "^7.0.0",
         "country-flag-icons": "^1.5.13",
         "create-pubsub": "^1.6.3",
@@ -2775,9 +2775,9 @@
       }
     },
     "node_modules/@wllama/wllama": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@wllama/wllama/-/wllama-3.5.1.tgz",
-      "integrity": "sha512-m5L0KKtmUTKz5lGvVVa/Y3qRtoobu80Jne51U0CSR6O930aOUURzhMEAolNsN4v0kfQ9u58wi2IdpUicLfaXUw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@wllama/wllama/-/wllama-3.6.0.tgz",
+      "integrity": "sha512-NN3ZBXqaaUwGXTQubkNvsCaLPjN2XVa0bVS40OYCE8zquYmRc2W3oHYEgwvuSWWDB8aUqTLyMioySCXNkcnD1w==",
       "license": "MIT"
     },
     "node_modules/@workflow/serde": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@mantine/hooks": "^9.0.0",
     "@mantine/notifications": "^9.0.0",
     "@tabler/icons-react": "^3.16.0",
-    "@wllama/wllama": "^3.1.0",
+    "@wllama/wllama": "^3.6.0",
     "ai": "^7.0.0",
     "country-flag-icons": "^1.5.13",
     "create-pubsub": "^1.6.3",


### PR DESCRIPTION
## Description

Currently, the first time the in-browser model loads, the loading card can show "0 MB / 0 MB" while the percentage keeps going up.

The size is published once per run, right before the download starts. `AiResponseSection` is lazy-loaded, so on a first load it can mount after that single publish, and `usePubSub` only subscribes on the effect that runs after the first render. When the publish lands in that window, the component keeps the initial `0`. The percentage recovers because `modelLoadingProgress` publishes continuously, which is why only the size was stuck.

This PR does two things:

- Republishes the size on every progress step. The download callback already reports the real total in bytes (summed across shards), so a subscriber that mounts late picks it up on the next update, and the number shown is the measured size instead of the estimate from the model catalog.
- Hides the size text in `LoadingModelContent` until the size is known, so it can never render "0 MB / 0 MB" again.

## How to test

1. Run `npm run test` (there are new tests for the loading card and for the progress callback).
2. Open the app with no model cached (clear the site data if needed), enable the AI response with the browser inference, and search for something.
3. While "Loading AI..." is on screen, check that the size shows up next to the percentage, and never as "0 MB / 0 MB".

Verified on the browser with a first-time download.

## Screenshots

_To be added._
