### PR TITLE
fix(deps): downgrade html-to-text to v9 to remove vulnerable deepmerge-ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "gpt-tokenizer": "^3.0.0",
         "hash-wasm": "^4.11.0",
         "helper-git-hash": "^1.0.0",
-        "html-to-text": "^10.0.0",
+        "html-to-text": "^9.0.5",
         "http-compression": "^1.0.20",
         "keyword-extractor": "^0.3.0",
         "node-emoji": "^2.1.3",
@@ -1852,19 +1852,16 @@
       "license": "MIT"
     },
     "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz",
-      "integrity": "sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "~2.3.0",
-        "domhandler": "~5.0.3"
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/KillyMXI"
-      },
-      "peerDependencies": {
-        "selderee": "~0.12.0"
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@shikijs/core": {
@@ -3214,13 +3211,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "license": "BSD-3-Clause",
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/default-browser": {
@@ -3916,22 +3913,19 @@
       "license": "MIT"
     },
     "node_modules/html-to-text": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
-      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
       "license": "MIT",
       "dependencies": {
-        "@selderee/plugin-htmlparser2": "~0.12.0",
-        "deepmerge-ts": "^7.1.5",
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
         "dom-serializer": "^2.0.0",
-        "htmlparser2": "^10.1.0",
-        "selderee": "~0.12.0"
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
       },
       "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/KillyMXI"
+        "node": ">=14"
       }
     },
     "node_modules/html-url-attributes": {
@@ -3955,9 +3949,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -3969,20 +3963,8 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-compression": {
@@ -4490,12 +4472,12 @@
       }
     },
     "node_modules/leac": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/leac/-/leac-0.7.0.tgz",
-      "integrity": "sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/KillyMXI"
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/less": {
@@ -6093,16 +6075,16 @@
       }
     },
     "node_modules/parseley": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.13.1.tgz",
-      "integrity": "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
       "license": "MIT",
       "dependencies": {
-        "leac": "^0.7.0",
-        "peberminta": "^0.10.0"
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/KillyMXI"
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/pathe": {
@@ -6113,12 +6095,12 @@
       "license": "MIT"
     },
     "node_modules/peberminta": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.10.0.tgz",
-      "integrity": "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/KillyMXI"
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -6932,15 +6914,15 @@
       "license": "MIT"
     },
     "node_modules/selderee": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
-      "integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
       "license": "MIT",
       "dependencies": {
-        "parseley": "~0.13.1"
+        "parseley": "^0.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/KillyMXI"
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gpt-tokenizer": "^3.0.0",
     "hash-wasm": "^4.11.0",
     "helper-git-hash": "^1.0.0",
-    "html-to-text": "^10.0.0",
+    "html-to-text": "^9.0.5",
     "http-compression": "^1.0.20",
     "keyword-extractor": "^0.3.0",
     "node-emoji": "^2.1.3",


### PR DESCRIPTION
## Root cause

`html-to-text@10.0.0` pulled in `deepmerge-ts@^7.1.5`, which has a stack-exhaustion DoS when merging recursive object graphs (CVE unassigned, GitHub advisory #35). The patched version is `8.0.0`, but `deepmerge-ts@8.0.1` was published only 2 days ago and is still subject to npm's 3-day new-package hold, so `npm install` refuses to resolve it right now.

## Fix

Downgraded `html-to-text` from `^10.0.0` to `^9.0.5`. Version 9 uses the unrelated `deepmerge@4` package (not `deepmerge-ts`), so the vulnerable package is removed from the tree entirely.

## Verification

- `npm audit` → 0 vulnerabilities
- `tsc --noEmit` → clean
- `npm run test` → 640 passed / 58 files
- `npm ls deepmerge-ts` → empty (no longer in the tree)

No source code changes — the `convert` API is compatible between v9 and v10.