### PR TITLE
fix(security): pin deepmerge-ts to 8.0.1 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3215,9 +3215,19 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "deepmerge-ts": "^8.0.1"
   }
 }


### PR DESCRIPTION
## Description

`html-to-text@10.0.0` pulls in `deepmerge-ts@^7.1.5`, the only path by which the vulnerable package reaches the tree. `deepmerge-ts` below `8.0.0` has a stack-exhaustion DoS when merging recursive object graphs (see [security/dependabot/35](https://github.com/felladrin/MiniSearch/security/dependabot/35)).

This PR pins `deepmerge-ts` to `^8.0.1` via an npm `overrides` entry, keeping `html-to-text` on v10 instead of downgrading it. The runtime API `html-to-text` uses (`deepmergeCustom`) is unchanged in 8.x, and the override sits alongside the existing `adm-zip` entry.

One decision worth a look: why `overrides` and not a downgrade of `html-to-text` to v9 (which uses `deepmerge@4`). A downgrade silently regresses a direct dependency and has no upgrade path back; the override is one line, stays on the current major, and can be dropped once `html-to-text` bumps its range to `^8`.

## How to test

1. `npm install` then `npm ls deepmerge-ts` — shows `8.0.1` under `html-to-text@10.0.0`.
2. `npm audit` — 0 vulnerabilities.
3. `npm test` — 640 tests pass, no behavior change.
4. Typecheck: `npx tsc --noEmit` is clean.
5. Live check: `npm run dev`, then call `/page-content` with a search query and a real page URL. Verified on the dev server: a Wikipedia article came back with ~6k characters of extracted text through the `deepmerge-ts@8.0.1` merge path.
