### PR TITLE
feat: report inference outcomes on /status

### DIFF
--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -165,6 +165,11 @@ Content-Type: application/json
 
 The token is passed as a URL query parameter (`?token=`), verified server-side with Argon2 against the build-time `VITE_SEARCH_TOKEN`, not as an `Authorization: Bearer` header. The model field is optional; if `INTERNAL_OPENAI_COMPATIBLE_API_MODEL` is unset, the server fetches and randomly selects from the upstream's available models.
 
+**Observability:** what happens to these requests is counted on `/status`
+under `inference`: how many answers finished, how many failed before or after
+the first token, how many models were tried, and which model ids failed. See
+the `/status` section of `docs/overview.md` for the field reference.
+
 **Features:**
 - Private data stays in your infrastructure
 - Custom model selection

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -308,26 +308,34 @@ answer are about the upstream and about the wait, not about what was asked:
 | `streamed` | number | Answers that finished normally |
 | `streamedRate` | number | `streamed` as a percentage of `requests` |
 | `averageTimeToFirstTokenMs` | number | The wait the user actually feels, over the answers that produced a token |
-| `averageDurationMs` | number | Whole-request duration, failures included |
-| `averageAttempts` | number | Models tried per request; above 1 means the pool is carrying failures |
+| `averageDurationMs` | number | Whole-request duration over every outcome, so a 2 ms rejected body and a 25 s answer land in the same average |
+| `averageAttempts` | number | Models tried, over the requests that reached the model loop; above 1 means the pool is carrying failures |
 | `modelFallbacks` | number | Times a retry moved to another model |
 | `modelsRefetched` | number | Times the model pool was re-listed mid-retry |
 | `streamsEndedWithoutFinish` | number | Attempts whose stream closed with no finish part, counted per attempt because the retry can still succeed |
 | `failed.failedBeforeFirstToken` | number | Every model failed before a token was sent, answered 503 |
 | `failed.failedMidStream` | number | The answer broke after content was already sent, so no retry was possible |
-| `failed.abandoned` | number | The client went away mid-answer; the only outcome with no response to observe it by |
+| `failed.abandoned` | number | The client was gone before or during the answer; the only outcome with no response to observe it by |
 | `failed.badRequest` | number | Body too large, unparsable, or failing the schema |
 | `failed.notConfigured` | number | `INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL` or its key is missing |
 | `failed.modelListUnavailable` | number | The upstream's model list could not be fetched |
 | `failed.noModelAvailable` | number | The list was fetched and held nothing usable |
 | `failed.internalError` | number | Anything the handler did not expect |
 | `failed.unclassified` | number | Should always be zero; a non-zero value means a path stopped reporting its outcome |
-| `byModel` | object | `attempted`, `streamed` and `failed` per model id, which is how a dead member of the pool becomes visible |
+| `byModel` | object | `attempted`, `streamed`, `failed` and `abandoned` per model id, which is how a dead member of the pool becomes visible. `attempted` equals the other three added up |
 
 `streamed` plus every `failed` entry sums to `requests`. A request refused at
 token verification is not counted here, since `authorization` above already
 counts it, and one refused for its method or its content type is answered
-before either counter is reached.
+before either counter is reached. So `inference.requests` should equal
+`authorization.bySurface.inference.authorized`, and a gap between the two is a
+request that never finished at all.
+
+Two fields read differently on a single-model deployment. With
+`INTERNAL_OPENAI_COMPATIBLE_API_MODEL` set there is no pool to fall back to, so
+the loop stops after the first failure: `averageAttempts` cannot exceed 1 and
+`modelFallbacks` stays at 0 however badly the upstream behaves. Read
+`failed.failedBeforeFirstToken` for that case instead.
 
 Model ids are configuration rather than user data, and `/inference` already
 sends the id to the browser in every chunk, so naming them here publishes

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -232,6 +232,7 @@ The `/status` endpoint returns a JSON object:
 | `webSearchServiceStatus` | string | `"healthy"` or `"unhealthy"` |
 | `pageReads` | object | Page-reading counters since last restart, see below |
 | `authorization` | object | Token and rate-limit outcomes since last restart, see below |
+| `inference` | object | AI answer counters since last restart, see below |
 | `build.timestamp` | string | ISO 8601 build time |
 | `build.gitCommit` | string | Short Git commit hash |
 
@@ -296,6 +297,41 @@ by surface, both properties of the request rather than of whoever sent it.
 a single user action fans out into a text search, an image search and a
 page-content read, so its `authorized` side says where the budget goes and its
 `rejected` side says who pays for it running out.
+
+`inference` reports what happened to the AI answers served through
+`/inference`. Nothing about the conversation is kept, so the questions it can
+answer are about the upstream and about the wait, not about what was asked:
+
+| Field | Type | Says |
+|---|---|---|
+| `requests` | number | Requests that passed token verification; the denominator for the rest |
+| `streamed` | number | Answers that finished normally |
+| `streamedRate` | number | `streamed` as a percentage of `requests` |
+| `averageTimeToFirstTokenMs` | number | The wait the user actually feels, over the answers that produced a token |
+| `averageDurationMs` | number | Whole-request duration, failures included |
+| `averageAttempts` | number | Models tried per request; above 1 means the pool is carrying failures |
+| `modelFallbacks` | number | Times a retry moved to another model |
+| `modelsRefetched` | number | Times the model pool was re-listed mid-retry |
+| `streamsEndedWithoutFinish` | number | Attempts whose stream closed with no finish part, counted per attempt because the retry can still succeed |
+| `failed.failedBeforeFirstToken` | number | Every model failed before a token was sent, answered 503 |
+| `failed.failedMidStream` | number | The answer broke after content was already sent, so no retry was possible |
+| `failed.abandoned` | number | The client went away mid-answer; the only outcome with no response to observe it by |
+| `failed.badRequest` | number | Body too large, unparsable, or failing the schema |
+| `failed.notConfigured` | number | `INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL` or its key is missing |
+| `failed.modelListUnavailable` | number | The upstream's model list could not be fetched |
+| `failed.noModelAvailable` | number | The list was fetched and held nothing usable |
+| `failed.internalError` | number | Anything the handler did not expect |
+| `failed.unclassified` | number | Should always be zero; a non-zero value means a path stopped reporting its outcome |
+| `byModel` | object | `attempted`, `streamed` and `failed` per model id, which is how a dead member of the pool becomes visible |
+
+`streamed` plus every `failed` entry sums to `requests`. A request refused at
+token verification is not counted here, since `authorization` above already
+counts it, and one refused for its method or its content type is answered
+before either counter is reached.
+
+Model ids are configuration rather than user data, and `/inference` already
+sends the id to the browser in every chunk, so naming them here publishes
+nothing new.
 
 ## Data Persistence Architecture
 

--- a/server/inferencesSinceLastRestart.ts
+++ b/server/inferencesSinceLastRestart.ts
@@ -1,0 +1,148 @@
+/**
+ * Aggregate counters for the AI answers served through `/inference`.
+ *
+ * Counts and durations only. The obvious thing to record about an inference is
+ * the conversation, and that is the whole of what the user typed, so none of it
+ * is kept: no prompt, no message, no answer, no token, and no timestamp per
+ * request. Model ids are configuration rather than user data, and the endpoint
+ * already sends them to the browser in every chunk, so those are named.
+ */
+
+/**
+ * How a request that reached the streaming block ended. A request refused at
+ * token verification is not one of these; those are counted as rejections in
+ * `authorizationSinceLastRestart.ts`, and a request refused for its method or
+ * its content type is answered before either counter is reached.
+ */
+export type InferenceOutcome =
+  | "streamed"
+  | "failedBeforeFirstToken"
+  | "failedMidStream"
+  | "abandoned"
+  | "badRequest"
+  | "notConfigured"
+  | "modelListUnavailable"
+  | "noModelAvailable"
+  | "internalError"
+  | "unclassified";
+
+const outcomes: Record<InferenceOutcome, number> = {
+  streamed: 0,
+  failedBeforeFirstToken: 0,
+  failedMidStream: 0,
+  abandoned: 0,
+  badRequest: 0,
+  notConfigured: 0,
+  modelListUnavailable: 0,
+  noModelAvailable: 0,
+  internalError: 0,
+  unclassified: 0,
+};
+
+interface ModelCounts {
+  attempted: number;
+  streamed: number;
+  failed: number;
+}
+
+const byModel = new Map<string, ModelCounts>();
+
+let totalAttempts = 0;
+let totalFirstTokenMs = 0;
+let answersWithFirstToken = 0;
+let totalStreamMs = 0;
+let modelFallbacks = 0;
+let modelsRefetched = 0;
+let streamsEndedWithoutFinish = 0;
+
+function countsFor(model: string): ModelCounts {
+  const existing = byModel.get(model);
+  if (existing) return existing;
+  const created = { attempted: 0, streamed: 0, failed: 0 };
+  byModel.set(model, created);
+  return created;
+}
+
+export function recordModelAttempt(model: string): void {
+  totalAttempts++;
+  countsFor(model).attempted++;
+}
+
+export function recordModelStreamed(model: string): void {
+  countsFor(model).streamed++;
+}
+
+export function recordModelFailure(model: string): void {
+  countsFor(model).failed++;
+}
+
+/** A retry moved to another model, which is the only reason the pool exists. */
+export function recordModelFallback(): void {
+  modelFallbacks++;
+}
+
+export function recordModelsRefetched(): void {
+  modelsRefetched++;
+}
+
+/**
+ * The upstream closed a stream without a finish part. Counted per attempt
+ * rather than per request, because the retry can still land on another model
+ * and the request can still end as `streamed`.
+ */
+export function recordStreamEndedWithoutFinish(): void {
+  streamsEndedWithoutFinish++;
+}
+
+/**
+ * Records one finished request. `firstTokenMs` is the wait the user actually
+ * felt, so it is kept apart from `durationMs`, which covers the whole answer.
+ */
+export function recordInference({
+  outcome,
+  durationMs,
+  firstTokenMs,
+}: {
+  outcome: InferenceOutcome;
+  durationMs: number;
+  firstTokenMs?: number;
+}): void {
+  outcomes[outcome]++;
+  totalStreamMs += durationMs;
+  if (firstTokenMs !== undefined) {
+    totalFirstTokenMs += firstTokenMs;
+    answersWithFirstToken++;
+  }
+}
+
+/**
+ * Every outcome sums to `requests`, so a request that stops being recorded
+ * shows up as a gap rather than being lost silently. `outcomes.unclassified` is
+ * that gap made visible: it should always be zero, and a non-zero value means
+ * a path through the handler no longer reports what it did.
+ */
+export function getInferenceStats() {
+  const { streamed, ...failed } = outcomes;
+  const requests = Object.values(outcomes).reduce(
+    (total, count) => total + count,
+    0,
+  );
+
+  return {
+    requests,
+    streamed,
+    streamedRate: Number(((streamed / requests) * 100 || 0).toFixed(1)),
+    averageTimeToFirstTokenMs: Math.round(
+      totalFirstTokenMs / answersWithFirstToken || 0,
+    ),
+    averageDurationMs: Math.round(totalStreamMs / requests || 0),
+    averageAttempts: Number((totalAttempts / requests || 0).toFixed(2)),
+    modelFallbacks,
+    modelsRefetched,
+    streamsEndedWithoutFinish,
+    failed,
+    byModel: Object.fromEntries(
+      [...byModel].map(([model, counts]) => [model, { ...counts }]),
+    ),
+  };
+}

--- a/server/inferencesSinceLastRestart.ts
+++ b/server/inferencesSinceLastRestart.ts
@@ -43,11 +43,13 @@ interface ModelCounts {
   attempted: number;
   streamed: number;
   failed: number;
+  abandoned: number;
 }
 
 const byModel = new Map<string, ModelCounts>();
 
 let totalAttempts = 0;
+let requestsWithAttempts = 0;
 let totalFirstTokenMs = 0;
 let answersWithFirstToken = 0;
 let totalStreamMs = 0;
@@ -58,13 +60,12 @@ let streamsEndedWithoutFinish = 0;
 function countsFor(model: string): ModelCounts {
   const existing = byModel.get(model);
   if (existing) return existing;
-  const created = { attempted: 0, streamed: 0, failed: 0 };
+  const created = { attempted: 0, streamed: 0, failed: 0, abandoned: 0 };
   byModel.set(model, created);
   return created;
 }
 
 export function recordModelAttempt(model: string): void {
-  totalAttempts++;
   countsFor(model).attempted++;
 }
 
@@ -74,6 +75,15 @@ export function recordModelStreamed(model: string): void {
 
 export function recordModelFailure(model: string): void {
   countsFor(model).failed++;
+}
+
+/**
+ * The client left while this model was streaming. Counted so that a model's
+ * `attempted` always equals `streamed` plus `failed` plus this, rather than
+ * quietly losing the attempts nobody stayed to read.
+ */
+export function recordModelAbandoned(model: string): void {
+  countsFor(model).abandoned++;
 }
 
 /** A retry moved to another model, which is the only reason the pool exists. */
@@ -102,13 +112,17 @@ export function recordInference({
   outcome,
   durationMs,
   firstTokenMs,
+  attempts,
 }: {
   outcome: InferenceOutcome;
   durationMs: number;
   firstTokenMs?: number;
+  attempts: number;
 }): void {
   outcomes[outcome]++;
   totalStreamMs += durationMs;
+  totalAttempts += attempts;
+  if (attempts > 0) requestsWithAttempts++;
   if (firstTokenMs !== undefined) {
     totalFirstTokenMs += firstTokenMs;
     answersWithFirstToken++;
@@ -136,7 +150,12 @@ export function getInferenceStats() {
       totalFirstTokenMs / answersWithFirstToken || 0,
     ),
     averageDurationMs: Math.round(totalStreamMs / requests || 0),
-    averageAttempts: Number((totalAttempts / requests || 0).toFixed(2)),
+    // Over the requests that reached the model loop at all: a request that
+    // never had a model to try would otherwise drag the average below 1 and
+    // make a thrashing pool look healthier the more unrelated traffic arrives.
+    averageAttempts: Number(
+      (totalAttempts / requestsWithAttempts || 0).toFixed(2),
+    ),
     modelFallbacks,
     modelsRefetched,
     streamsEndedWithoutFinish,

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -34,6 +34,7 @@ import {
 } from "../shared/openaiModels";
 import { getModelConfig } from "./config/modelConfig";
 import { handleTokenVerification } from "./handleTokenVerification";
+import { getInferenceStats } from "./inferencesSinceLastRestart";
 import { internalApiEndpointServerHook } from "./internalApiEndpointServerHook";
 
 function createRequest(
@@ -900,6 +901,267 @@ describe("internalApiEndpointServerHook", () => {
           errorSpy.mockRestore();
         }
       });
+    });
+  });
+  describe("inference counters", () => {
+    const setupStreaming = () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL", "http://test-api");
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_KEY", "test-key");
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", "test-model");
+      vi.mocked(getModelConfig).mockReturnValue({
+        maxRetries: 5,
+        baseBackoffMs: 100,
+        maxBackoffMs: 5000,
+        requestTimeoutMs: 30000,
+        maxConcurrentRequests: 10,
+        defaultMaxTokens: 2048,
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      vi.mocked(createOpenAICompatible).mockReturnValue({
+        chatModel: vi.fn().mockReturnValue("mock-chat-model"),
+      } as never);
+    };
+
+    async function callInference(response = createResponse()) {
+      const handler = getRegisteredHandler();
+      await handler(
+        createRequest({ messages: [{ role: "user", content: "hi" }] }),
+        response,
+        vi.fn(),
+      );
+      return response;
+    }
+
+    beforeEach(setupStreaming);
+
+    it("counts a finished answer under its model", async () => {
+      const before = getInferenceStats();
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "text-delta", text: "Hello" },
+            { type: "finish" },
+          ]) as never,
+      );
+
+      await callInference();
+
+      const after = getInferenceStats();
+      expect(after.streamed).toBe(before.streamed + 1);
+      expect(after.requests).toBe(before.requests + 1);
+      expect(after.averageAttempts).toBeGreaterThan(0);
+      expect(after.byModel["test-model"].attempted).toBe(
+        (before.byModel["test-model"]?.attempted ?? 0) + 1,
+      );
+      expect(after.byModel["test-model"].streamed).toBe(
+        (before.byModel["test-model"]?.streamed ?? 0) + 1,
+      );
+    });
+
+    it("counts a request the client walked away from", async () => {
+      const before = getInferenceStats();
+      vi.mocked(streamText).mockImplementation(
+        () => streamOf([{ type: "text-delta", text: "Hello" }]) as never,
+      );
+      const response = createResponse();
+      const mutable = response as {
+        writableEnded: boolean;
+        destroyed: boolean;
+      };
+      mutable.writableEnded = true;
+      mutable.destroyed = true;
+
+      await callInference(response);
+
+      // The only outcome with no response to observe it by, which is the
+      // reason it is worth counting at all.
+      expect(getInferenceStats().failed.abandoned).toBe(
+        before.failed.abandoned + 1,
+      );
+    });
+
+    it("counts an exhausted ladder as a failure before the first token", async () => {
+      const before = getInferenceStats();
+      vi.mocked(streamText).mockImplementation(() => streamOf([]) as never);
+
+      const response = await callInference();
+
+      expect(response.statusCode).toBe(503);
+      const after = getInferenceStats();
+      expect(after.failed.failedBeforeFirstToken).toBe(
+        before.failed.failedBeforeFirstToken + 1,
+      );
+      expect(after.streamsEndedWithoutFinish).toBe(
+        before.streamsEndedWithoutFinish + 1,
+      );
+      expect(after.byModel["test-model"].failed).toBe(
+        (before.byModel["test-model"]?.failed ?? 0) + 1,
+      );
+    });
+
+    it("counts a failure after content as a mid-stream failure", async () => {
+      const before = getInferenceStats();
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "text-delta", text: "Half an answer" },
+            { type: "error", error: new Error("upstream died") },
+          ]) as never,
+      );
+
+      await callInference();
+
+      expect(getInferenceStats().failed.failedMidStream).toBe(
+        before.failed.failedMidStream + 1,
+      );
+    });
+
+    it("counts a fallback to another model", async () => {
+      const before = getInferenceStats();
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      vi.mocked(listOpenAiCompatibleModels).mockResolvedValue([
+        { id: "model-a" },
+        { id: "model-b" },
+      ]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+      let calls = 0;
+      vi.mocked(streamText).mockImplementation(() => {
+        calls += 1;
+        return (
+          calls === 1
+            ? streamOf([])
+            : streamOf([
+                { type: "text-delta", text: "Recovered" },
+                { type: "finish" },
+              ])
+        ) as never;
+      });
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          createResponse(),
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      const after = getInferenceStats();
+      expect(after.modelFallbacks).toBe(before.modelFallbacks + 1);
+      expect(after.byModel["model-a"].failed).toBe(
+        (before.byModel["model-a"]?.failed ?? 0) + 1,
+      );
+      expect(after.byModel["model-b"].streamed).toBe(
+        (before.byModel["model-b"]?.streamed ?? 0) + 1,
+      );
+      expect(after.streamed).toBe(before.streamed + 1);
+    });
+
+    it.each([
+      [
+        "badRequest",
+        async () => {
+          const handler = getRegisteredHandler();
+          const request = Readable.from(["{invalid"]) as IncomingMessage;
+          request.url = "/inference?token=abc";
+          request.method = "POST";
+          request.headers = {
+            host: "localhost:3000",
+            "content-type": "application/json",
+          };
+          await handler(request, createResponse(), vi.fn());
+        },
+      ],
+      [
+        "notConfigured",
+        async () => {
+          vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL", undefined);
+          await callInference();
+        },
+      ],
+      [
+        "modelListUnavailable",
+        async () => {
+          vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+          vi.mocked(listOpenAiCompatibleModels).mockRejectedValue(
+            new Error("registry timeout"),
+          );
+          const errorSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+          try {
+            await callInference();
+          } finally {
+            errorSpy.mockRestore();
+          }
+        },
+      ],
+    ] as const)(
+      "counts a %s answer under its own outcome",
+      async (outcome, run) => {
+        const before = getInferenceStats();
+
+        await run();
+
+        expect(getInferenceStats().failed[outcome]).toBe(
+          before.failed[outcome] + 1,
+        );
+      },
+    );
+
+    it("counts every request exactly once and classifies all of them", async () => {
+      const before = getInferenceStats();
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "text-delta", text: "Hello" },
+            { type: "finish" },
+          ]) as never,
+      );
+
+      await callInference();
+      await callInference();
+
+      const stats = getInferenceStats();
+      const total =
+        stats.streamed +
+        Object.values(stats.failed).reduce((sum, count) => sum + count, 0);
+
+      expect(stats.requests).toBe(before.requests + 2);
+      expect(total).toBe(stats.requests);
+      // Zero unless a path through the handler stopped reporting its outcome.
+      expect(stats.failed.unclassified).toBe(0);
+    });
+
+    it("keeps no part of the conversation", async () => {
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "text-delta", text: "borogoves" },
+            { type: "finish" },
+          ]) as never,
+      );
+      const handler = getRegisteredHandler();
+      await handler(
+        createRequest({
+          messages: [{ role: "user", content: "outgrabe mimsy-42" }],
+        }),
+        createResponse(),
+        vi.fn(),
+      );
+
+      const serialized = JSON.stringify(getInferenceStats());
+      expect(serialized).not.toContain("outgrabe");
+      expect(serialized).not.toContain("borogoves");
+      expect(serialized).not.toContain("abc");
     });
   });
 });

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -1,6 +1,14 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 vi.mock("./handleTokenVerification", () => ({
   handleTokenVerification: vi.fn(),
@@ -935,6 +943,12 @@ describe("internalApiEndpointServerHook", () => {
 
     beforeEach(setupStreaming);
 
+    // Every case in this block goes through the handler, so this covers all of
+    // them rather than whichever one happened to run last.
+    afterAll(() => {
+      expect(getInferenceStats().failed.unclassified).toBe(0);
+    });
+
     it("counts a finished answer under its model", async () => {
       const before = getInferenceStats();
       vi.mocked(streamText).mockImplementation(
@@ -978,6 +992,41 @@ describe("internalApiEndpointServerHook", () => {
       // reason it is worth counting at all.
       expect(getInferenceStats().failed.abandoned).toBe(
         before.failed.abandoned + 1,
+      );
+    });
+
+    it("counts an attempt the client walked away from mid-answer", async () => {
+      const before = getInferenceStats();
+      const response = createResponse();
+      const mutable = response as {
+        writableEnded: boolean;
+        destroyed: boolean;
+      };
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "text-delta", text: "Half an answer" },
+            { type: "text-delta", text: "never read" },
+          ]) as never,
+      );
+      response.write.mockImplementation(() => {
+        // Writable for the first part, gone before the second, which is the
+        // path that leaves a model attempted with no result of its own.
+        mutable.writableEnded = true;
+        mutable.destroyed = true;
+        return true;
+      });
+
+      await callInference(response);
+
+      const after = getInferenceStats();
+      expect(after.failed.abandoned).toBe(before.failed.abandoned + 1);
+      const model = after.byModel["test-model"];
+      expect(model.abandoned).toBe(
+        (before.byModel["test-model"]?.abandoned ?? 0) + 1,
+      );
+      expect(model.attempted).toBe(
+        model.streamed + model.failed + model.abandoned,
       );
     });
 
@@ -1137,8 +1186,7 @@ describe("internalApiEndpointServerHook", () => {
 
       expect(stats.requests).toBe(before.requests + 2);
       expect(total).toBe(stats.requests);
-      // Zero unless a path through the handler stopped reporting its outcome.
-      expect(stats.failed.unclassified).toBe(0);
+      expect(stats.averageAttempts).toBeGreaterThanOrEqual(1);
     });
 
     it("keeps no part of the conversation", async () => {

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -12,6 +12,7 @@ import { handleTokenVerification } from "./handleTokenVerification.ts";
 import {
   type InferenceOutcome,
   recordInference,
+  recordModelAbandoned,
   recordModelAttempt,
   recordModelFailure,
   recordModelFallback,
@@ -169,6 +170,7 @@ export function internalApiEndpointServerHook<
 
       const startedAt = performance.now();
       let firstTokenMs: number | undefined;
+      let attempts = 0;
       // Set on the way out of every path below. The default is the bucket that
       // means "a path stopped reporting", so a missed one is visible on
       // `/status` instead of landing in a bucket that means something else.
@@ -296,6 +298,7 @@ export function internalApiEndpointServerHook<
           }
 
           recordModelAttempt(model);
+          attempts++;
 
           try {
             const result = streamText({
@@ -310,6 +313,7 @@ export function internalApiEndpointServerHook<
             for await (const part of result.stream) {
               if (!isResponseWritable(response)) {
                 outcome = "abandoned";
+                recordModelAbandoned(model);
                 return;
               }
 
@@ -413,6 +417,7 @@ export function internalApiEndpointServerHook<
           outcome,
           durationMs: performance.now() - startedAt,
           firstTokenMs,
+          attempts,
         });
       }
     },

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -10,6 +10,16 @@ import {
 import { getModelConfig } from "./config/modelConfig.ts";
 import { handleTokenVerification } from "./handleTokenVerification.ts";
 import {
+  type InferenceOutcome,
+  recordInference,
+  recordModelAttempt,
+  recordModelFailure,
+  recordModelFallback,
+  recordModelStreamed,
+  recordModelsRefetched,
+  recordStreamEndedWithoutFinish,
+} from "./inferencesSinceLastRestart.ts";
+import {
   calculateBackoffTime,
   isResponseWritable,
   safeEndResponse,
@@ -157,6 +167,13 @@ export function internalApiEndpointServerHook<
       );
       if (!shouldContinue) return;
 
+      const startedAt = performance.now();
+      let firstTokenMs: number | undefined;
+      // Set on the way out of every path below. The default is the bucket that
+      // means "a path stopped reporting", so a missed one is visible on
+      // `/status` instead of landing in a bucket that means something else.
+      let outcome: InferenceOutcome = "unclassified";
+
       try {
         let rawRequestBody: unknown;
         try {
@@ -170,6 +187,7 @@ export function internalApiEndpointServerHook<
             } else if (chunk instanceof Uint8Array) {
               buf = Buffer.from(chunk);
             } else {
+              outcome = "badRequest";
               sendJsonError(response, 400, {
                 error: "Invalid request body stream",
               });
@@ -177,6 +195,7 @@ export function internalApiEndpointServerHook<
             }
             totalBytes += buf.length;
             if (totalBytes > maxBodyBytes) {
+              outcome = "badRequest";
               sendJsonError(response, 413, { error: "Request body too large" });
               return;
             }
@@ -184,6 +203,7 @@ export function internalApiEndpointServerHook<
           }
           rawRequestBody = JSON.parse(Buffer.concat(chunks).toString());
         } catch (_error) {
+          outcome = "badRequest";
           sendJsonError(response, 400, { error: "Invalid request body" });
           return;
         }
@@ -192,6 +212,7 @@ export function internalApiEndpointServerHook<
           chatCompletionRequestSchema.safeParse(rawRequestBody);
         if (!parsedRequestBody.success) {
           const issue = parsedRequestBody.error.issues[0];
+          outcome = "badRequest";
           sendJsonError(response, 400, {
             error: `Invalid request body: ${issue.path.join(".") || "body"} ${issue.message}`,
           });
@@ -203,6 +224,7 @@ export function internalApiEndpointServerHook<
           !process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL ||
           !process.env.INTERNAL_OPENAI_COMPATIBLE_API_KEY
         ) {
+          outcome = "notConfigured";
           sendJsonError(response, 500, {
             error: "OpenAI API configuration is missing",
           });
@@ -232,6 +254,7 @@ export function internalApiEndpointServerHook<
               "Error fetching models:",
               error instanceof Error ? error.message : error,
             );
+            outcome = "modelListUnavailable";
             sendJsonError(response, 500, {
               error: "Failed to fetch available models",
             });
@@ -240,6 +263,7 @@ export function internalApiEndpointServerHook<
         }
 
         if (!model) {
+          outcome = "noModelAvailable";
           sendJsonError(response, 500, { error: "No model available" });
           return;
         }
@@ -267,8 +291,11 @@ export function internalApiEndpointServerHook<
           attemptedModels.add(model);
 
           if (!isResponseWritable(response)) {
+            outcome = "abandoned";
             return;
           }
+
+          recordModelAttempt(model);
 
           try {
             const result = streamText({
@@ -281,9 +308,14 @@ export function internalApiEndpointServerHook<
             });
 
             for await (const part of result.stream) {
-              if (!isResponseWritable(response)) return;
+              if (!isResponseWritable(response)) {
+                outcome = "abandoned";
+                return;
+              }
 
               if (part.type === "text-delta") {
+                if (!hasEmittedContent)
+                  firstTokenMs = performance.now() - startedAt;
                 hasEmittedContent = true;
                 sendSseData(response, createChunkPayload(model, part.text));
               } else if (part.type === "error") {
@@ -294,13 +326,17 @@ export function internalApiEndpointServerHook<
                   createChunkPayload(model, undefined, "stop"),
                 );
                 sendSseDone(response);
+                outcome = "streamed";
+                recordModelStreamed(model);
                 return;
               }
             }
 
+            recordStreamEndedWithoutFinish();
             throw new Error("Stream ended unexpectedly");
           } catch (error) {
             lastError = error;
+            recordModelFailure(model);
             console.error(
               "Error during streaming:",
               error instanceof Error ? error.message : error,
@@ -318,6 +354,7 @@ export function internalApiEndpointServerHook<
                   process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL,
                   process.env.INTERNAL_OPENAI_COMPATIBLE_API_KEY,
                 );
+                recordModelsRefetched();
               } catch (refetchError) {
                 console.warn(
                   "Failed to refetch models:",
@@ -334,6 +371,7 @@ export function internalApiEndpointServerHook<
             );
             if (!nextModel) break;
             model = nextModel;
+            recordModelFallback();
 
             const backoffMs = calculateBackoffTime(attempt);
             await new Promise((resolve) => setTimeout(resolve, backoffMs));
@@ -344,6 +382,7 @@ export function internalApiEndpointServerHook<
           lastError instanceof Error ? lastError.message : "Unknown error";
 
         if (!response.headersSent) {
+          outcome = "failedBeforeFirstToken";
           sendJsonError(response, 503, {
             error: "Service unavailable - all models failed",
             lastError: lastErrorMessage,
@@ -351,6 +390,9 @@ export function internalApiEndpointServerHook<
           return;
         }
 
+        outcome = hasEmittedContent
+          ? "failedMidStream"
+          : "failedBeforeFirstToken";
         sendSseError(
           response,
           `Service unavailable - all models failed: ${lastErrorMessage}`,
@@ -361,9 +403,16 @@ export function internalApiEndpointServerHook<
           "Error in internal API endpoint:",
           error instanceof Error ? error.message : error,
         );
+        outcome = "internalError";
         sendJsonError(response, 500, {
           error: "Internal server error",
           message: error instanceof Error ? error.message : "Unknown error",
+        });
+      } finally {
+        recordInference({
+          outcome,
+          durationMs: performance.now() - startedAt,
+          firstTokenMs,
         });
       }
     },

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -1,6 +1,7 @@
 import prettyMilliseconds from "pretty-ms";
 import type { PreviewServer, ViteDevServer } from "vite";
 import { getAuthorizationStats } from "./authorizationSinceLastRestart.ts";
+import { getInferenceStats } from "./inferencesSinceLastRestart.ts";
 import { getPageReadStats } from "./pageReadsSinceLastRestart.ts";
 import { getRerankerStatus } from "./rerankerService.ts";
 import {
@@ -68,6 +69,7 @@ export function statusEndpointServerHook<
       webSearchServiceStatus,
       pageReads: getPageReadStats(),
       authorization: getAuthorizationStats(),
+      inference: getInferenceStats(),
       build: {
         timestamp: new Date(
           server.config.define?.VITE_BUILD_DATE_TIME || "",


### PR DESCRIPTION
## Description

`/inference` is behind every AI answer, and `/status` said nothing about it. The handler already distinguished nine ways a request can end and discarded all of them, including the one nobody can see from the outside: the client that walks away mid-answer, which returns silently and leaves no response to infer anything from.

Each terminating path now records its outcome, and `/status` reports them as `inference`, alongside the wait before the first token, the models tried per request, the fallbacks, the streams that closed without a finish part, and per-model attempted/streamed/failed/abandoned counts. That last one is how a dead member of the model pool becomes visible: `selectRandomModel` draws blindly, so a model that always fails is otherwise just a slower average.

Nothing about the conversation is kept: no prompt, no message, no answer, no token, no per-request timestamp. Model ids are named on purpose, since `createChunkPayload` already sends the id to the browser in every chunk, so `/status` publishes nothing the app doesn't.

### What changed

| File | Change |
| --- | --- |
| `server/inferencesSinceLastRestart.ts` | New counters: nine outcomes summing to `requests`, averages for the first token and the whole request, attempts, fallbacks, re-lists, streams without a finish part, and per-model counts |
| `server/internalApiEndpointServerHook.ts` | Sets an outcome on every path and records once in a `finally`, tracks the first token and the attempts, and counts each model's attempt, success, failure and abandon |
| `server/statusEndpointServerHook.ts` | One `inference` field in the payload |
| `server/internalApiEndpointServerHook.test.ts` | 11 new cases: each outcome, the two ways a client can leave, a fallback across models, the closed-totals invariant, and one asserting no part of the conversation reaches the counters |
| `docs/overview.md`, `docs/ai-integration.md` | The `inference` field reference, and a pointer to it from the internal-API section |

Three decisions worth a reviewer's attention.

`streamEndedWithoutFinish` is counted per attempt, not as an outcome. The throw is caught by the retry loop, so a request that hits it can still end as `streamed`; treating it as terminal would have double-counted those and broken the sum.

`outcome` defaults to a bucket called `unclassified` that should always read zero. A path that stops reporting therefore shows up as a gap, the way `pageReads` makes an uncounted page visible, rather than landing in a bucket that means something else. An `afterAll` in the test block asserts it across every case.

`inference.requests` should equal `authorization.bySurface.inference.authorized`. A gap between them is a request that never terminated, which is currently possible: `requestTimeoutMs` is read from the model config and never passed to `streamText`, so a hung upstream is counted nowhere. Filed as #2421 rather than fixed here.

## How to test

1. `npm run test` (667 passing in 59 files, 11 new) and `npm run lint`.
2. Ask the app anything with `inferenceType` set to `internal`, then `curl localhost:7860/status` and read `inference`: `streamed` climbs, `byModel` names the model that answered, and `averageTimeToFirstTokenMs` is the wait you just sat through.
3. Point `INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL` at nothing and ask again: `failed.notConfigured` climbs and `streamedRate` drops.
4. Start an answer and close the tab mid-stream: `failed.abandoned` and `byModel[...].abandoned` climb, with no other trace anywhere.

Tripwire, run and reverted: deleting one `outcome` assignment fails both the case that covers that path and the `unclassified` invariant.

Closes #2413
