### PR TITLE
feat: report search timing, reranker effect and dropped thumbnails on /status

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -220,7 +220,8 @@ The `/status` endpoint returns a JSON object:
 | Field | Type | Description |
 |---|---|---|
 | `uptime` | string | Human-readable server uptime |
-| `sessions` | number | Active verified token sessions |
+| `sessions` | number | Distinct verified sessions since last restart, which is what the averages below divide by |
+| `activeSessions` | number | Sessions still in the cache, dropped after 30 idle minutes |
 | `textualSearches` | number | Text search count since last restart |
 | `graphicalSearches` | number | Image search count since last restart |
 | `averageTextualSearchesPerSession` | number | Text searches / sessions ratio |
@@ -233,6 +234,9 @@ The `/status` endpoint returns a JSON object:
 | `pageReads` | object | Page-reading counters since last restart, see below |
 | `authorization` | object | Token and rate-limit outcomes since last restart, see below |
 | `inference` | object | AI answer counters since last restart, see below |
+| `searches` | object | Search timing, circuit state and grounding, see below |
+| `reranker` | object | Reranking cost and effect, see below |
+| `thumbnails` | object | Image thumbnail fetches, see below |
 | `build.timestamp` | string | ISO 8601 build time |
 | `build.gitCommit` | string | Short Git commit hash |
 
@@ -340,6 +344,31 @@ the loop stops after the first failure: `averageAttempts` cannot exceed 1 and
 Model ids are configuration rather than user data, and `/inference` already
 sends the id to the browser in every chunk, so naming them here publishes
 nothing new.
+
+`searches`, `reranker` and `thumbnails` are the numbers behind the constants
+in the search path. Each row names the constant it is there to move, the same
+way `pageReads` does:
+
+| Field | Type | Tunes |
+|---|---|---|
+| `searches.averageTextualMs` | number | The 30 s client timeout in `client/modules/search.ts`, and SearXNG's own engine timeouts |
+| `searches.averageGraphicalMs` | number | The same, for image searches |
+| `searches.circuitState` | string | Nothing; whether searches are being short-circuited right now |
+| `searches.circuitOpens` | number | `failureThreshold` and `resetTimeout` on the SearXNG breaker: each opening is a minute of serving no searches at all |
+| `searches.withGrounding` | number | Nothing; how often an answer had page excerpts to stand on |
+| `searches.withoutGrounding` | number | The page-reading budget and timeouts in `docs/page-content.md`, counted per search rather than per page |
+| `reranker.reranks` | number | Nothing; the denominator for the rest |
+| `reranker.averageMs` | number | Whether reranking or SearXNG is what users wait for, and so whether to rerank a shortlist instead of all 30 results |
+| `reranker.keptRate` | number | `kStandardDeviationFactor`: near 100% means the filter is not filtering |
+| `reranker.fallbackApplied` | number | `minPercentageFallback`: a large share means the deviation threshold is emptying batches the fallback then has to rescue |
+| `reranker.skippedUnhealthy` | number | Nothing; searches served in SearXNG's own order because the model was not loaded |
+| `reranker.failed` | number | Nothing; the same, because reranking threw |
+| `thumbnails.requested` | number | Nothing; the denominator for the two below |
+| `thumbnails.dropped` | number | `THUMBNAIL_TIMEOUT_MS` and `MAX_THUMBNAIL_BYTES`: every one of these is an image result the user never saw |
+| `thumbnails.blocked` | number | The SSRF guard, as the share of thumbnails pointing outside public space |
+
+`thumbnails.dropped` includes the blocked ones, so `requested` minus `dropped`
+is what reached the client.
 
 ## Data Persistence Architecture
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -121,7 +121,7 @@ CSRF protection uses a build-time generated token:
 2. **Storage**: Server stores token file at `{os.tempdir()}/minisearch-token`
 3. **Client Hashing**: Client hashes token before sending in requests (never sends raw token)
 4. **Verification**: Server compares request hash against stored token
-5. **Caching**: Verified tokens stored in `server/verifiedTokens.ts` (in-memory `Set<string>`) to avoid redundant cryptographic operations
+5. **Caching**: Verified tokens stored in `server/verifiedTokens.ts` (in-memory `Map` of token to last-seen time) to avoid redundant cryptographic operations
 
 ## Data Flow and Communication
 
@@ -200,7 +200,7 @@ Key server-side modules:
 - **`server/webSearchService.ts`**: Integrates with SearXNG at `http://127.0.0.1:8888`. Implements a circuit breaker (opens after 5 failures, resets after 60s) and retry logic (up to 3 retries with exponential backoff for 500 errors).
 - **`server/pageContentService.ts`**: Reads result pages for answer grounding: SSRF-guarded fetches with a byte cap, readable-text extraction, and query-relevant passage selection.
 - **`server/searchToken.ts`**: Manages a token at `{os.tempdir()}/minisearch-token` used for CSRF protection on search requests.
-- **`server/verifiedTokens.ts`**: In-memory `Set<string>` of verified session tokens.
+- **`server/verifiedTokens.ts`**: In-memory `Map` of verified session token to last-seen time, evicted after 30 idle minutes, plus a cumulative count of the distinct sessions seen since the last restart.
 - **`server/searchesSinceLastRestart.ts`**: In-memory counters for search analytics.
 
 ### Cache Control
@@ -220,7 +220,7 @@ The `/status` endpoint returns a JSON object:
 | Field | Type | Description |
 |---|---|---|
 | `uptime` | string | Human-readable server uptime |
-| `sessions` | number | Distinct verified sessions since last restart, which is what the averages below divide by |
+| `sessions` | number | Distinct verified sessions since last restart, which the two per-session averages below divide by |
 | `activeSessions` | number | Sessions still in the cache, dropped after 30 idle minutes |
 | `textualSearches` | number | Text search count since last restart |
 | `graphicalSearches` | number | Image search count since last restart |
@@ -272,9 +272,18 @@ is counted at all (see `docs/page-content.md`):
 | `skipped.timedOut` | number | `REQUEST_TIMEOUT_MS` |
 | `skipped.tooLittleText` | number | `MIN_USEFUL_CHARS`, and the extractor's selectors |
 | `skipped.failed` | number | Nothing; the residue worth watching for a pattern |
+| `grounding.requests` | number | Nothing; the denominator for the two below |
+| `grounding.withContent` | number | Nothing; requests where at least one page yielded text |
+| `grounding.withoutContent` | number | The budgets and timeouts above, read per request instead of per page: six pages at a 50% read rate can be three fully grounded answers or six half-grounded ones |
 
 `read` plus every `skipped` entry sums to `requested`, so a page that goes
 uncounted shows up as a gap rather than being lost silently.
+
+`grounding` counts `/page-content` requests and not searches. A search only
+reaches that endpoint when the browser has AI responses on, page reading on,
+and the search returned results, and AI responses are off by default, so
+`grounding.requests` sitting at zero while `textualSearches` climbs means
+nobody asked for an answer, not that nothing could be read.
 
 `authorization` reports what happened to the requests that reached token
 verification, the funnel `/search/text`, `/search/images`, `/page-content` and
@@ -351,15 +360,15 @@ way `pageReads` does:
 
 | Field | Type | Tunes |
 |---|---|---|
-| `searches.averageTextualMs` | number | The 30 s client timeout in `client/modules/search.ts`, and SearXNG's own engine timeouts |
+| `searches.averageTextualMs` | number | The 30 s client timeout in `client/modules/search.ts`. Over the text searches SearXNG answered, so a failed or short-circuited one is not in it, and up to 7 s of retry backoff is |
 | `searches.averageGraphicalMs` | number | The same, for image searches |
+| `reranker.considered` | number | Nothing; results handed to the score filter, the denominator for `keptRate` |
+| `reranker.kept` | number | Nothing; results that survived it |
 | `searches.circuitState` | string | Nothing; whether searches are being short-circuited right now |
 | `searches.circuitOpens` | number | `failureThreshold` and `resetTimeout` on the SearXNG breaker: each opening is a minute of serving no searches at all |
-| `searches.withGrounding` | number | Nothing; how often an answer had page excerpts to stand on |
-| `searches.withoutGrounding` | number | The page-reading budget and timeouts in `docs/page-content.md`, counted per search rather than per page |
 | `reranker.reranks` | number | Nothing; the denominator for the rest |
-| `reranker.averageMs` | number | Whether reranking or SearXNG is what users wait for, and so whether to rerank a shortlist instead of all 30 results |
-| `reranker.keptRate` | number | `kStandardDeviationFactor`: near 100% means the filter is not filtering |
+| `reranker.averageMs` | number | Whether reranking or SearXNG is what users wait for, and so whether to rerank a shortlist instead of all 30 results. Over `reranks`, covering the filtering and sorting as well as the model |
+| `reranker.keptRate` | number | `kStandardDeviationFactor`: near 100% means the filter is not filtering. Text and image reranks are pooled, and the two run through different paths, so this moves with the traffic mix as well as with the threshold |
 | `reranker.fallbackApplied` | number | `minPercentageFallback`: a large share means the deviation threshold is emptying batches the fallback then has to rescue |
 | `reranker.skippedUnhealthy` | number | Nothing; searches served in SearXNG's own order because the model was not loaded |
 | `reranker.failed` | number | Nothing; the same, because reranking threw |

--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -159,6 +159,15 @@ npx vitest run --config vitest.integration.config.ts
 | Empty documents array | Returns empty array without running inference |
 | Unicode sanitization needed | Logs warning, continues with sanitized input |
 
+## Observability
+
+`/status` reports what reranking costs and what it changes, under `reranker`:
+how long a rerank takes, the share of results that survive the score filter,
+how often the percentage fallback has to rescue a batch, and how often a search
+was served in SearXNG's own order because the model was not loaded or threw.
+The two thresholds in `filterResultsByScore` have no other evidence behind
+them; see the `/status` section of `docs/overview.md` for the field reference.
+
 ## Related Topics
 
 - **Search System**: `docs/overview.md` - Search pipeline overview

--- a/server/pageContentEndpointServerHook.test.ts
+++ b/server/pageContentEndpointServerHook.test.ts
@@ -205,9 +205,9 @@ describe("pageContentEndpointServerHook", () => {
     expect(response.statusCode).toBe(500);
     expect(parseBody(response)).toEqual({ error: "Internal server error" });
   });
-  it("records whether the search got anything to ground on", async () => {
-    const { getSearchStats } = await import("./searchesSinceLastRestart");
-    const before = getSearchStats();
+  it("records whether a page-content request got anything to ground on", async () => {
+    const { getPageReadStats } = await import("./pageReadsSinceLastRestart");
+    const before = getPageReadStats().grounding;
     vi.mocked(handleTokenVerification).mockResolvedValue({
       shouldContinue: true,
     });
@@ -219,12 +219,19 @@ describe("pageContentEndpointServerHook", () => {
     ]);
     await callEndpoint(url).handled;
 
-    expect(getSearchStats().withGrounding).toBe(before.withGrounding + 1);
-    expect(getSearchStats().withoutGrounding).toBe(before.withoutGrounding);
+    expect(getPageReadStats().grounding.withContent).toBe(
+      before.withContent + 1,
+    );
+    expect(getPageReadStats().grounding.withoutContent).toBe(
+      before.withoutContent,
+    );
 
     vi.mocked(fetchPageContents).mockResolvedValue([]);
     await callEndpoint(url).handled;
 
-    expect(getSearchStats().withoutGrounding).toBe(before.withoutGrounding + 1);
+    expect(getPageReadStats().grounding.withoutContent).toBe(
+      before.withoutContent + 1,
+    );
+    expect(getPageReadStats().grounding.requests).toBe(before.requests + 2);
   });
 });

--- a/server/pageContentEndpointServerHook.test.ts
+++ b/server/pageContentEndpointServerHook.test.ts
@@ -205,4 +205,26 @@ describe("pageContentEndpointServerHook", () => {
     expect(response.statusCode).toBe(500);
     expect(parseBody(response)).toEqual({ error: "Internal server error" });
   });
+  it("records whether the search got anything to ground on", async () => {
+    const { getSearchStats } = await import("./searchesSinceLastRestart");
+    const before = getSearchStats();
+    vi.mocked(handleTokenVerification).mockResolvedValue({
+      shouldContinue: true,
+    });
+
+    const url = "/page-content?q=cats&url=https%3A%2F%2Fa.example%2F&token=abc";
+
+    vi.mocked(fetchPageContents).mockResolvedValue([
+      { url: "https://a.example/", content: "text worth quoting" },
+    ]);
+    await callEndpoint(url).handled;
+
+    expect(getSearchStats().withGrounding).toBe(before.withGrounding + 1);
+    expect(getSearchStats().withoutGrounding).toBe(before.withoutGrounding);
+
+    vi.mocked(fetchPageContents).mockResolvedValue([]);
+    await callEndpoint(url).handled;
+
+    expect(getSearchStats().withoutGrounding).toBe(before.withoutGrounding + 1);
+  });
 });

--- a/server/pageContentEndpointServerHook.ts
+++ b/server/pageContentEndpointServerHook.ts
@@ -2,7 +2,7 @@ import type { PreviewServer, ViteDevServer } from "vite";
 import { z } from "zod";
 import { handleTokenVerification } from "./handleTokenVerification.ts";
 import { fetchPageContents } from "./pageContentService.ts";
-import { recordGroundingOutcome } from "./searchesSinceLastRestart.ts";
+import { recordGroundingOutcome } from "./pageReadsSinceLastRestart.ts";
 
 const MAX_QUERY_LENGTH = 2000;
 const MAX_URL_LENGTH = 2048;

--- a/server/pageContentEndpointServerHook.ts
+++ b/server/pageContentEndpointServerHook.ts
@@ -2,6 +2,7 @@ import type { PreviewServer, ViteDevServer } from "vite";
 import { z } from "zod";
 import { handleTokenVerification } from "./handleTokenVerification.ts";
 import { fetchPageContents } from "./pageContentService.ts";
+import { recordGroundingOutcome } from "./searchesSinceLastRestart.ts";
 
 const MAX_QUERY_LENGTH = 2000;
 const MAX_URL_LENGTH = 2048;
@@ -78,6 +79,7 @@ export function pageContentEndpointServerHook<
     try {
       const { query, urls } = parsedParams.data;
       const contents = await fetchPageContents(query, urls);
+      recordGroundingOutcome(contents.length > 0);
 
       response.setHeader("Content-Type", "application/json");
       response.end(

--- a/server/pageReadsSinceLastRestart.ts
+++ b/server/pageReadsSinceLastRestart.ts
@@ -33,6 +33,14 @@ const outcomes: Record<PageReadOutcome, number> = {
   failed: 0,
 };
 
+// Counted per request rather than per page: six pages at a 50% read rate can
+// be three fully grounded answers or six half-grounded ones, and those want
+// different fixes. A request only happens when the browser has AI responses and
+// page reading on and the search returned results, so these do not count
+// searches.
+let groundingRequests = 0;
+let groundingRequestsWithContent = 0;
+
 let totalReadMs = 0;
 let bodiesTruncated = 0;
 let totalPassagesKept = 0;
@@ -62,6 +70,12 @@ export function recordPageRead({
   totalPassagesAvailable += passagesAvailable;
 }
 
+/** One `/page-content` request, and whether any of its pages yielded text. */
+export function recordGroundingOutcome(hadContent: boolean): void {
+  groundingRequests++;
+  if (hadContent) groundingRequestsWithContent++;
+}
+
 /**
  * `read` plus every `skipped` entry sums to `requested`, so a page that goes
  * uncounted shows up as a gap rather than being lost silently.
@@ -87,5 +101,10 @@ export function getPageReadStats() {
       ((totalPassagesKept / totalPassagesAvailable) * 100 || 0).toFixed(1),
     ),
     skipped,
+    grounding: {
+      requests: groundingRequests,
+      withContent: groundingRequestsWithContent,
+      withoutContent: groundingRequests - groundingRequestsWithContent,
+    },
   };
 }

--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -114,4 +114,56 @@ describe("rankSearchResults", () => {
     // Double quotes in the snippet are preserved (no Markdown wrapper to escape for)
     expect(docs[0]).toBe('Title\nContent with "quotes"');
   });
+  it("reports how many results survived the score filter", async () => {
+    const { getRerankingStats } = await import("./rerankingSinceLastRestart");
+    const before = getRerankingStats();
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 9 },
+      { index: 1, relevance_score: 8.5 },
+      { index: 2, relevance_score: 8.4 },
+    ] as { index: number; relevance_score: number }[]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+
+    const ranked = await rankSearchResults("test", [
+      ["A", "a", "https://a.com"],
+      ["B", "b", "https://b.com"],
+      ["C", "c", "https://c.com"],
+    ]);
+
+    const after = getRerankingStats();
+    expect(after.reranks).toBe(before.reranks + 1);
+    expect(ranked.length).toBeGreaterThan(0);
+    // keptRate is a share of everything considered so far, so the only safe
+    // assertion across a shared counter is that it stayed a percentage.
+    expect(after.keptRate).toBeGreaterThan(0);
+    expect(after.keptRate).toBeLessThanOrEqual(100);
+  });
+
+  it("reports the percentage fallback when the deviation filter empties a batch", async () => {
+    const { getRerankingStats } = await import("./rerankingSinceLastRestart");
+    const before = getRerankingStats();
+    // One result far above a long tail: the standard-deviation threshold keeps
+    // too few, so the percentage fallback has to rescue the batch.
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 100 },
+      ...Array.from({ length: 9 }, (_unused, index) => ({
+        index: index + 1,
+        relevance_score: 0,
+      })),
+    ] as { index: number; relevance_score: number }[]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+
+    await rankSearchResults(
+      "test",
+      Array.from({ length: 10 }, (_unused, index) => [
+        `T${index}`,
+        `C${index}`,
+        `https://${index}.com`,
+      ]) as [string, string, string][],
+    );
+
+    expect(getRerankingStats().fallbackApplied).toBe(
+      before.fallbackApplied + 1,
+    );
+  });
 });

--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -114,6 +114,57 @@ describe("rankSearchResults", () => {
     // Double quotes in the snippet are preserved (no Markdown wrapper to escape for)
     expect(docs[0]).toBe('Title\nContent with "quotes"');
   });
+  it("counts one rerank per ranked batch, and none for an empty one", async () => {
+    const { getRerankingStats } = await import("./rerankingSinceLastRestart");
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const results: [string, string, string][] = [
+      ["A", "a", "https://a.com"],
+      ["B", "b", "https://b.com"],
+    ];
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 9 },
+      { index: 1, relevance_score: 8 },
+    ] as { index: number; relevance_score: number }[]);
+
+    const before = getRerankingStats();
+    await rankSearchResults("test", results);
+    await rankSearchResults("test", results, true);
+
+    expect(getRerankingStats().reranks).toBe(before.reranks + 2);
+
+    // Reranking nothing is not a rerank: a search with no results still
+    // reaches here, and counting it would pull the average toward zero.
+    mockRerank.mockResolvedValue(
+      [] as { index: number; relevance_score: number }[],
+    );
+    await rankSearchResults("test", []);
+
+    expect(getRerankingStats().reranks).toBe(before.reranks + 2);
+  });
+
+  it("counts the results the score filter considered and kept", async () => {
+    const { getRerankingStats } = await import("./rerankingSinceLastRestart");
+    const { rankSearchResults } = await import("./rankSearchResults");
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 9 },
+      { index: 1, relevance_score: 8.9 },
+      { index: 2, relevance_score: 8.8 },
+    ] as { index: number; relevance_score: number }[]);
+
+    const before = getRerankingStats();
+    const ranked = await rankSearchResults("test", [
+      ["A", "a", "https://a.com"],
+      ["B", "b", "https://b.com"],
+      ["C", "c", "https://c.com"],
+    ]);
+    const after = getRerankingStats();
+
+    // Counts, not just the ratio: the ratio alone passes for any
+    // implementation that returns a percentage.
+    expect(after.considered).toBe(before.considered + 3);
+    expect(after.kept).toBe(before.kept + ranked.length);
+  });
+
   it("reports how many results survived the score filter", async () => {
     const { getRerankingStats } = await import("./rerankingSinceLastRestart");
     const before = getRerankingStats();

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -17,13 +17,18 @@ export async function rankSearchResults(
     if (filtered.fellBackToPercentage) usedPercentageFallback = true;
     return filtered.items;
   };
-  const report = (kept: number) =>
+  // A search with no results still reaches here, and reranking nothing is not
+  // a rerank: counting it would drag the average toward zero on exactly the
+  // instances where searches are coming back empty.
+  const report = (considered: number, kept: number) => {
+    if (considered === 0) return;
     recordRerank({
-      considered: searchResults.length,
+      considered,
       kept,
       durationMs: performance.now() - startedAt,
       usedPercentageFallback,
     });
+  };
 
   const results = await rerank(query, documents);
 
@@ -33,7 +38,6 @@ export async function rankSearchResults(
   }));
 
   if (scoredResults.length === 0) {
-    report(0);
     return [];
   }
 
@@ -41,7 +45,7 @@ export async function rankSearchResults(
     const ranked = filterResults(scoredResults)
       .sort((a, b) => b.score - a.score)
       .map(({ result }) => result);
-    report(ranked.length);
+    report(scoredResults.length, ranked.length);
     return ranked;
   }
 
@@ -62,7 +66,7 @@ export async function rankSearchResults(
   const ranked = [firstResult, ...nextTopResults, ...remainingResults].map(
     ({ result }) => result,
   );
-  report(ranked.length);
+  report(scoredResults.length, ranked.length);
   return ranked;
 }
 

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -1,4 +1,5 @@
 import { rerank } from "./rerankerService.ts";
+import { recordRerank } from "./rerankingSinceLastRestart.ts";
 
 export async function rankSearchResults(
   query: string,
@@ -9,6 +10,21 @@ export async function rankSearchResults(
     ([title, snippet]) => `${title}\n${snippet}`,
   );
 
+  const startedAt = performance.now();
+  let usedPercentageFallback = false;
+  const filterResults = (items: ScoredResultItem[]) => {
+    const filtered = filterResultsByScore(items);
+    if (filtered.fellBackToPercentage) usedPercentageFallback = true;
+    return filtered.items;
+  };
+  const report = (kept: number) =>
+    recordRerank({
+      considered: searchResults.length,
+      kept,
+      durationMs: performance.now() - startedAt,
+      usedPercentageFallback,
+    });
+
   const results = await rerank(query, documents);
 
   const scoredResults = results.map(({ index, relevance_score }) => ({
@@ -17,18 +33,21 @@ export async function rankSearchResults(
   }));
 
   if (scoredResults.length === 0) {
+    report(0);
     return [];
   }
 
   if (!preserveTopResults) {
-    return filterResultsByScore(scoredResults)
+    const ranked = filterResults(scoredResults)
       .sort((a, b) => b.score - a.score)
       .map(({ result }) => result);
+    report(ranked.length);
+    return ranked;
   }
 
   const [firstResult, ...nextResults] = scoredResults;
 
-  const filteredNextResults = filterResultsByScore(nextResults);
+  const filteredNextResults = filterResults(nextResults);
 
   const nextTopResultsCount = 9;
 
@@ -40,9 +59,11 @@ export async function rankSearchResults(
     .slice(nextTopResultsCount)
     .sort((a, b) => b.score - a.score);
 
-  return [firstResult, ...nextTopResults, ...remainingResults].map(
+  const ranked = [firstResult, ...nextTopResults, ...remainingResults].map(
     ({ result }) => result,
   );
+  report(ranked.length);
+  return ranked;
 }
 
 type SearchResultTuple = [title: string, content: string, url: string];
@@ -51,12 +72,21 @@ type ScoredResultItemWithNormalizedScore = ScoredResultItem & {
   normalizedScore: number;
 };
 
+/**
+ * Returns the surviving results and whether the percentage fallback had to
+ * rescue them, which is the signal that `kStandardDeviationFactor` emptied a
+ * batch it should not have.
+ */
 function filterResultsByScore(
   inputResults: ScoredResultItem[],
   kStandardDeviationFactor = 0.3,
   minPercentageFallback = 0.4,
-): ScoredResultItemWithNormalizedScore[] {
-  if (inputResults.length === 0) return [];
+): {
+  items: ScoredResultItemWithNormalizedScore[];
+  fellBackToPercentage: boolean;
+} {
+  if (inputResults.length === 0)
+    return { items: [], fellBackToPercentage: false };
 
   const originalScores = inputResults.map(({ score }) => score);
   const minScore = Math.min(...originalScores);
@@ -87,6 +117,8 @@ function filterResultsByScore(
     ({ normalizedScore }) => normalizedScore >= threshold,
   );
 
+  let fellBackToPercentage = false;
+
   if (
     filteredItems.length <
       Math.ceil(itemsWithNormalizedScore.length * minPercentageFallback) &&
@@ -97,7 +129,8 @@ function filterResultsByScore(
       ({ normalizedScore }) =>
         normalizedScore >= highestNormalizedScore * minPercentageFallback,
     );
+    fellBackToPercentage = true;
   }
 
-  return filteredItems;
+  return { items: filteredItems, fellBackToPercentage };
 }

--- a/server/rerankingSinceLastRestart.ts
+++ b/server/rerankingSinceLastRestart.ts
@@ -52,6 +52,8 @@ export function getRerankingStats() {
   return {
     reranks,
     averageMs: Math.round(totalMs / reranks || 0),
+    considered: totalConsidered,
+    kept: totalKept,
     keptRate: Number(((totalKept / totalConsidered) * 100 || 0).toFixed(1)),
     fallbackApplied,
     skippedUnhealthy,

--- a/server/rerankingSinceLastRestart.ts
+++ b/server/rerankingSinceLastRestart.ts
@@ -1,0 +1,60 @@
+/**
+ * Aggregate counters for the reranking stage.
+ *
+ * The reranker sees the query and every snippet, and none of that is kept: how
+ * many results came in, how many survived the score filter, how long the model
+ * took, and how often it was unavailable. Those are the numbers the filter's
+ * two thresholds should be moved against, and today they have none.
+ */
+
+let reranks = 0;
+let totalMs = 0;
+let totalConsidered = 0;
+let totalKept = 0;
+let fallbackApplied = 0;
+let skippedUnhealthy = 0;
+let failed = 0;
+
+export function recordRerank({
+  considered,
+  kept,
+  durationMs,
+  usedPercentageFallback,
+}: {
+  considered: number;
+  kept: number;
+  durationMs: number;
+  usedPercentageFallback: boolean;
+}): void {
+  reranks++;
+  totalMs += durationMs;
+  totalConsidered += considered;
+  totalKept += kept;
+  if (usedPercentageFallback) fallbackApplied++;
+}
+
+/** The model was not loaded, so the endpoint served SearXNG's own order. */
+export function recordRerankSkipped(): void {
+  skippedUnhealthy++;
+}
+
+/** The model was loaded and reranking threw anyway. */
+export function recordRerankFailed(): void {
+  failed++;
+}
+
+/**
+ * `keptRate` is a share rather than a count for the same reason
+ * `pageReads.excerptKeptRate` is: a count of searches whose results were
+ * filtered reads ~100% whatever the threshold is, and settles nothing.
+ */
+export function getRerankingStats() {
+  return {
+    reranks,
+    averageMs: Math.round(totalMs / reranks || 0),
+    keptRate: Number(((totalKept / totalConsidered) * 100 || 0).toFixed(1)),
+    fallbackApplied,
+    skippedUnhealthy,
+    failed,
+  };
+}

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -23,6 +23,10 @@ vi.mock("./rerankerService", () => ({
 vi.mock("./searchesSinceLastRestart", () => ({
   incrementTextualSearchesSinceLastRestart: vi.fn(),
   incrementGraphicalSearchesSinceLastRestart: vi.fn(),
+  recordSearchDuration: vi.fn(),
+  recordThumbnailRequested: vi.fn(),
+  recordThumbnailDropped: vi.fn(),
+  recordThumbnailBlocked: vi.fn(),
 }));
 
 vi.mock("./webSearchService", () => ({
@@ -36,6 +40,10 @@ import { searchEndpointServerHook } from "./searchEndpointServerHook";
 import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
+  recordSearchDuration,
+  recordThumbnailBlocked,
+  recordThumbnailDropped,
+  recordThumbnailRequested,
 } from "./searchesSinceLastRestart";
 import { fetchSearXNG } from "./webSearchService";
 
@@ -625,5 +633,132 @@ describe("searchEndpointServerHook", () => {
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify({ error: "Internal server error" }),
     );
+  });
+  describe("search path counters", () => {
+    it("records how long SearXNG took on a text search", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([
+        ["Title", "Snippet", "https://example.com"],
+      ]);
+      const handler = getRegisteredHandler();
+
+      await handler(
+        createRequest("/search/text?q=test&token=abc"),
+        createResponse(),
+        vi.fn(),
+      );
+
+      expect(recordSearchDuration).toHaveBeenCalledWith(
+        "text",
+        expect.any(Number),
+      );
+    });
+
+    it("does not record a duration when SearXNG fails", async () => {
+      vi.mocked(fetchSearXNG).mockRejectedValue(new Error("down"));
+      const handler = getRegisteredHandler();
+
+      await handler(
+        createRequest("/search/text?q=test&token=abc"),
+        createResponse(),
+        vi.fn(),
+      );
+
+      expect(recordSearchDuration).not.toHaveBeenCalled();
+    });
+
+    it("counts a thumbnail that was fetched and one that was dropped", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([
+        [
+          "picture",
+          "https://example.com/page",
+          "https://example.com/thumb.jpg",
+          "https://example.com/full.jpg",
+        ],
+      ]);
+      mockFetch.mockRejectedValue(new Error("thumbnail host down"));
+      const handler = getRegisteredHandler();
+
+      await handler(
+        createRequest("/search/images?q=test&token=abc"),
+        createResponse(),
+        vi.fn(),
+      );
+
+      expect(recordThumbnailRequested).toHaveBeenCalledTimes(1);
+      expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+      expect(recordThumbnailBlocked).not.toHaveBeenCalled();
+    });
+
+    it("counts a thumbnail refused for resolving outside public space", async () => {
+      vi.mocked(fetchSearXNG).mockResolvedValue([
+        [
+          "picture",
+          "https://example.com/page",
+          "https://169.254.169.254/thumb.jpg",
+          "https://example.com/full.jpg",
+        ],
+      ]);
+      lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+      const handler = getRegisteredHandler();
+
+      await handler(
+        createRequest("/search/images?q=test&token=abc"),
+        createResponse(),
+        vi.fn(),
+      );
+
+      expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
+      // Blocked thumbnails are dropped too, so the requested total stays closed.
+      expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+    });
+
+    it("counts the searches served without the reranker", async () => {
+      const { getRerankingStats } = await import("./rerankingSinceLastRestart");
+      const before = getRerankingStats();
+      vi.mocked(getRerankerStatus).mockResolvedValue(false);
+      vi.mocked(fetchSearXNG).mockResolvedValue([
+        ["Title", "Snippet", "https://example.com"],
+      ]);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const handler = getRegisteredHandler();
+
+      try {
+        await handler(
+          createRequest("/search/text?q=test&token=abc"),
+          createResponse(),
+          vi.fn(),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+
+      expect(getRerankingStats().skippedUnhealthy).toBe(
+        before.skippedUnhealthy + 1,
+      );
+    });
+
+    it("counts a rerank that threw mid-request", async () => {
+      const { getRerankingStats } = await import("./rerankingSinceLastRestart");
+      const before = getRerankingStats();
+      vi.mocked(getRerankerStatus).mockResolvedValue(true);
+      vi.mocked(rankSearchResults).mockRejectedValue(new Error("model gone"));
+      vi.mocked(fetchSearXNG).mockResolvedValue([
+        ["Title", "Snippet", "https://example.com"],
+      ]);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const handler = getRegisteredHandler();
+
+      try {
+        await handler(
+          createRequest("/search/text?q=test&token=abc"),
+          createResponse(),
+          vi.fn(),
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(getRerankingStats().failed).toBe(before.failed + 1);
+    });
   });
 });

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -4,8 +4,16 @@ import { handleTokenVerification } from "./handleTokenVerification.ts";
 import { rankSearchResults } from "./rankSearchResults.ts";
 import { getRerankerStatus } from "./rerankerService.ts";
 import {
+  recordRerankFailed,
+  recordRerankSkipped,
+} from "./rerankingSinceLastRestart.ts";
+import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
+  recordSearchDuration,
+  recordThumbnailBlocked,
+  recordThumbnailDropped,
+  recordThumbnailRequested,
 } from "./searchesSinceLastRestart.ts";
 import { resolvePublicUrl } from "./utils/publicUrl.ts";
 import { readCappedBytes } from "./utils/streamUtils.ts";
@@ -44,6 +52,7 @@ type ImageResult = [
 ];
 
 async function fetchThumbnailAsDataUrl(thumbnailSource: string) {
+  recordThumbnailRequested();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), THUMBNAIL_TIMEOUT_MS);
   try {
@@ -57,6 +66,7 @@ async function fetchThumbnailAsDataUrl(thumbnailSource: string) {
         // Malformed, non-HTTP, or a private/link-local/reserved address:
         // do not fetch it on the server's behalf. Throwing lets the caller's
         // catch drop the whole image result, matching the other failure paths.
+        recordThumbnailBlocked();
         throw new Error(
           "Refusing to fetch thumbnail from a non-public address",
         );
@@ -106,6 +116,7 @@ async function handleRanking(
 ): Promise<[title: string, content: string, url: string][]> {
   const isRerankerHealthy = await getRerankerStatus();
   if (!isRerankerHealthy) {
+    recordRerankSkipped();
     console.warn("Reranker service is not healthy, using unranked results");
   }
 
@@ -115,6 +126,7 @@ async function handleRanking(
     }
     return results;
   } catch (error) {
+    recordRerankFailed();
     console.error(
       "Error ranking search results:",
       error instanceof Error ? error.message : error,
@@ -168,8 +180,10 @@ export function searchEndpointServerHook<
       const searchType = isTextSearch ? "text" : "images";
 
       let searxngResults: TextResult[] | ImageResult[];
+      const searchStartedAt = performance.now();
       try {
         searxngResults = await fetchSearXNG(query, searchType, limit);
+        recordSearchDuration(searchType, performance.now() - searchStartedAt);
       } catch {
         // SearXNG is unreachable: answer non-200 so the client can tell an
         // outage apart from a search that genuinely has no results.
@@ -208,6 +222,7 @@ export function searchEndpointServerHook<
 
                 return [title, url, thumbnail, sourceUrl] as ImageResult;
               } catch {
+                recordThumbnailDropped();
                 return null;
               }
             }),

--- a/server/searchesSinceLastRestart.ts
+++ b/server/searchesSinceLastRestart.ts
@@ -57,8 +57,6 @@ export function incrementSearchesWithAllResultsDiscardedSinceLastRestart() {
 
 let textualSearchMs = 0;
 let graphicalSearchMs = 0;
-let searchesWithGroundingSinceLastRestart = 0;
-let searchesWithoutGroundingSinceLastRestart = 0;
 let thumbnailsRequested = 0;
 let thumbnailsDropped = 0;
 let thumbnailsBlocked = 0;
@@ -72,16 +70,6 @@ export function recordSearchDuration(
   else graphicalSearchMs += durationMs;
 }
 
-/**
- * Whether one search got any page content to ground its answer on.
- * `pageReads` counts pages; this counts searches, and a 50% read rate means
- * something different depending on which of the two it came from.
- */
-export function recordGroundingOutcome(hadContent: boolean): void {
-  if (hadContent) searchesWithGroundingSinceLastRestart++;
-  else searchesWithoutGroundingSinceLastRestart++;
-}
-
 export function recordThumbnailRequested(): void {
   thumbnailsRequested++;
 }
@@ -91,7 +79,11 @@ export function recordThumbnailDropped(): void {
   thumbnailsDropped++;
 }
 
-/** Refused because the host resolved outside public space: a security signal, not a tuning one. */
+/**
+ * Refused before any request was made: malformed, non-HTTP, unresolvable, or
+ * resolving outside public space. The SSRF guard does not distinguish them, so
+ * a dead thumbnail host lands here next to a genuine private-address attempt.
+ */
 export function recordThumbnailBlocked(): void {
   thumbnailsBlocked++;
 }
@@ -104,8 +96,6 @@ export function getSearchStats() {
     averageGraphicalMs: Math.round(
       graphicalSearchMs / graphicalSearchesSinceLastRestart || 0,
     ),
-    withGrounding: searchesWithGroundingSinceLastRestart,
-    withoutGrounding: searchesWithoutGroundingSinceLastRestart,
   };
 }
 

--- a/server/searchesSinceLastRestart.ts
+++ b/server/searchesSinceLastRestart.ts
@@ -49,3 +49,70 @@ export function getSearchesWithAllResultsDiscardedSinceLastRestart() {
 export function incrementSearchesWithAllResultsDiscardedSinceLastRestart() {
   searchesWithAllResultsDiscardedSinceLastRestart++;
 }
+
+// The counters below are the numbers behind the constants in the search path:
+// the client's request timeout, the thumbnail timeout and byte cap, and whether
+// the pages behind the results contribute anything. Same basis as the rest of
+// this file: totals and running sums, never a query and never a URL.
+
+let textualSearchMs = 0;
+let graphicalSearchMs = 0;
+let searchesWithGroundingSinceLastRestart = 0;
+let searchesWithoutGroundingSinceLastRestart = 0;
+let thumbnailsRequested = 0;
+let thumbnailsDropped = 0;
+let thumbnailsBlocked = 0;
+
+/** One SearXNG round trip, retries and backoff included, so it stays comparable with the timeouts it is there to tune. */
+export function recordSearchDuration(
+  searchType: "text" | "images",
+  durationMs: number,
+): void {
+  if (searchType === "text") textualSearchMs += durationMs;
+  else graphicalSearchMs += durationMs;
+}
+
+/**
+ * Whether one search got any page content to ground its answer on.
+ * `pageReads` counts pages; this counts searches, and a 50% read rate means
+ * something different depending on which of the two it came from.
+ */
+export function recordGroundingOutcome(hadContent: boolean): void {
+  if (hadContent) searchesWithGroundingSinceLastRestart++;
+  else searchesWithoutGroundingSinceLastRestart++;
+}
+
+export function recordThumbnailRequested(): void {
+  thumbnailsRequested++;
+}
+
+/** Counts every thumbnail that never reached the client, `blocked` ones included. */
+export function recordThumbnailDropped(): void {
+  thumbnailsDropped++;
+}
+
+/** Refused because the host resolved outside public space: a security signal, not a tuning one. */
+export function recordThumbnailBlocked(): void {
+  thumbnailsBlocked++;
+}
+
+export function getSearchStats() {
+  return {
+    averageTextualMs: Math.round(
+      textualSearchMs / textualSearchesSinceLastRestart || 0,
+    ),
+    averageGraphicalMs: Math.round(
+      graphicalSearchMs / graphicalSearchesSinceLastRestart || 0,
+    ),
+    withGrounding: searchesWithGroundingSinceLastRestart,
+    withoutGrounding: searchesWithoutGroundingSinceLastRestart,
+  };
+}
+
+export function getThumbnailStats() {
+  return {
+    requested: thumbnailsRequested,
+    dropped: thumbnailsDropped,
+    blocked: thumbnailsBlocked,
+  };
+}

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -4,15 +4,24 @@ import { getAuthorizationStats } from "./authorizationSinceLastRestart.ts";
 import { getInferenceStats } from "./inferencesSinceLastRestart.ts";
 import { getPageReadStats } from "./pageReadsSinceLastRestart.ts";
 import { getRerankerStatus } from "./rerankerService.ts";
+import { getRerankingStats } from "./rerankingSinceLastRestart.ts";
 import {
   getGraphicalSearchesSinceLastRestart,
   getSearchesWithAllResultsDiscardedSinceLastRestart,
   getSearchesWithoutResultsSinceLastRestart,
   getSearchesWithUnresponsiveEnginesSinceLastRestart,
+  getSearchStats,
   getTextualSearchesSinceLastRestart,
+  getThumbnailStats,
 } from "./searchesSinceLastRestart.ts";
-import { getVerifiedTokensAmount } from "./verifiedTokens.ts";
-import { getWebSearchStatus } from "./webSearchService.ts";
+import {
+  getActiveSessionsAmount,
+  getVerifiedTokensAmount,
+} from "./verifiedTokens.ts";
+import {
+  getSearchCircuitStats,
+  getWebSearchStatus,
+} from "./webSearchService.ts";
 
 const serverStartTime = Date.now();
 
@@ -70,6 +79,10 @@ export function statusEndpointServerHook<
       pageReads: getPageReadStats(),
       authorization: getAuthorizationStats(),
       inference: getInferenceStats(),
+      activeSessions: getActiveSessionsAmount(),
+      searches: { ...getSearchStats(), ...getSearchCircuitStats() },
+      reranker: getRerankingStats(),
+      thumbnails: getThumbnailStats(),
       build: {
         timestamp: new Date(
           server.config.define?.VITE_BUILD_DATE_TIME || "",

--- a/server/utils/circuitBreaker.test.ts
+++ b/server/utils/circuitBreaker.test.ts
@@ -75,4 +75,44 @@ describe("CircuitBreaker", () => {
       expect(stateAfter === "OPEN" || stateAfter === "HALF_OPEN").toBe(true);
     });
   });
+  describe("getOpens", () => {
+    it("returns zero for a circuit that never opened", () => {
+      const cb = new CircuitBreaker();
+      expect(cb.getOpens("unknown")).toBe(0);
+    });
+
+    it("counts one opening per trip and keeps the count after a reset", async () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 2,
+        resetTimeout: 0,
+        successThreshold: 1,
+      });
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        await expect(
+          cb.execute("upstream", async () => {
+            throw new Error("down");
+          }),
+        ).rejects.toThrow("down");
+      }
+
+      expect(cb.getState("upstream")).toBe("OPEN");
+      expect(cb.getOpens("upstream")).toBe(1);
+
+      // A call while the circuit is open is refused without reaching the
+      // upstream, and counts as no new opening.
+      await expect(
+        cb.execute("upstream", async () => "never runs"),
+      ).rejects.toThrow("Circuit breaker is open");
+      expect(cb.getOpens("upstream")).toBe(1);
+
+      // The reset timer is a macrotask, so the half-open transition needs one
+      // turn of the loop before a recovery can go through.
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      await cb.execute("upstream", async () => "back");
+      expect(cb.getState("upstream")).toBe("CLOSED");
+      // The count is since-restart, so closing the circuit does not clear it.
+      expect(cb.getOpens("upstream")).toBe(1);
+    });
+  });
 });

--- a/server/utils/circuitBreaker.ts
+++ b/server/utils/circuitBreaker.ts
@@ -11,6 +11,8 @@ interface CircuitMetrics {
   successes: number;
   lastFailure?: number;
   state: CircuitState;
+  /** Times this circuit has opened, which `resetMetrics` deliberately keeps. */
+  opens: number;
 }
 
 const defaultOptions: CircuitBreakerOptions = {
@@ -53,12 +55,22 @@ export class CircuitBreaker {
     return this.metrics.get(key)?.state || "CLOSED";
   }
 
+  /**
+   * How often this circuit has opened. A closed circuit says nothing about
+   * whether the instance spent the last hour serving no searches at all, which
+   * is what this answers.
+   */
+  getOpens(key: string): number {
+    return this.metrics.get(key)?.opens ?? 0;
+  }
+
   private getOrCreateMetrics(key: string): CircuitMetrics {
     if (!this.metrics.has(key)) {
       this.metrics.set(key, {
         failures: 0,
         successes: 0,
         state: "CLOSED",
+        opens: 0,
       });
     }
 
@@ -98,6 +110,7 @@ export class CircuitBreaker {
       metrics.state !== "OPEN"
     ) {
       metrics.state = "OPEN";
+      metrics.opens++;
       setTimeout(() => {
         if (metrics.state === "OPEN") {
           metrics.state = "HALF_OPEN";

--- a/server/verifiedTokens.test.ts
+++ b/server/verifiedTokens.test.ts
@@ -63,4 +63,21 @@ describe("verifiedTokens", () => {
 
     expect(isVerifiedToken("active")).toBe(true);
   });
+  it("reports the sessions still in the cache apart from the cumulative count", async () => {
+    const {
+      addVerifiedToken,
+      getActiveSessionsAmount,
+      getVerifiedTokensAmount,
+    } = await import("./verifiedTokens");
+
+    const cumulativeBefore = getVerifiedTokensAmount();
+    const activeBefore = getActiveSessionsAmount();
+
+    addVerifiedToken("active-token-a");
+    addVerifiedToken("active-token-b");
+    addVerifiedToken("active-token-a");
+
+    expect(getVerifiedTokensAmount()).toBe(cumulativeBefore + 2);
+    expect(getActiveSessionsAmount()).toBe(activeBefore + 2);
+  });
 });

--- a/server/verifiedTokens.ts
+++ b/server/verifiedTokens.ts
@@ -35,6 +35,15 @@ export function getVerifiedTokensAmount() {
   return sessionCount;
 }
 
+/**
+ * Sessions still in the cache, which is the number of people the instance is
+ * serving right now. `getVerifiedTokensAmount` is the cumulative one, and the
+ * two together say whether a busy day was many short visits or a few long ones.
+ */
+export function getActiveSessionsAmount() {
+  return verifiedTokens.size;
+}
+
 export function isVerifiedToken(token: string) {
   return verifiedTokens.has(token);
 }

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -77,6 +77,18 @@ export async function startWebSearchService() {
   }
 }
 
+/**
+ * The state of the circuit in front of SearXNG, and how often it has opened. An
+ * open circuit answers every search with a failure without calling SearXNG at
+ * all, which no other counter distinguishes from SearXNG being down.
+ */
+export function getSearchCircuitStats() {
+  return {
+    circuitState: searxngCircuitBreaker.getState("searxng"),
+    circuitOpens: searxngCircuitBreaker.getOpens("searxng"),
+  };
+}
+
 export async function getWebSearchStatus() {
   try {
     const response = await fetch(`${SERVICE_BASE_URL}/healthz`, {


### PR DESCRIPTION
## Description

Eight constants in the search path decide what a user sees, and none of them had a number behind it. `pageReads` was built for exactly this job and stopped at page reading: nothing timed a SearXNG round trip, nothing said whether the circuit breaker had been open, nothing reported what the reranker's two score-filter thresholds actually do, and an image whose thumbnail failed was dropped in silence.

`/status` now carries `searches`, `reranker` and `thumbnails`, plus `activeSessions`. Every row in the docs names the constant it exists to move, the way the `pageReads` table already does, so the payload answers "what should we change" and not just "what happened".

Two corrections came out of writing it. `sessions` was documented as active sessions while `getVerifiedTokensAmount` returns the cumulative count since restart, and two other lines still described `verifiedTokens` as a `Set<string>` when it has been a `Map` with idle eviction for a while. And the grounded-vs-not pair, which counts `/page-content` requests, now lives under `pageReads.grounding` where that denominator is true, rather than under `searches` where it read as one search in two.

### What changed

| File | Change |
| --- | --- |
| `server/searchesSinceLastRestart.ts` | SearXNG round-trip sums per search type, and the three thumbnail counters |
| `server/rerankingSinceLastRestart.ts` | New: reranks, duration, considered and kept with their rate, percentage-fallback rescues, and the searches served unranked because the model was missing or threw |
| `server/rankSearchResults.ts` | `filterResultsByScore` returns whether the percentage fallback rescued the batch; a batch with nothing in it is no longer reported as a rerank |
| `server/utils/circuitBreaker.ts` | Counts how often each circuit opened, and keeps the count across a reset |
| `server/webSearchService.ts` | Exposes the SearXNG circuit's state and opens |
| `server/searchEndpointServerHook.ts` | Times the SearXNG call, counts thumbnails requested, dropped and refused, and records a skipped or failed rerank |
| `server/pageContentEndpointServerHook.ts`, `server/pageReadsSinceLastRestart.ts` | Grounding per request, as `pageReads.grounding` |
| `server/verifiedTokens.ts` | `getActiveSessionsAmount`, the sessions still in the cache |
| `server/statusEndpointServerHook.ts` | Four new fields |
| Tests | 14 new cases across five files, including the circuit-open count surviving a reset and the two rerank paths reporting exactly once |
| `docs/overview.md`, `docs/reranking.md` | The three field tables, the grounding rows, the two corrections above, and a pointer from the reranker's own page |

What these make answerable, since that is the point: `reranker.keptRate` near 100% means `kStandardDeviationFactor` is not filtering; a large `reranker.fallbackApplied` means the deviation threshold keeps emptying batches the percentage fallback then rescues, which is two constants pretending to be one; `reranker.averageMs` next to `searches.averageTextualMs` says whether reranking or SearXNG is what users wait for, and so whether reranking a shortlist is worth doing; `thumbnails.dropped` as a share of `requested` says how much of an image search never renders; `grounding.withoutContent` says how often an answer ran on snippets alone; and `circuitOpens` is the only number that distinguishes minutes of serving nothing from SearXNG merely being slow.

Two things deliberately left as they are. `reranker`'s rate pools text and image reranks, which run through different paths, so it moves with the traffic mix as well as with the threshold; the row says so, and splitting it is a follow-up if the pooled number proves unreadable. And `thumbnails.blocked` counts everything `resolvePublicUrl` refuses, including an unresolvable host, because the guard does not distinguish them; the row says that too, and `pageReads.skipped.blocked` has the same conflation with the same wording problem, which is worth a separate pass.

## How to test

1. `npm run test` (681 passing in 59 files, 14 new) and `npm run lint`.
2. Search for something, then `curl localhost:7860/status`: `searches.averageTextualMs` is your round trip, `reranker.considered` and `kept` bracket `keptRate`, and `thumbnails.requested` matches the image results you got.
3. Point SearXNG at nothing and search five times: `searches.circuitOpens` reaches 1 and `circuitState` reads `OPEN`, which no other field shows.
4. Turn AI responses on and search again: `pageReads.grounding.requests` climbs, and `withoutContent` tells you whether the answer had anything to stand on.

Tripwires, run and reverted: dropping `recordThumbnailDropped()` reddens 2 cases, dropping the `fellBackToPercentage` flag reddens the fallback case, and reporting `kept` as the batch size reddens the counts case.

Closes #2415
