### PR TITLE
test: stop the circuit-breaker open-state test racing its own reset timer

### DIFF
--- a/server/utils/circuitBreaker.test.ts
+++ b/server/utils/circuitBreaker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CircuitBreaker } from "./circuitBreaker";
 
 describe("CircuitBreaker", () => {
@@ -76,15 +76,24 @@ describe("CircuitBreaker", () => {
     });
   });
   describe("getOpens", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("returns zero for a circuit that never opened", () => {
       const cb = new CircuitBreaker();
       expect(cb.getOpens("unknown")).toBe(0);
     });
 
     it("counts one opening per trip and keeps the count after a reset", async () => {
+      // Fake timers, because the refusal below only holds while the reset timer
+      // has not fired: on real timers the window is whatever the machine takes
+      // to reach the next line, which is not a window at all.
+      vi.useFakeTimers();
+      const resetTimeout = 1000;
       const cb = new CircuitBreaker({
         failureThreshold: 2,
-        resetTimeout: 0,
+        resetTimeout,
         successThreshold: 1,
       });
 
@@ -106,9 +115,7 @@ describe("CircuitBreaker", () => {
       ).rejects.toThrow("Circuit breaker is open");
       expect(cb.getOpens("upstream")).toBe(1);
 
-      // The reset timer is a macrotask, so the half-open transition needs one
-      // turn of the loop before a recovery can go through.
-      await new Promise((resolve) => setTimeout(resolve, 1));
+      await vi.advanceTimersByTimeAsync(resetTimeout + 1);
       await cb.execute("upstream", async () => "back");
       expect(cb.getState("upstream")).toBe("CLOSED");
       // The count is since-restart, so closing the circuit does not clear it.


### PR DESCRIPTION
## Description

CI on `main` went red on [e0f8ae0a](https://github.com/felladrin/MiniSearch/commit/e0f8ae0a), in the `getOpens` test added by #2423:

```
FAIL server/utils/circuitBreaker.test.ts > CircuitBreaker > getOpens > counts one opening per trip and keeps the count after a reset
AssertionError: promise resolved "'never runs'" instead of rejecting
```

Root cause is the test, not the breaker. It configured `resetTimeout: 0`, which means `recordFailure` schedules the half-open transition for the next macrotask. The next assertion expects a call to be refused while the circuit is open, so the window it relies on is however long the runner takes to reach that line. Locally that is microseconds and the timer never gets a turn; on a loaded CI runner the timer fired first, the circuit went half-open, and the call ran the upstream and resolved.

Fake timers give the refusal a real window: the reset is now 1000 ms and nothing advances the clock until the test does. The recovery step advances the timers explicitly instead of sleeping 1 ms and hoping the transition already happened.

## How to test

```
npx vitest run server/utils/circuitBreaker.test.ts
```

10 passed, and 10 consecutive runs pass. Removing `metrics.opens++` from `server/utils/circuitBreaker.ts` fails it with `expected +0 to be 1`, so the assertion still holds the behavior it was written for.