### PR TITLE
Fix the unanchored www. strip in getHostname

### DIFF
--- a/client/modules/stringFormatters.test.ts
+++ b/client/modules/stringFormatters.test.ts
@@ -12,9 +12,14 @@ describe("stringFormatters", () => {
     it.each([
       ["https://example.com/page", "example.com"],
       ["https://www.example.com/page", "example.com"],
-      // A subdomain survives. Note the strip is unanchored today, so
-      // `my.www.example.com` still loses its middle label: see #2427.
+      // A subdomain survives.
       ["https://docs.example.com/page", "docs.example.com"],
+      // Anchored, so `www.` deeper in the host stays.
+      ["https://my.www.example.com/page", "my.www.example.com"],
+      // Anchored, so an overlapping `www.` at offset 1 is not a prefix.
+      ["https://wwww.example.com/page", "wwww.example.com"],
+      // The strip runs once, not per occurrence.
+      ["https://www.www.example.com/page", "www.example.com"],
       // The hostname, so the port stays out of it.
       ["https://localhost:3000", "localhost"],
       // Not a URL at all: hand back what came in, for display.

--- a/client/modules/stringFormatters.ts
+++ b/client/modules/stringFormatters.ts
@@ -2,7 +2,7 @@ import uFuzzy from "@leeoniya/ufuzzy";
 
 export function getHostname(url: string) {
   try {
-    return new URL(url).hostname.replace("www.", "");
+    return new URL(url).hostname.replace(/^www\./, "");
   } catch {
     return url;
   }


### PR DESCRIPTION
Currently, `getHostname` strips the first occurrence of `www.` anywhere in the hostname, because `String.replace` with a string pattern is unanchored. A result from `my.www.example.com` was displayed under `my.example.com`, and `wwww.example.com` under a host that does not exist (`wexample.com`), so a result could be attributed to a source the user never visited.

This PR anchors the pattern to `/^www\./`, so only a leading `www.` label is stripped.

## What changed

| File | Change |
| --- | --- |
| `client/modules/stringFormatters.ts` | Anchored the strip to the host prefix |
| `client/modules/stringFormatters.test.ts` | Rows for `my.www.example.com`, `wwww.example.com` and `www.www.example.com`; the rows fail on the old code |

## How to test

1. `npm test` (the three new rows fail when the anchoring is removed).

Closes #2427.
