### PR TITLE
Drop the unreachable date-only branch in getSemanticVersion

### DIFF
--- a/client/modules/stringFormatters.test.ts
+++ b/client/modules/stringFormatters.test.ts
@@ -35,10 +35,32 @@ describe("stringFormatters", () => {
       // Built in UTC, because the formatter reads UTC fields: a local-time Date
       // would format as the day before for anyone east of UTC.
       [new Date(Date.UTC(2024, 0, 15)), "2024.1.15"],
-      // A date-only string is read as UTC, so the day cannot shift westwards.
+      // Read as UTC, so the fixture pins the same instant on every runner.
       ["2024-06-01", "2024.6.1"],
     ])("dates %s as %s", (date, expected) => {
       expect(getSemanticVersion(date)).toBe(expected);
+    });
+
+    it("does not follow the runner's timezone", () => {
+      const originalTimeZone = process.env.TZ;
+      try {
+        // A UTC-midnight instant reads as the previous day only in a zone
+        // behind UTC; a zone ahead of it needs a late-in-the-day instant to
+        // read as the next day. So each direction pins its own. The
+        // getDate() checks make a silent no-op of the zone change fail
+        // loudly instead of passing vacuously.
+        process.env.TZ = "Pacific/Pago_Pago"; // UTC-11
+        const westMidnight = new Date(Date.UTC(2024, 0, 15));
+        expect(westMidnight.getDate()).toBe(14);
+        expect(getSemanticVersion(westMidnight)).toBe("2024.1.15");
+        process.env.TZ = "Pacific/Kiritimati"; // UTC+14
+        const eastLate = new Date(Date.UTC(2024, 5, 1, 23));
+        expect(eastLate.getDate()).toBe(2);
+        expect(getSemanticVersion(eastLate)).toBe("2024.6.1");
+      } finally {
+        if (originalTimeZone === undefined) delete process.env.TZ;
+        else process.env.TZ = originalTimeZone;
+      }
     });
   });
 

--- a/client/modules/stringFormatters.ts
+++ b/client/modules/stringFormatters.ts
@@ -9,10 +9,7 @@ export function getHostname(url: string) {
 }
 
 export function getSemanticVersion(date: number | string | Date) {
-  const targetDate =
-    typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
-      ? new Date(`${date}T00:00:00Z`)
-      : new Date(date);
+  const targetDate = new Date(date);
   return `${targetDate.getUTCFullYear()}.${targetDate.getUTCMonth() + 1}.${targetDate.getUTCDate()}`;
 }
 


### PR DESCRIPTION
`getSemanticVersion` special-cased `YYYY-MM-DD` strings by appending `T00:00:00Z` before parsing, but per [ECMA-262](https://tc39.es/ecma262/#sec-date-time-string-format) a date-only string is already interpreted as UTC, so the branch produced the same instant as `new Date(date)` for every input it matched. No test could distinguish the two arms, and it read as a guard against a timezone shift the spec already rules out.

This PR drops the branch, and pins the UTC formatting with a test that forces the runner's zone west and east of UTC.

## What changed

| File | Change |
| --- | --- |
| `client/modules/stringFormatters.ts` | Removed the unreachable date-only branch |
| `client/modules/stringFormatters.test.ts` | New test pins the output with `TZ` set to UTC-11 and UTC+14; each half fails independently when the formatter reads local fields, and a `getDate()` check per half makes a silent no-op of the zone change fail loudly |

## How to test

1. `npm test` (the new test fails when `getUTC*` is swapped for local `get*`).

Closes #2428.
