### PR TITLE
Pass on requests without a URL in the inference hook

### DIFF
--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -178,15 +178,15 @@ describe("internalApiEndpointServerHook", () => {
       expect(response.end).not.toHaveBeenCalled();
     });
 
-    it("responds 400 when request.url is missing", async () => {
+    it("passes on a request without a URL instead of answering for it", async () => {
       const handler = getRegisteredHandler();
+      const next = vi.fn();
       const response = createResponse();
       const request = createRequest({});
       request.url = undefined;
-      await handler(request, response, vi.fn());
-      expect(response.statusCode).toBe(400);
-      const payload = JSON.parse(response.end.mock.calls[0][0]);
-      expect(payload.error).toContain("URL is required");
+      await handler(request, response, next);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(response.end).not.toHaveBeenCalled();
     });
   });
 

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -134,12 +134,7 @@ export function internalApiEndpointServerHook<
       response: ServerResponse,
       next: () => void,
     ) => {
-      if (!request.url) {
-        sendJsonError(response, 400, { error: "Bad Request: URL is required" });
-        return;
-      }
-
-      if (!request.url.startsWith("/inference")) {
+      if (!request.url?.startsWith("/inference")) {
         return next();
       }
 


### PR DESCRIPTION
Currently, the `/inference` middleware tests `request.url` before it tests whether the request
is even for `/inference`. A request without a URL is therefore answered with a 400 by this
hook and never reaches the middleware that follows it. This hook is the last custom
middleware registered in `vite.config.ts`, so what a URL-less request was actually being
denied from was Vite's own internal handlers (static assets, SPA fallback, transform) - and
it was the only middleware in the chain that could answer for a path it does not own.

This PR passes such requests on: the hook now calls `next()` when the URL is missing or does
not start with `/inference`, using the same `!request.url?.startsWith(...)` guard as its
neighbors (`search`, `page-content`, `status`). Every request that carries a URL is handled
exactly as before, including the 405, 415 and 413 answers.

A note on reachability: Node sets `url` on every request it delivers, so this is a
robustness fix for an ordering/ownership problem rather than an observed bug. The safe
answer for a request a hook cannot identify is to pass it on, not to claim it.

## What changed

| File | Change |
| --- | --- |
| `server/internalApiEndpointServerHook.ts` | Missing URL now falls through to `next()` instead of answering 400, matching the sibling hooks' guard form |
| `server/internalApiEndpointServerHook.test.ts` | The `request.url is missing` case now asserts the request is passed on (`next` called, response untouched) |

## How to test

1. `npm test` (the updated guard case fails on the old 400 behavior).

Closes #2419.
