### PR TITLE
fix: rate-limit the access-key validation endpoint

### DIFF
--- a/client/components/Pages/AccessPage.tsx
+++ b/client/components/Pages/AccessPage.tsx
@@ -23,9 +23,12 @@ export default function AccessPage({
     setState((prev) => ({ ...prev, error: "" }));
     try {
       const isValid = await validateAccessKey(state.accessKey);
-      if (isValid) {
+      if (isValid === "valid") {
         addLogEntry("Valid access key entered");
         onAccessKeyValid();
+      } else if (isValid === "rateLimited") {
+        // The module already raised the refusal notice; no wrong-key error.
+        addLogEntry("Access key validation rate-limited");
       } else {
         setState((prev) => ({ ...prev, error: "Invalid access key" }));
         addLogEntry("Invalid access key attempt");

--- a/client/modules/accessKey.test.ts
+++ b/client/modules/accessKey.test.ts
@@ -28,6 +28,12 @@ vi.mock("./logEntries", () => ({
   addLogEntry: vi.fn(),
 }));
 
+vi.mock("@mantine/notifications", () => ({
+  notifications: {
+    show: vi.fn(),
+  },
+}));
+
 const TIMEOUT_HOURS = 24;
 
 describe("Access Key Module", () => {
@@ -42,7 +48,7 @@ describe("Access Key Module", () => {
   });
 
   describe("validateAccessKey", () => {
-    it("should return true for valid access key", async () => {
+    it("should return valid for a valid access key", async () => {
       const { validateAccessKey } = await import("./accessKey");
       mockFetch.mockResolvedValue({
         ok: true,
@@ -50,11 +56,11 @@ describe("Access Key Module", () => {
       });
 
       const result = await validateAccessKey("test-key-123");
-      expect(result).toBe(true);
+      expect(result).toBe("valid");
       expect(mockFetch).toHaveBeenCalled();
     });
 
-    it("should return false for invalid access key", async () => {
+    it("should return invalid for an invalid access key", async () => {
       const { validateAccessKey } = await import("./accessKey");
       mockFetch.mockResolvedValue({
         ok: true,
@@ -62,15 +68,15 @@ describe("Access Key Module", () => {
       });
 
       const result = await validateAccessKey("invalid-key");
-      expect(result).toBe(false);
+      expect(result).toBe("invalid");
     });
 
-    it("should return false on network error", async () => {
+    it("should return invalid on network error", async () => {
       const { validateAccessKey } = await import("./accessKey");
       mockFetch.mockRejectedValue(new Error("Network error"));
 
       const result = await validateAccessKey("test-key");
-      expect(result).toBe(false);
+      expect(result).toBe("invalid");
     });
 
     it("should send a hash the server can verify against the access key", async () => {
@@ -89,15 +95,32 @@ describe("Access Key Module", () => {
       expect(getDigestLength(await getHashSentFor("test-key-123"))).toBe(32);
     });
 
-    it("should return false when response is not ok", async () => {
+    it("should return invalid when response is not ok", async () => {
       const { validateAccessKey } = await import("./accessKey");
       mockFetch.mockResolvedValue({
         ok: false,
         status: 401,
+        json: vi.fn().mockResolvedValue({ valid: false }),
       });
 
       const result = await validateAccessKey("test-key");
-      expect(result).toBe(false);
+      expect(result).toBe("invalid");
+    });
+
+    it("treats a 429 as a rate-limited refusal and stores no hash", async () => {
+      const { validateAccessKey } = await import("./accessKey");
+      const { notifications } = await import("@mantine/notifications");
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+      });
+
+      const result = await validateAccessKey("test-key");
+      expect(result).toBe("rateLimited");
+      expect(localStorage.getItem("accessKeyHash")).toBeNull();
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Too many attempts" }),
+      );
     });
   });
 
@@ -161,6 +184,24 @@ describe("Access Key Module", () => {
 
       const result = await verifyStoredAccessKey(TIMEOUT_HOURS);
       expect(result).toBe(false);
+    });
+
+    it("keeps the stored hash on a 429 instead of deleting it", async () => {
+      const { verifyStoredAccessKey } = await import("./accessKey");
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+      });
+
+      localStorage.setItem(
+        "accessKeyHash",
+        JSON.stringify({ hash: "test-hash", timestamp: Date.now() }),
+      );
+      const result = await verifyStoredAccessKey(TIMEOUT_HOURS);
+
+      expect(result).toBe(false);
+      // A rate-limited validation must not be read as a wrong key.
+      expect(localStorage.getItem("accessKeyHash")).not.toBeNull();
     });
   });
 });

--- a/client/modules/accessKey.ts
+++ b/client/modules/accessKey.ts
@@ -30,7 +30,11 @@ async function hashAccessKey(accessKey: string): Promise<string> {
  * Validates the key against the server; on success the hash is stored locally
  * so later loads can go through `verifyStoredAccessKey`.
  */
-export async function validateAccessKey(accessKey: string): Promise<boolean> {
+export type AccessKeyResult = "valid" | "invalid" | "rateLimited";
+
+export async function validateAccessKey(
+  accessKey: string,
+): Promise<AccessKeyResult> {
   try {
     const hash = await hashAccessKey(accessKey);
     const response = await fetch("/api/validate-access-key", {
@@ -38,6 +42,20 @@ export async function validateAccessKey(accessKey: string): Promise<boolean> {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ accessKeyHash: hash }),
     });
+
+    // A 429 is "try again in a moment", not "wrong key": keep the two apart so
+    // the caller can show a refusal message instead of a wrong-key error.
+    if (response.status === 429) {
+      addLogEntry("Access key validation rate-limited");
+      notifications.show({
+        title: "Too many attempts",
+        message: "Please wait a few seconds and try again",
+        color: "yellow",
+        position: "top-right",
+      });
+      return "rateLimited";
+    }
+
     const data = await response.json();
 
     if (data.valid) {
@@ -47,9 +65,10 @@ export async function validateAccessKey(accessKey: string): Promise<boolean> {
       };
       localStorage.setItem(ACCESS_KEY_STORAGE_KEY, JSON.stringify(storedData));
       addLogEntry("Access key hash stored");
+      return "valid";
     }
 
-    return data.valid;
+    return "invalid";
   } catch (error) {
     addLogEntry(`Error validating access key: ${error}`);
     notifications.show({
@@ -58,7 +77,7 @@ export async function validateAccessKey(accessKey: string): Promise<boolean> {
       color: "red",
       position: "top-right",
     });
-    return false;
+    return "invalid";
   }
 }
 
@@ -89,6 +108,14 @@ export async function verifyStoredAccessKey(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ accessKeyHash: hash }),
     });
+
+    // A 429 must not be read as "wrong key": the stored hash may be fine and
+    // the caller simply hit the rate limiter. Keep the hash on disk so a
+    // later load can still validate it.
+    if (response.status === 429) {
+      addLogEntry("Stored access key validation rate-limited");
+      return false;
+    }
 
     const data = await response.json();
     if (!data.valid) {

--- a/server/validateAccessKeyServerHook.test.ts
+++ b/server/validateAccessKeyServerHook.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockArgon2Verify = vi.fn();
+const mockConsumeRateLimitPoint = vi.fn();
 
 vi.mock("hash-wasm", () => ({
   argon2Verify: (...args: unknown[]) => mockArgon2Verify(...args),
 }));
 
+vi.mock("./verifyTokenAndRateLimit", () => ({
+  consumeRateLimitPoint: (...args: unknown[]) =>
+    mockConsumeRateLimitPoint(...args),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Within budget by default; the rate-limited case opts out.
+  mockConsumeRateLimitPoint.mockResolvedValue(true);
 });
 
 function makeMockRequest(
@@ -108,16 +116,64 @@ describe("validateAccessKeyServerHook", () => {
     );
 
     await new Promise<void>((resolve) => {
-      handler(req as never, res as never, () => {});
-      // Trigger the end callback that the handler registered
-      for (const cb of req.endCallbacks) {
-        cb();
-      }
-      // argon2Verify is async, so we need to wait for it.
-      setTimeout(resolve, 50);
+      void handler(req as never, res as never, () => {});
+      // The handler consumes a rate-limit point (async) before it registers its
+      // end listener, so trigger it on a later macrotask.
+      setImmediate(() => {
+        for (const cb of req.endCallbacks) {
+          cb();
+        }
+        setTimeout(resolve, 50);
+      });
     });
 
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ valid: true }));
+    // The request was within budget, so the limiter let it through.
+    expect(mockConsumeRateLimitPoint).toHaveBeenCalledTimes(1);
+  });
+
+  it("responds 429 and skips the argon2 loop when the limiter refuses", async () => {
+    process.env.ACCESS_KEYS = "test-key";
+    mockConsumeRateLimitPoint.mockResolvedValue(false);
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: {
+        url: string;
+        method: string;
+        on: (event: string, cb: (chunk: string) => void) => void;
+      },
+      res: {
+        setHeader: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+        statusCode: number;
+      },
+      next: () => void,
+    ) => void;
+
+    const res = makeMockResponse();
+    const req = makeMockRequest(
+      "/api/validate-access-key",
+      "POST",
+      JSON.stringify({ accessKeyHash: "some-hash" }),
+    );
+
+    await new Promise<void>((resolve) => {
+      handler(req as never, res as never, () => {});
+      setTimeout(resolve, 50);
+    });
+
+    expect(res.statusCode).toBe(429);
+    expect(res.end).toHaveBeenCalledWith(
+      JSON.stringify({ error: "Too many requests." }),
+    );
+    // The limiter refused before the argon2 loop ran, so no key was verified.
+    expect(mockArgon2Verify).not.toHaveBeenCalled();
   });
 
   it("should return valid: false when no access keys match", async () => {
@@ -151,11 +207,13 @@ describe("validateAccessKeyServerHook", () => {
     );
 
     await new Promise<void>((resolve) => {
-      handler(req as never, res as never, () => {});
-      for (const cb of req.endCallbacks) {
-        cb();
-      }
-      setTimeout(resolve, 50);
+      void handler(req as never, res as never, () => {});
+      setImmediate(() => {
+        for (const cb of req.endCallbacks) {
+          cb();
+        }
+        setTimeout(resolve, 50);
+      });
     });
 
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ valid: false }));
@@ -188,11 +246,13 @@ describe("validateAccessKeyServerHook", () => {
     const req = makeMockRequest("/api/validate-access-key", "POST", "not-json");
 
     await new Promise<void>((resolve) => {
-      handler(req as never, res as never, () => {});
-      for (const cb of req.endCallbacks) {
-        cb();
-      }
-      setTimeout(resolve, 50);
+      void handler(req as never, res as never, () => {});
+      setImmediate(() => {
+        for (const cb of req.endCallbacks) {
+          cb();
+        }
+        setTimeout(resolve, 50);
+      });
     });
 
     expect(res.statusCode).toBe(400);

--- a/server/validateAccessKeyServerHook.ts
+++ b/server/validateAccessKeyServerHook.ts
@@ -1,5 +1,6 @@
 import { argon2Verify } from "hash-wasm";
 import type { PreviewServer, ViteDevServer } from "vite";
+import { consumeRateLimitPoint } from "./verifyTokenAndRateLimit.ts";
 
 /** POST /api/validate-access-key: checks an argon2id hash against the configured `ACCESS_KEYS`. */
 export function validateAccessKeyServerHook<
@@ -8,6 +9,19 @@ export function validateAccessKeyServerHook<
   server.middlewares.use(async (req, res, next) => {
     if (req.url !== "/api/validate-access-key" || req.method !== "POST") {
       return next();
+    }
+
+    // Consume a rate-limit point before the argon2 loop. A wrong hash costs one
+    // full argon2 verification per configured key, so nothing may bound that
+    // work other than the limiter - the same lever the search token path closes.
+    // It shares the search path's limiter, so a caller cannot hold a second
+    // budget. The answer is a 429, not a `{ valid: false }`, so a client can
+    // tell "too many attempts" from "wrong key".
+    if (!(await consumeRateLimitPoint(req))) {
+      res.statusCode = 429;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Too many requests." }));
+      return;
     }
 
     const accessKeys = process.env.ACCESS_KEYS?.split(",") ?? [];

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -6,6 +6,8 @@ let mockIsVerifiedToken = false;
 let mockRateLimiterShouldFail = false;
 const mockAddVerifiedToken = vi.fn();
 const mockConsume = vi.fn();
+// Every limiter instance that a consume touches; one module should mean one.
+const consumeInstances = new Set<unknown>();
 
 vi.mock("hash-wasm", () => ({
   argon2Verify: vi.fn(() => Promise.resolve(mockArgon2VerifyResult)),
@@ -14,6 +16,7 @@ vi.mock("hash-wasm", () => ({
 vi.mock("rate-limiter-flexible", () => ({
   RateLimiterMemory: class {
     consume = vi.fn((key: string) => {
+      consumeInstances.add(this);
       mockConsume(key);
       if (mockRateLimiterShouldFail) {
         return Promise.reject(new Error("Rate limit exceeded"));
@@ -199,6 +202,43 @@ describe("verifyTokenAndRateLimit", () => {
     const result = await verifyTokenAndRateLimit("fallback-token");
     expect(result.isAuthorized).toBe(true);
     expect(mockConsume).toHaveBeenCalledWith("fallback-token");
+  });
+});
+
+describe("consumeRateLimitPoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consumeInstances.clear();
+    mockRateLimiterShouldFail = false;
+  });
+
+  it("consumes from the limiter keyed on socket.remoteAddress when not behind a trusted proxy", async () => {
+    const { consumeRateLimitPoint } = await import("./verifyTokenAndRateLimit");
+    const mockReq = makeMockRequest("192.168.1.100");
+    expect(await consumeRateLimitPoint(mockReq)).toBe(true);
+    expect(mockConsume).toHaveBeenCalledWith("127.0.0.1");
+  });
+
+  it("reports out of budget when the limiter refuses", async () => {
+    mockRateLimiterShouldFail = true;
+    const { consumeRateLimitPoint } = await import("./verifyTokenAndRateLimit");
+    expect(await consumeRateLimitPoint(makeMockRequest("192.168.1.100"))).toBe(
+      false,
+    );
+  });
+
+  it("draws from the same limiter instance and key as the search path", async () => {
+    const { verifyTokenAndRateLimit, consumeRateLimitPoint } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const mockReq = makeMockRequest("192.168.1.100");
+    await verifyTokenAndRateLimit("valid-token", mockReq);
+    await consumeRateLimitPoint(mockReq);
+    // Both went through the one shared limiter, keyed on the same address.
+    expect(consumeInstances.size).toBe(1);
+    expect(mockConsume).toHaveBeenCalledTimes(2);
+    expect(mockConsume).toHaveBeenNthCalledWith(1, "127.0.0.1");
+    expect(mockConsume).toHaveBeenNthCalledWith(2, "127.0.0.1");
   });
 });
 

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -70,6 +70,27 @@ export function getClientIp(request: IncomingMessage): string {
   return request.socket.remoteAddress || "unknown";
 }
 
+/**
+ * Consume one point from the shared rate limiter for a request, keyed by the
+ * client IP. Returns `true` when the request is within budget, `false` when the
+ * limiter refuses it.
+ *
+ * It reuses the same limiter instance the search path consumes from, so a
+ * caller cannot get a second, independent budget by hitting a different
+ * endpoint. Endpoints that pay for expensive work without a token (access-key
+ * validation) must consume here before doing that work.
+ */
+export async function consumeRateLimitPoint(
+  request: IncomingMessage,
+): Promise<boolean> {
+  try {
+    await rateLimiter.consume(getClientIp(request));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function verifyTokenAndRateLimit(
   token: string | null,
   request?: IncomingMessage,


### PR DESCRIPTION
Currently, `POST /api/validate-access-key` loops over every entry in `ACCESS_KEYS` and runs `argon2Verify` against the submitted hash, breaking early only on a match. A wrong hash therefore costs one full argon2 verification per configured key, and the endpoint neither passes through `handleTokenVerification` nor touches the rate limiter, so nothing bounds how fast a caller can ask for that work — exactly the open path the issue describes.

Found while reviewing #2414.

Consume a rate-limit point from the shared limiter before the argon2 loop runs, and answer 429 when the limiter refuses, so the cost of guessing is bounded the same way it is on the search path. The endpoint takes no token, so it needs the limiter alone and not the token check that `handleTokenVerification` wraps around it.

Because the client was the only consumer, fixing the server response shape alone would have left `verifyStoredAccessKey` deleting a still-valid stored hash on 429 (reading the 429 as a wrong-key response). Both client functions now treat a 429 as a rate-limited refusal: `validateAccessKey` returns a three-valued result so `AccessPage` can show a refusal message instead of a wrong-key error, and `verifyStoredAccessKey` returns before the `removeItem` so a rate-limited load does not wipe a valid key.

## What changed

| File | Change |
| --- | --- |
| `server/verifyTokenAndRateLimit.ts` | Export `consumeRateLimitPoint`, keyed on the client IP, sharing the same limiter instance the search path uses |
| `server/validateAccessKeyServerHook.ts` | Consume a point before the argon2 loop; 429 when the limiter refuses |
| `client/modules/accessKey.ts` | `validateAccessKey` returns `AccessKeyResult` (`valid | invalid | rateLimited`) instead of `boolean`; 429 handled as a refusal, not a wrong key; `verifyStoredAccessKey` returns before `removeItem` on 429 |
| `client/components/Pages/AccessPage.tsx` | Branch on the three result values so a rate-limited submission does not show "Invalid access key" |
| `server/verifyTokenAndRateLimit.test.ts` | Three direct tests for `consumeRateLimitPoint`: keyed on `socket.remoteAddress`, returns false on refusal, and the search path and this function draw from the same limiter instance (`consumeInstances.size === 1`) |
| `server/validateAccessKeyServerHook.test.ts` | Case asserting the argon2 loop does not run when the limiter refuses, and the 429 is returned in its place |
| `client/modules/accessKey.test.ts` | Client 429 cases for both functions: `validateAccessKey` returns `rateLimited` without storing a hash (and the notifications call is asserted against the title); `verifyStoredAccessKey` keeps the stored hash intact |

## Where to start

Most of the diff is tests (165 insertions). The behavior change is ~35 lines of source across four files.

Two decisions worth a look:

- The limiter instance is shared (`verifyTokenAndRateLimit.ts:11`), so a caller cannot hold a second budget by hitting a different endpoint. The test pins this with `consumeInstances.size === 1`.
- `validateAccessKey` returns a three-valued result instead of a boolean, so the caller can distinguish "rate-limited" from "wrong key." The inline error in `AccessPage` stays out of the module — only the toast remains there.

What was left out: a `Retry-After` header on the 429 response (same surface as the "one point buys N argon2 verifies" follow-up you noted), and the `authorization` counter question from the issue (separate decision from the rate limit itself).

## How to test

1. `npm test` (650 passing — 650 now, 644 before the new tests).
2. `npm run lint` (biome, tsc, knip, jscpd, documentation validator all exit 0).

Closes #2418.
