### PR TITLE
fix: replace dead mid-retry model re-list with a reachable condition

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -347,7 +347,8 @@ request that never finished at all.
 Two fields read differently on a single-model deployment. With
 `INTERNAL_OPENAI_COMPATIBLE_API_MODEL` set there is no pool to fall back to, so
 the loop stops after the first failure: `averageAttempts` cannot exceed 1 and
-`modelFallbacks` stays at 0 however badly the upstream behaves. Read
+`modelFallbacks` stays at 0 however badly the upstream behaves. The pool also
+never refreshes in that mode, so `modelsRefetched` stays at 0; read
 `failed.failedBeforeFirstToken` for that case instead.
 
 Model ids are configuration rather than user data, and `/inference` already

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -783,6 +783,143 @@ describe("internalApiEndpointServerHook", () => {
       expect(writes).toContain("[DONE]");
     });
 
+    it("re-lists the model pool when every model has been attempted", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      // Only model-a in the initial pool; it fails, then the pool is refreshed
+      // to include model-b, which succeeds.
+      vi.mocked(listOpenAiCompatibleModels)
+        .mockResolvedValueOnce([{ id: "model-a" }])
+        .mockResolvedValueOnce([{ id: "model-b" }]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      let callCount = 0;
+      vi.mocked(streamText).mockImplementation(() => {
+        callCount += 1;
+        return (
+          callCount === 1
+            ? streamOf([{ type: "error", error: new Error("upstream down") }])
+            : streamOf([
+                { type: "text-delta", text: "Recovered" },
+                { type: "finish" },
+              ])
+        ) as never;
+      });
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // The pool was refreshed once, and the new model succeeded.
+        expect(listOpenAiCompatibleModels).toHaveBeenCalledTimes(2);
+        expect(streamText).toHaveBeenCalledTimes(2);
+        const writes = response.write.mock.calls.map((c) => c[0]).join("");
+        expect(writes).toContain("Recovered");
+        expect(writes).not.toContain("all models failed");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not re-list when a model remains in the pool", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      vi.mocked(listOpenAiCompatibleModels).mockResolvedValue([
+        { id: "model-a" },
+        { id: "model-b" },
+      ]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      let callCount = 0;
+      vi.mocked(streamText).mockImplementation(() => {
+        callCount += 1;
+        return (
+          callCount === 1
+            ? streamOf([{ type: "error", error: new Error("upstream down") }])
+            : streamOf([
+                { type: "text-delta", text: "Recovered" },
+                { type: "finish" },
+              ])
+        ) as never;
+      });
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // model-b is still in the pool, so no re-list is needed.
+        expect(listOpenAiCompatibleModels).toHaveBeenCalledTimes(1);
+        expect(streamText).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("re-lists only once even when both the original and refetched pools fail", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      // Only model-a in the initial pool; refetch yields model-b, which also fails.
+      vi.mocked(listOpenAiCompatibleModels)
+        .mockResolvedValueOnce([{ id: "model-a" }])
+        .mockResolvedValueOnce([{ id: "model-b" }]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "error", error: new Error("upstream down") },
+          ]) as never,
+      );
+
+      const before = getInferenceStats();
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // The pool was refreshed once; even though both models failed we do not
+        // loop on a failing /models endpoint.
+        expect(listOpenAiCompatibleModels).toHaveBeenCalledTimes(2);
+        // The refetched pool feeds selection — the second call receives it.
+        expect(vi.mocked(selectRandomModel).mock.calls[1][0]).toEqual([
+          { id: "model-b" },
+        ]);
+        expect(response.statusCode).toBe(503);
+        // The counter moved from the successful refetch.
+        expect(getInferenceStats().modelsRefetched).toBe(
+          before.modelsRefetched + 1,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("responds 500 when model list fetch fails and no env model set", async () => {
       vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
       vi.mocked(listOpenAiCompatibleModels).mockRejectedValue(

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -237,6 +237,10 @@ export function internalApiEndpointServerHook<
         let model = process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL;
         let availableModels: { id: string }[] = [];
         const attemptedModels = new Set<string>();
+        // Tracks whether a mid-request model-list re-fetch has already run.
+        // Set before the try so a failing `/models` endpoint does not trigger
+        // another refetch on the next failed attempt — we already gave it a shot.
+        let hasRefetched = false;
 
         if (!model) {
           try {
@@ -344,10 +348,16 @@ export function internalApiEndpointServerHook<
             if (hasEmittedContent) break;
             if (attempt >= maxAttempts) break;
 
+            // Re-list when every model in the current pool has been attempted
+            // and we have not already re-listed this request. A provider whose
+            // pool changes mid-flight needs a fresh listing to recover; without
+            // the `!hasRefetched` guard we would loop on a stale list.
             if (
-              availableModels.length === 0 &&
-              !process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL
+              !process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL &&
+              availableModels.every((m) => attemptedModels.has(m.id)) &&
+              !hasRefetched
             ) {
+              hasRefetched = true;
               try {
                 availableModels = await listOpenAiCompatibleModels(
                   process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL,


### PR DESCRIPTION
Currently, the mid-retry model re-list in `/inference` is dead code. The guard reads `availableModels.length === 0 && !INTERNAL_OPENAI_COMPATIBLE_API_MODEL`. With the env var set, the second clause is false. Without it, the initial listing either throws (handler answers 500) or returns an empty list (selectRandomModel yields nothing, handler answers 500 before the loop). By the time the retry loop runs, `availableModels` is non-empty and the first clause is false — the branch never fires, and the `modelsRefetched` counter never moves outside tests.

Replace the guard with the condition the code was clearly meant to express: re-list when every model in the current pool has been attempted and we have not already re-listed this request. `hasRefetched` is set before the try so a failing `/models` endpoint does not trigger another refetch on a subsequent attempt — the loop would break anyway (selectRandomModel returns null on a fully-attempted pool), but the flag makes the intent explicit and protects against future restructuring.

## What changed

| File | Change |
| --- | --- |
| `server/internalApiEndpointServerHook.ts` | Replaced the dead guard with `!INTERNAL_OPENAI_COMPATIBLE_API_MODEL && availableModels.every(m => attemptedModels.has(m.id)) && !hasRefetched`. Moved `hasRefetched = true` before the try so a failing `/models` endpoint does not re-enter the block. |
| `server/internalApiEndpointServerHook.test.ts` | Three new handler-level tests: (1) re-lists when every model attempted and a new model appears, succeeding on the second attempt; (2) does not re-list when an untried model remains in the pool; (3) re-lists only once even when both the original and refetched pools fail — pins the `hasRefetched` flag, the refetched pool feeding `selectRandomModel`, and the `modelsRefetched` counter. |
| `docs/overview.md` | Added `modelsRefetched` to the single-model-deployment paragraph (it stays at 0 there too). |

## Where to start

The behavior change is 13 lines in `internalApiEndpointServerHook.ts`. Most of the diff is tests (150 insertions).

One non-blocking observation outside this PR: a mid-retry `/models` failure is invisible on `/status` — it only reaches `console.warn`. `modelsRefetched` counts successes only, and `failed.modelListUnavailable` covers just the initial fetch. The request lands in `failed.failedBeforeFirstToken`, indistinguishable from a plain model failure. Worth a separate issue.

## How to test

1. `npm test` (653 passing).
2. `npm run lint` (biome, tsc, knip, jscpd, documentation validator all exit 0).

Closes #2422.
