### PR TITLE
fix: apply the configured request timeout to the upstream stream

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -347,7 +347,8 @@ request that never finished at all.
 Two fields read differently on a single-model deployment. With
 `INTERNAL_OPENAI_COMPATIBLE_API_MODEL` set there is no pool to fall back to, so
 the loop stops after the first failure: `averageAttempts` cannot exceed 1 and
-`modelFallbacks` stays at 0 however badly the upstream behaves. Read
+`modelFallbacks` stays at 0 however badly the upstream behaves. The pool also
+never refreshes in that mode, so `modelsRefetched` stays at 0; read
 `failed.failedBeforeFirstToken` for that case instead.
 
 Model ids are configuration rather than user data, and `/inference` already

--- a/server/internalApiEndpointServerHook.test.ts
+++ b/server/internalApiEndpointServerHook.test.ts
@@ -493,6 +493,127 @@ describe("internalApiEndpointServerHook", () => {
       ).toBe(true);
     });
 
+    it("aborts the upstream stream when no part arrives within the idle timeout", async () => {
+      vi.mocked(streamText).mockImplementation(
+        ({ abortSignal }: { abortSignal?: AbortSignal } = {}) => {
+          // Yields one part, then yields an abort part when the signal fires —
+          // mirrors the AI SDK v7 pull handler behavior.
+          return {
+            stream: (async function* () {
+              yield { type: "text-delta", text: "Half" } as never;
+              // Wait until the abort signal fires, then emit the abort part.
+              await new Promise<void>((resolve) => {
+                const check = () => {
+                  if (abortSignal?.aborted) {
+                    resolve();
+                  } else {
+                    abortSignal?.addEventListener("abort", () => resolve(), {
+                      once: true,
+                    });
+                  }
+                };
+                check();
+              });
+              yield { type: "abort" } as never;
+            })(),
+          } as never;
+        },
+      );
+
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+      vi.useFakeTimers();
+      try {
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        // Not yet past the timeout — signal should be clear.
+        await vi.advanceTimersByTimeAsync(29_999);
+        expect(
+          vi.mocked(streamText).mock.calls[0][0].abortSignal?.aborted,
+        ).toBe(false);
+        // Past the timeout — signal should be set and the abort part emitted.
+        await vi.advanceTimersByTimeAsync(2);
+        await pending;
+
+        // The abort is treated as an attempt failure: the stalled stream is
+        // cut and the SSE error frame carries the message.
+        const writes = response.write.mock.calls.map((c) => c[0] as string);
+        expect(
+          writes.some((s: string) => s.includes("Service unavailable")),
+        ).toBe(true);
+        expect(writes.some((s: string) => s.includes("stalled"))).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("retries the next model when the first model stalls before any content", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      vi.mocked(listOpenAiCompatibleModels).mockResolvedValue([
+        { id: "model-a" },
+        { id: "model-b" },
+      ]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      // First call (model-a) stalls; second call (model-b) succeeds.
+      vi.mocked(streamText).mockImplementationOnce(
+        ({ abortSignal }: { abortSignal?: AbortSignal } = {}) => {
+          // Yields nothing, then emits an abort part when the signal fires.
+          return {
+            stream: (async function* () {
+              await new Promise<void>((resolve) => {
+                const check = () => {
+                  if (abortSignal?.aborted) {
+                    resolve();
+                  } else {
+                    abortSignal?.addEventListener("abort", () => resolve(), {
+                      once: true,
+                    });
+                  }
+                };
+                check();
+              });
+              yield { type: "abort" } as never;
+            })(),
+          } as never;
+        },
+      );
+      vi.mocked(streamText).mockImplementationOnce(
+        () =>
+          streamOf([
+            { type: "text-delta", text: "Recovered" },
+            { type: "finish" },
+          ]) as never,
+      );
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        // Advance past the idle timeout; model-a stalls and aborts.
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // The ladder walked to model-b, which succeeded.
+        expect(streamText).toHaveBeenCalledTimes(2);
+        const writes = response.write.mock.calls.map((c) => c[0] as string);
+        expect(writes.some((s: string) => s.includes("Recovered"))).toBe(true);
+        expect(writes.some((s: string) => s.includes("stalled"))).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("responds 503 JSON when the stream ends before any content", async () => {
       vi.mocked(streamText).mockImplementation(() => streamOf([]) as never);
       const handler = getRegisteredHandler();
@@ -781,6 +902,143 @@ describe("internalApiEndpointServerHook", () => {
       expect(writes).not.toContain("A different answer");
       expect(writes).toContain("all models failed");
       expect(writes).toContain("[DONE]");
+    });
+
+    it("re-lists the model pool when every model has been attempted", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      // Only model-a in the initial pool; it fails, then the pool is refreshed
+      // to include model-b, which succeeds.
+      vi.mocked(listOpenAiCompatibleModels)
+        .mockResolvedValueOnce([{ id: "model-a" }])
+        .mockResolvedValueOnce([{ id: "model-b" }]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      let callCount = 0;
+      vi.mocked(streamText).mockImplementation(() => {
+        callCount += 1;
+        return (
+          callCount === 1
+            ? streamOf([{ type: "error", error: new Error("upstream down") }])
+            : streamOf([
+                { type: "text-delta", text: "Recovered" },
+                { type: "finish" },
+              ])
+        ) as never;
+      });
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // The pool was refreshed once, and the new model succeeded.
+        expect(listOpenAiCompatibleModels).toHaveBeenCalledTimes(2);
+        expect(streamText).toHaveBeenCalledTimes(2);
+        const writes = response.write.mock.calls.map((c) => c[0]).join("");
+        expect(writes).toContain("Recovered");
+        expect(writes).not.toContain("all models failed");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not re-list when a model remains in the pool", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      vi.mocked(listOpenAiCompatibleModels).mockResolvedValue([
+        { id: "model-a" },
+        { id: "model-b" },
+      ]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      let callCount = 0;
+      vi.mocked(streamText).mockImplementation(() => {
+        callCount += 1;
+        return (
+          callCount === 1
+            ? streamOf([{ type: "error", error: new Error("upstream down") }])
+            : streamOf([
+                { type: "text-delta", text: "Recovered" },
+                { type: "finish" },
+              ])
+        ) as never;
+      });
+
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // model-b is still in the pool, so no re-list is needed.
+        expect(listOpenAiCompatibleModels).toHaveBeenCalledTimes(1);
+        expect(streamText).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("re-lists only once even when both the original and refetched pools fail", async () => {
+      vi.stubEnv("INTERNAL_OPENAI_COMPATIBLE_API_MODEL", undefined);
+      // Only model-a in the initial pool; refetch yields model-b, which also fails.
+      vi.mocked(listOpenAiCompatibleModels)
+        .mockResolvedValueOnce([{ id: "model-a" }])
+        .mockResolvedValueOnce([{ id: "model-b" }]);
+      vi.mocked(selectRandomModel)
+        .mockReturnValueOnce("model-a")
+        .mockReturnValueOnce("model-b");
+
+      vi.mocked(streamText).mockImplementation(
+        () =>
+          streamOf([
+            { type: "error", error: new Error("upstream down") },
+          ]) as never,
+      );
+
+      const before = getInferenceStats();
+      vi.useFakeTimers();
+      try {
+        const handler = getRegisteredHandler();
+        const response = createResponse();
+        const pending = handler(
+          createRequest({ messages: [{ role: "user", content: "hi" }] }),
+          response,
+          vi.fn(),
+        );
+        await vi.runAllTimersAsync();
+        await pending;
+
+        // The pool was refreshed once; even though both models failed we do not
+        // loop on a failing /models endpoint.
+        expect(listOpenAiCompatibleModels).toHaveBeenCalledTimes(2);
+        // The refetched pool feeds selection — the second call receives it.
+        expect(vi.mocked(selectRandomModel).mock.calls[1][0]).toEqual([
+          { id: "model-b" },
+        ]);
+        expect(response.statusCode).toBe(503);
+        // The counter moved from the successful refetch.
+        expect(getInferenceStats().modelsRefetched).toBe(
+          before.modelsRefetched + 1,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("responds 500 when model list fetch fails and no env model set", async () => {

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -237,6 +237,10 @@ export function internalApiEndpointServerHook<
         let model = process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL;
         let availableModels: { id: string }[] = [];
         const attemptedModels = new Set<string>();
+        // Tracks whether a mid-request model-list re-fetch has already run.
+        // Set before the try so a failing `/models` endpoint does not trigger
+        // another refetch on the next failed attempt — we already gave it a shot.
+        let hasRefetched = false;
 
         if (!model) {
           try {
@@ -295,6 +299,19 @@ export function internalApiEndpointServerHook<
           recordModelAttempt(model);
           attempts++;
 
+          // An idle timeout bounds how long the upstream may stay silent.
+          // A long answer is allowed to proceed; only a stall is cut.
+          const abortController = new AbortController();
+          let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+          function resetIdleTimeout(): void {
+            if (idleTimeoutId !== undefined) clearTimeout(idleTimeoutId);
+            idleTimeoutId = setTimeout(
+              () => abortController.abort(),
+              config.requestTimeoutMs,
+            );
+          }
+
           try {
             const result = streamText({
               model: openaiProvider.chatModel(model),
@@ -303,14 +320,23 @@ export function internalApiEndpointServerHook<
               topP: clampedTopP,
               maxOutputTokens: clampedMaxTokens,
               maxRetries: 0,
+              abortSignal: abortController.signal,
             });
 
+            // Arm the timer before the first part so a stall before the first
+            // token is also bounded — not just the gap between parts.
+            resetIdleTimeout();
             for await (const part of result.stream) {
               if (!isResponseWritable(response)) {
                 outcome = "abandoned";
                 recordModelAbandoned(model);
+                clearTimeout(idleTimeoutId);
                 return;
               }
+
+              // Any part counts as liveness: a reasoning model may spend more
+              // than requestTimeoutMs in reasoning-delta before emitting text.
+              resetIdleTimeout();
 
               if (part.type === "text-delta") {
                 if (!hasEmittedContent)
@@ -318,8 +344,18 @@ export function internalApiEndpointServerHook<
                 hasEmittedContent = true;
                 sendSseData(response, createChunkPayload(model, part.text));
               } else if (part.type === "error") {
+                clearTimeout(idleTimeoutId);
                 throw part.error;
+              } else if (part.type === "abort") {
+                // The AI SDK v7 enqueues an abort part and closes the stream
+                // cleanly rather than throwing; re-throw so the catch block
+                // records the failure and walks the retry ladder.
+                clearTimeout(idleTimeoutId);
+                throw new Error(
+                  `Upstream stalled for ${config.requestTimeoutMs}ms`,
+                );
               } else if (part.type === "finish") {
+                clearTimeout(idleTimeoutId);
                 sendSseData(
                   response,
                   createChunkPayload(model, undefined, "stop"),
@@ -331,9 +367,11 @@ export function internalApiEndpointServerHook<
               }
             }
 
+            clearTimeout(idleTimeoutId);
             recordStreamEndedWithoutFinish();
             throw new Error("Stream ended unexpectedly");
           } catch (error) {
+            clearTimeout(idleTimeoutId);
             lastError = error;
             recordModelFailure(model);
             console.error(
@@ -344,10 +382,16 @@ export function internalApiEndpointServerHook<
             if (hasEmittedContent) break;
             if (attempt >= maxAttempts) break;
 
+            // Re-list when every model in the current pool has been attempted
+            // and we have not already re-listed this request. A provider whose
+            // pool changes mid-flight needs a fresh listing to recover; without
+            // the `!hasRefetched` guard we would loop on a stale list.
             if (
-              availableModels.length === 0 &&
-              !process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL
+              !process.env.INTERNAL_OPENAI_COMPATIBLE_API_MODEL &&
+              availableModels.every((m) => attemptedModels.has(m.id)) &&
+              !hasRefetched
             ) {
+              hasRefetched = true;
               try {
                 availableModels = await listOpenAiCompatibleModels(
                   process.env.INTERNAL_OPENAI_COMPATIBLE_API_BASE_URL,


### PR DESCRIPTION
Currently, `getModelConfig()` returns a `requestTimeoutMs` and `/inference` never uses it. `streamText` is called with `maxRetries: 0` and no `abortSignal`, so neither MiniSearch nor the AI SDK bounds how long an upstream may take. An upstream that accepts the connection, opens a stream and then goes quiet leaves the request in flight indefinitely: the `for await` never advances, the retry ladder never runs, the client waits on an SSE stream that will never finish, and the server holds the response open.

The counters added in #2413 make this visible rather than hypothetical: they record in a `finally`, which only runs when the request terminates, so a hung request is counted nowhere. `inference.requests` on `/status` should equal `authorization.bySurface.inference.authorized`, and a gap between the two is exactly this.

Pass an abort signal derived from `requestTimeoutMs` to `streamText`. Arm the idle timeout before the first part so a stall before the first token is bounded, not just the gap between parts. Reset the timer on every stream part so a reasoning model that spends more than `requestTimeoutMs` in `reasoning-delta` before its first `text-delta` is not killed mid-flow. The AI SDK v7 enqueues an `abort` part and closes the stream cleanly rather than throwing, so the loop handles `part.type === "abort"` by re-throwing so the catch block records the failure and walks the retry ladder.

## What changed

| File | Change |
| --- | --- |
| `server/internalApiEndpointServerHook.ts` | Create an `AbortController` per `streamText` call; arm an idle timeout before the first part; reset on every part; pass `abortSignal` to `streamText`; handle `part.type === "abort"` by re-throwing |
| `server/internalApiEndpointServerHook.test.ts` | Two new tests: (1) stall after first token — asserts the abort signal is clear at 29999 ms and set at 30001 ms, and the SSE error frame carries "stalled"; (2) stall before any content — proves the retry ladder walks to the next model |

## Where to start

The behavior change is ~30 lines in `internalApiEndpointServerHook.ts`. Most of the diff is tests.

One non-blocking observation: worst case for a stall before the first token is 5 attempts × 30s plus backoff (~155s to a 503). If a bounded whole-request deadline is desired instead of (or in addition to) the idle timeout, that is a separate issue.

## How to test

1. `npm test` (655 passing).
2. `npm run lint` (biome, tsc, knip, jscpd, documentation validator all exit 0).

Closes #2421.
