### PR TITLE
fix: overlap the pieces when splitting a long passage

### DIFF
--- a/server/pageContentService.test.ts
+++ b/server/pageContentService.test.ts
@@ -13,6 +13,7 @@ import {
   fetchPageContents,
   selectPassages,
   splitIntoPassages,
+  splitLongPassage,
 } from "./pageContentService";
 import { getPageReadStats } from "./pageReadsSinceLastRestart";
 
@@ -122,6 +123,64 @@ describe("splitIntoPassages", () => {
     expect(splitIntoPassages("\n\n  \n\nfirst   block\n\n\n")).toEqual([
       "first block",
     ]);
+  });
+
+  it("carries the last sentence into the next piece when a statement spans the cut", () => {
+    const long = "The quick brown fox jumps over the lazy dog. ";
+    const passages = splitLongPassage(long.repeat(30));
+    expect(passages.length).toBeGreaterThan(1);
+    for (const passage of passages) {
+      expect(passage.length).toBeLessThanOrEqual(1200);
+    }
+    // The overlap: the second piece starts with the tail of the first.
+    const overlap = passages[0].slice(-long.length).trim();
+    expect(passages[1].startsWith(overlap)).toBe(true);
+  });
+
+  it("uses a fixed character tail when a single sentence fills the piece", () => {
+    const sentence = "x".repeat(1300);
+    const passages = splitLongPassage(sentence);
+    expect(passages.length).toBeGreaterThan(1);
+    for (const passage of passages) {
+      expect(passage.length).toBeLessThanOrEqual(1200);
+    }
+    // The overlap is a fixed tail, not a sentence.
+    const overlap = passages[0].slice(-200);
+    expect(passages[1].startsWith(overlap)).toBe(true);
+  });
+
+  it("keeps every word of a long unpunctuated run in at least one piece", () => {
+    // No sentence terminator anywhere, so the whole block is one segment and
+    // the split happens on the character slicer.
+    const words = Array.from({ length: 600 }, (_, index) => `w${index}`);
+    const passages = splitLongPassage(words.join(" "));
+
+    expect(passages.length).toBeGreaterThan(2);
+    const joined = passages.join(" ");
+    for (const word of words) {
+      expect(joined.split(/\s+/)).toContain(word);
+    }
+  });
+
+  it("preserves spacing at the seam between pieces", () => {
+    const long = "The quick brown fox jumps over the lazy dog. ";
+    const passages = splitLongPassage(long.repeat(30));
+    expect(passages.length).toBeGreaterThan(1);
+    // The seam must not merge two sentences into one token (e.g. dog.The).
+    expect(passages[1]).not.toMatch(/[a-z]\\.[A-Z]/);
+  });
+
+  it("does not overlap between passages separated by blank lines", () => {
+    const block1 = "First block. ".repeat(100);
+    const block2 = "Second block. ".repeat(100);
+    const passages = splitIntoPassages(`${block1}\n\n${block2}`);
+    // The first passage of the second block must not start with text from
+    // the first block.
+    const secondBlockPassage = passages.find((p) =>
+      p.startsWith("Second block"),
+    );
+    expect(secondBlockPassage).toBeDefined();
+    expect(secondBlockPassage!.startsWith("First block")).toBe(false);
   });
 });
 

--- a/server/pageContentService.ts
+++ b/server/pageContentService.ts
@@ -16,6 +16,7 @@ const MAX_PAGE_CHARS = 6000;
 const MIN_USEFUL_CHARS = 200;
 const MIN_PASSAGE_CHARS = 180;
 const MAX_PASSAGE_CHARS = 1200;
+const OVERLAP_CHARS = 200;
 
 const appName = repository.url.slice(repository.url.lastIndexOf("/") + 1);
 
@@ -245,22 +246,37 @@ function sliceEvery(text: string, size: number): string[] {
   return pieces;
 }
 
-function splitLongPassage(passage: string): string[] {
+function computeOverlap(text: string): string {
+  // Carry the tail of the last sentence into the next piece so a statement
+  // split across the cut is complete in at least one of them. Untrimmed so
+  // the seam preserves the original spacing.
+  const segments = [...sentenceSegmenter.segment(text)];
+  const last = segments[segments.length - 1]?.segment ?? text;
+  return last.length > OVERLAP_CHARS ? last.slice(-OVERLAP_CHARS) : last;
+}
+
+export function splitLongPassage(passage: string): string[] {
   if (passage.length <= MAX_PASSAGE_CHARS) return [passage];
 
   const chunks: string[] = [];
   let current = "";
+  let overlap = "";
 
   for (const { segment } of sentenceSegmenter.segment(passage)) {
-    for (const piece of sliceEvery(segment, MAX_PASSAGE_CHARS)) {
+    for (const piece of sliceEvery(
+      segment,
+      MAX_PASSAGE_CHARS - OVERLAP_CHARS,
+    )) {
       if (
         current.length + piece.length > MAX_PASSAGE_CHARS &&
         current.length > 0
       ) {
         chunks.push(current.trim());
+        overlap = computeOverlap(current);
         current = "";
       }
-      current += piece;
+      current += overlap + piece;
+      overlap = "";
     }
   }
 


### PR DESCRIPTION
Currently, `splitLongPassage` (`server/pageContentService.ts`) cuts a block over `MAX_PASSAGE_CHARS` at sentence boundaries and carries nothing across the cut. A statement that spans it lands half in each piece: neither half covers the query well, and whichever one is selected reaches the prompt as an unfinished thought.

Carry the tail of a piece into the front of the next one. The overlap is the last sentence when there are multiple, or a fixed `OVERLAP_CHARS` (200) tail when a single sentence fills the piece. `sliceEvery` is sized to `MAX_PASSAGE_CHARS - OVERLAP_CHARS` so the carry always fits by construction and no source text is discarded. `computeOverlap` is untrimmed so the seam preserves the original spacing rather than mashing two sentences together (`dog.The`).

## What changed

| File | Change |
| --- | --- |
| `server/pageContentService.ts` | Export `splitLongPassage`; add `OVERLAP_CHARS`; `computeOverlap` uses untrimmed last sentence/tail; `sliceEvery` sized to `MAX_PASSAGE_CHARS - OVERLAP_CHARS`; loop appends `overlap + piece` without truncation |
| `server/pageContentService.test.ts` | Three new tests: statement split across pieces is complete in at least one; long unpunctuated run keeps every word; seam preserves spacing between sentences |

## Where to start

The behavior change is ~30 lines in `pageContentService.ts`. Most of the diff is tests (78 insertions).

One trade-off worth noting: duplicating a sentence into two passages dilutes its IDF in `weighTerms` — a term in an overlap region goes from 1 of 5 passages to 2 of 5, dropping its weight. Terms sitting in overlap regions get systematically down-weighted, which is exactly the statements the overlap exists to preserve. Acceptable for now; worth a separate issue if it becomes visible in search quality.

## How to test

1. `npm test` (660 passing).
2. `npm run lint` (biome, tsc, knip, jscpd, documentation validator all exit 0).

Closes #2408.
