### PR TITLE
fix: read PDF results instead of dropping them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "keyword-extractor": "^0.3.0",
         "node-emoji": "^2.1.3",
         "onnxruntime-node": "^1.24.3",
+        "pdf-parse": "^1.1.4",
         "postcss": "^8.5.25",
         "postcss-preset-mantine": "^1.17.0",
         "postcss-simple-vars": "^7.0.1",
@@ -5861,6 +5862,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6121,6 +6128,22 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
     },
     "node_modules/peberminta": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "keyword-extractor": "^0.3.0",
     "node-emoji": "^2.1.3",
     "onnxruntime-node": "^1.24.3",
+    "pdf-parse": "^1.1.4",
     "postcss": "^8.5.25",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",

--- a/server/pageContentService.test.ts
+++ b/server/pageContentService.test.ts
@@ -8,6 +8,10 @@ vi.mock("node:dns/promises", () => ({
   lookup: lookupMock,
 }));
 
+vi.mock("pdf-parse", () => ({
+  default: vi.fn().mockResolvedValue({ text: "" }),
+}));
+
 import {
   extractReadableText,
   fetchPageContents,
@@ -347,13 +351,29 @@ describe("page read counters", () => {
       httpError: 1,
     });
 
+    // A PDF is no longer dropped as notADocument; it goes through the passage
+    // pipeline and is counted as read (or tooLittleText if the text is short).
+    const { default: pdfParse } = await import("pdf-parse");
+    vi.mocked(pdfParse).mockResolvedValue({
+      text: "CAT SLEEPS 16 HOURS A DAY. ".repeat(20),
+      info: {},
+    } as never);
     fetchMock.mockResolvedValue(
-      new Response("%PDF-1.7", {
+      new Response("%PDF-1.7\n%%EOF", {
         status: 200,
         headers: { "content-type": "application/pdf" },
       }),
     );
-    expect((await countOutcomes("https://example.com/a.pdf")).skipped).toEqual({
+    const pdfOutcome = await countOutcomes("https://example.com/a.pdf");
+    expect(pdfOutcome.read).toBe(1);
+    // The notADocument case is still covered by a non-document type.
+    fetchMock.mockResolvedValue(
+      new Response("binary goo", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    expect((await countOutcomes("https://example.com/x.bin")).skipped).toEqual({
       notADocument: 1,
     });
   });
@@ -546,15 +566,35 @@ describe("fetchPageContents", () => {
 
   it("skips responses that are not documents", async () => {
     fetchMock.mockResolvedValue(
-      new Response("%PDF-1.7", {
+      new Response("binary goo", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    expect(
+      await fetchPageContents("cats", ["https://example.com/x.bin"]),
+    ).toEqual([]);
+  });
+
+  it("reads a PDF and returns its text as passages", async () => {
+    const { default: pdfParse } = await import("pdf-parse");
+    vi.mocked(pdfParse).mockResolvedValue({
+      text: "CAT SLEEPS 16 HOURS A DAY. ".repeat(20),
+      info: {},
+    } as never);
+    fetchMock.mockResolvedValue(
+      new Response("%PDF-1.7\nCAT SLEEPS 16 HOURS A DAY.\n%%EOF", {
         status: 200,
         headers: { "content-type": "application/pdf" },
       }),
     );
 
-    expect(
-      await fetchPageContents("cats", ["https://example.com/a.pdf"]),
-    ).toEqual([]);
+    const contents = await fetchPageContents("cats sleep", [
+      "https://example.com/a.pdf",
+    ]);
+    expect(contents).toHaveLength(1);
+    expect(contents[0].content).toContain("CAT SLEEPS");
   });
 
   it("skips pages that answer with an error status", async () => {

--- a/server/pageContentService.ts
+++ b/server/pageContentService.ts
@@ -1,4 +1,5 @@
 import { convert as convertHtmlToPlainText } from "html-to-text";
+import pdfParse from "pdf-parse";
 import { repository, version } from "../package.json" with { type: "json" };
 import {
   type PageReadOutcome,
@@ -141,7 +142,7 @@ function isTimeout(error: unknown): boolean {
 }
 
 type DownloadResult =
-  | { outcome: "ok"; html: string; bodyTruncated: boolean }
+  | { outcome: "ok"; html?: string; text?: string; bodyTruncated: boolean }
   | { outcome: Exclude<PageReadOutcome, "read" | "tooLittleText"> };
 
 /**
@@ -194,8 +195,11 @@ async function downloadDocument(rawUrl: string): Promise<DownloadResult> {
 
     const contentType = response.headers.get("content-type") ?? "";
     if (!READABLE_CONTENT_TYPES.test(contentType.trim())) {
-      await response.body?.cancel().catch(() => {});
-      return { outcome: "notADocument" };
+      // PDF is not in READABLE_CONTENT_TYPES but we still want to read it.
+      if (!contentType.trim().toLowerCase().startsWith("application/pdf")) {
+        await response.body?.cancel().catch(() => {});
+        return { outcome: "notADocument" };
+      }
     }
 
     try {
@@ -203,6 +207,10 @@ async function downloadDocument(rawUrl: string): Promise<DownloadResult> {
         response,
         MAX_RESPONSE_BYTES,
       );
+      if (contentType.trim().toLowerCase().startsWith("application/pdf")) {
+        const { text } = await pdfParse(bytes);
+        return { outcome: "ok", text, bodyTruncated: truncated };
+      }
       return {
         outcome: "ok",
         html: decodeDocument(bytes, contentType),
@@ -494,7 +502,11 @@ async function fetchPageContent(
   const { bodyTruncated } = download;
 
   try {
-    const passages = splitIntoPassages(extractReadableText(download.html));
+    const passages = splitIntoPassages(
+      download.text !== undefined
+        ? download.text
+        : extractReadableText(download.html!),
+    );
     const selected = selectPassages(query, passages, MAX_PAGE_CHARS);
     const content = selected.join("\n");
 

--- a/server/pdf-parse.d.ts
+++ b/server/pdf-parse.d.ts
@@ -1,0 +1,5 @@
+declare module "pdf-parse" {
+  export default function pdfParse(
+    data: Uint8Array,
+  ): Promise<{ text: string; info: Record<string, unknown> }>;
+}


### PR DESCRIPTION
Currently, `READABLE_CONTENT_TYPES` (`server/pageContentService.ts`) accepts `text/html`, `application/xhtml+xml` and `text/plain`, so a PDF result is recorded as `notADocument` and reaches the prompt with its snippet alone. On questions that land on specs, papers, standards and manuals, that is often the result holding the answer.

Add `application/pdf` to the accepted types and parse it with `pdf-parse` (v1, the lightweight pure-JS text-only extractor) before handing the text to the same passage pipeline the HTML path uses. The 6 s deadline and the 1.5 MB body cap still apply, and a malformed or encrypted PDF is counted as `failed` and leaves the other pages of the same search untouched.

## What changed

| File | Change |
| --- | --- |
| `server/pageContentService.ts` | Accept `application/pdf`; parse with `pdf-parse` and return `text` instead of `html`; use `download.text` in the passage pipeline |
| `server/pageContentService.test.ts` | Mock `pdf-parse`; update the notADocument test to use a non-document type; add a test that a PDF yields passages and excerpts |
| `server/pdf-parse.d.ts` | Type declaration for `pdf-parse` (no published types) |
| `package.json` | Add `pdf-parse@^1.1.4` |

## Where to start

The behavior change is ~15 lines in `pageContentService.ts`. Most of the diff is tests and the new dependency declaration.

`pdf-parse` v1 is deliberately scoped to text extraction only — no renderer, no image support. It has one dependency (`node-ensure`) and runs entirely in JS, so it stays inside the byte and timeout budget.

## How to test

1. `npm test` (656 passing).
2. `npm run lint` (biome, tsc, knip, jscpd, documentation validator all exit 0).

Closes #2410.
