### PR TITLE
fix: rank and select excerpt passages from one pool across pages (#2407)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,6 +11,7 @@ The architecture follows a layered design where search, AI inference, and presen
 MiniSearch integrates multiple technology stacks within a unified deployment container:
 
 ### Frontend
+
 - **React** - UI framework
 - **React DOM** - DOM rendering
 - **Mantine UI** - Component library (`@mantine/core`, `@mantine/hooks`, `@mantine/carousel`)
@@ -18,11 +19,13 @@ MiniSearch integrates multiple technology stacks within a unified deployment con
 - **TypeScript** - Type safety
 
 ### AI & Search
+
 - **@wllama/wllama** - Client-side AI inference (WebGPU-accelerated or CPU via WebAssembly)
 - **AI SDK** - AI integration layer
 - **@ai-sdk/openai-compatible** - Unified AI interface
 
 ### Data & State
+
 - **Dexie** - IndexedDB management
 - **create-pubsub** - State management (avoid React Context)
 - **usePubSub** - Component subscriptions
@@ -40,6 +43,7 @@ The application has three primary entry points:
 ## Multi-Service Container Architecture
 
 The Docker container runs three services concurrently:
+
 - **SearXNG** - Privacy-focused metasearch engine
 - **ONNX Runtime** - In-process inference for result reranking
 - **Node.js application** - Main application server
@@ -55,6 +59,7 @@ PubSub channels are created using the create-pubsub package and provide type-saf
 ## Data Persistence Strategy
 
 MiniSearch employs a dual-layer persistence approach:
+
 - **IndexedDB** - Local storage for search history, settings, cached results, and saved AI transcripts
 - **TTL-based caching** - 15-minute cache for search results to minimize API calls
 
@@ -67,11 +72,13 @@ Long-running chat sessions use an in-memory conversation summary that rolls exce
 The system supports two operational modes:
 
 ### Development Mode
+
 - Hot module replacement (HMR) on port 7861
 - Volume mount for live code updates
 - Vite dev server with source maps
 
 ### Production Mode
+
 - Pre-built static assets in /dist
 - Vite preview server (no HMR)
 - Optimized bundle with minification
@@ -130,6 +137,7 @@ MiniSearch uses a PubSub-based architecture where state flows through independen
 ### State Machine Transitions
 
 **Text Generation States:**
+
 - `idle` - No active generation
 - `awaitingModelDownloadAllowance` - Waiting for user consent to download a browser model
 - `loadingModel` - Downloading or initializing the browser (Wllama) model
@@ -141,6 +149,7 @@ MiniSearch uses a PubSub-based architecture where state flows through independen
 - `failed` - Error occurred
 
 **Search States:**
+
 - `idle` - No active search
 - `running` - Search in progress
 - `completed` - Results received
@@ -170,7 +179,7 @@ Callers write tokens directly to `updateResponse` or `updateReasoningContent` wi
 Three channels register built-in side-effect subscribers at module load time for automatic logging:
 
 | Channel | Side Effect |
-|---------|-------------|
+| --------- | ------------- |
 | `textGenerationStatePubSub` | Logs state transitions via `addLogEntry` |
 | `textSearchStatePubSub` | Logs state transitions via `addLogEntry` |
 | `imageSearchStatePubSub` | Logs state transitions via `addLogEntry` |
@@ -184,7 +193,7 @@ The build pipeline uses Biome for linting and formatting, TypeScript for type ch
 MiniSearch implements all server-side logic as Vite plugin hooks. Each hook registers middleware on Vite's HTTP server, working identically in both dev (`vite`) and production preview (`vite preview`) modes. Hooks are declared in `vite.config.ts` and registered via `configureServer`/`configurePreviewServer` callbacks.
 
 | Hook | File | Purpose |
-|------|------|---------|
+| ------ | ------ | --------- |
 | `compressionServerHook` | `server/compressionServerHook.ts` | gzip/brotli compression for all responses |
 | `crossOriginServerHook` | `server/crossOriginServerHook.ts` | COOP/COEP headers for SharedArrayBuffer |
 | `searchEndpointServerHook` | `server/searchEndpointServerHook.ts` | `/search/text` and `/search/images` endpoints proxied to SearXNG |
@@ -208,7 +217,7 @@ Key server-side modules:
 The `cacheServerHook` sets Cache-Control headers on every response:
 
 | Path Pattern | Cache-Control Header | Rationale |
-|---|---|---|
+| --- | --- | --- |
 | `/assets/*` | `public, max-age=31536000, immutable` | Content-hashed filenames never change |
 | `/` or `*.html` | `no-cache` | HTML must always check for updates |
 | Everything else | `public, max-age=86400, must-revalidate` | 24-hour cache with revalidation |
@@ -218,7 +227,7 @@ The `cacheServerHook` sets Cache-Control headers on every response:
 The `/status` endpoint returns a JSON object:
 
 | Field | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `uptime` | string | Human-readable server uptime |
 | `sessions` | number | Distinct verified sessions since last restart, which the two per-session averages below divide by |
 | `activeSessions` | number | Sessions still in the cache, dropped after 30 idle minutes |
@@ -258,13 +267,13 @@ is attached to a constant that someone will want to move, which is the reason it
 is counted at all (see `docs/page-content.md`):
 
 | Field | Type | Tunes |
-|---|---|---|
+| --- | --- | --- |
 | `requested` | number | Nothing; the denominator for the rest |
 | `read` | number | Nothing; how often the feature contributed anything |
 | `readRate` | number | Nothing; `read` as a percentage of `requested` |
 | `averageReadMs` | number | `REQUEST_TIMEOUT_MS`, including the reads that hit it |
 | `bodiesTruncated` | number | `MAX_RESPONSE_BYTES` |
-| `excerptKeptRate` | number | `MAX_PAGE_CHARS`, as the share of a page's passages that fit it |
+| `excerptKeptRate` | number | `MAX_PAGE_CHARS` and the 0.9 dedup threshold, as the share of pooled passages that survive |
 | `skipped.blocked` | number | The SSRF guard, and how often callers aim at private space |
 | `skipped.notADocument` | number | `READABLE_CONTENT_TYPES` |
 | `skipped.httpError` | number | Nothing; how often sites refuse the instance |
@@ -290,7 +299,7 @@ verification, the funnel `/search/text`, `/search/images`, `/page-content` and
 `/inference` all pass through:
 
 | Field | Type | Says |
-|---|---|---|
+| --- | --- | --- |
 | `requests` | number | Requests that reached verification; the denominator for the rest |
 | `authorized` | number | Requests that passed it |
 | `rejectedRate` | number | Rejections as a percentage of `requests` |
@@ -316,7 +325,7 @@ page-content read, so its `authorized` side says where the budget goes and its
 answer are about the upstream and about the wait, not about what was asked:
 
 | Field | Type | Says |
-|---|---|---|
+| --- | --- | --- |
 | `requests` | number | Requests that passed token verification; the denominator for the rest |
 | `streamed` | number | Answers that finished normally |
 | `streamedRate` | number | `streamed` as a percentage of `requests` |
@@ -360,7 +369,7 @@ in the search path. Each row names the constant it is there to move, the same
 way `pageReads` does:
 
 | Field | Type | Tunes |
-|---|---|---|
+| --- | --- | --- |
 | `searches.averageTextualMs` | number | The 30 s client timeout in `client/modules/search.ts`. Over the text searches SearXNG answered, so a failed or short-circuited one is not in it, and up to 7 s of retry backoff is |
 | `searches.averageGraphicalMs` | number | The same, for image searches |
 | `reranker.considered` | number | Nothing; results handed to the score filter, the denominator for `keptRate` |
@@ -394,7 +403,7 @@ Two separate Dexie databases handle different persistence needs:
    - Cache config:
 
 | Constant | Value | Description |
-|----------|-------|-------------|
+| ---------- | ------- | ------------- |
 | TTL | 15 minutes | Cache entry lifetime |
 | MAX_ENTRIES | 100 | Maximum cached queries per store |
 | ENABLED | true | Global cache toggle |
@@ -402,11 +411,11 @@ Two separate Dexie databases handle different persistence needs:
 | METRICS_LOG_INTERVAL | 10 | Operations between hit-rate log entries |
 | REQUEST_TIMEOUT | 30,000 ms | Fetch timeout |
 
-   - Query hashing: djb2 XOR Murmur algorithm for cache key generation
-   - Management operations: `cleanExpiredCache`, `pruneCache`, `ensureIntegrity`
-   - Performance monitoring: `cacheMetrics` tracks hit/miss rates for text and image searches
+- Query hashing: djb2 XOR Murmur algorithm for cache key generation
+- Management operations: `cleanExpiredCache`, `pruneCache`, `ensureIntegrity`
+- Performance monitoring: `cacheMetrics` tracks hit/miss rates for text and image searches
 
-2. **HistoryDatabase** (`client/modules/history.ts`): Long-term persistence of user interactions. Three coordinated tables:
+1. **HistoryDatabase** (`client/modules/history.ts`): Long-term persistence of user interactions. Three coordinated tables:
    - `searches`: Canonical log of each query with hydrated results payloads
    - `llmResponses`: AI answers tied to their originating search run
    - `chatHistory`: Chronological chat turns scoped by `conversationId` (which equals `searchRunId`)
@@ -415,6 +424,7 @@ Two separate Dexie databases handle different persistence needs:
 ### localStorage Persistence
 
 Lightweight state persisted across sessions via `createLocalStoragePubSub` pattern:
+
 - `settings`: Application preferences (inference type, model, UI options)
 - `querySuggestions`: Shuffled search suggestion pool
 - `lastSearchTokenHash`: Cached security token hash
@@ -424,18 +434,21 @@ Lightweight state persisted across sessions via `createLocalStoragePubSub` patte
 ## Application Bootstrap Flow
 
 ### Server-Side Bootstrap (vite.config.ts)
+
 1. Loads environment variables via `dotenv.config`
 2. Generates/retrieves search token for CSRF protection
 3. Injects environment-based constants as compile-time replacements (`VITE_SEARCH_TOKEN`, `VITE_ACCESS_KEYS_ENABLED`, etc.)
 4. Registers all middleware hooks (see Server Hook System above)
 
 ### Client-Side Bootstrap (client/index.tsx)
+
 1. Retrieves current settings via `getSettings()`
 2. Registers ready/close listeners on `historyDatabase`, opens DB if history enabled
 3. Sets up reactive listener to open/close DB when user toggles history in settings
 4. Creates React root and renders `<App />`
 
 ### App Component Initialization (client/components/App/App.tsx)
+
 1. `useInitializeSettings`: Merges default settings with stored values into `settingsPubSub`
 2. `useAccessKeyValidation`: Checks `VITE_ACCESS_KEYS_ENABLED`; if enabled, verifies stored key; shows loading state during check; renders `<AccessPage />` or `<MainPage />` accordingly
 

--- a/docs/page-content.md
+++ b/docs/page-content.md
@@ -25,7 +25,9 @@ and no page is read either way until AI responses are on.
 2. The top `searchResultsToConsider` (6) URLs go to `/page-content`, together
    with the query, via `client/modules/pageContent.ts`.
 3. `server/pageContentService.ts` reads each page, extracts its readable text,
-   splits it into passages, and returns the passages that best cover the query.
+   splits it into passages, ranks all passages from all pages together, and
+   selects from the pooled ranking with a per-URL cap and near-duplicate
+   suppression, so syndicated paragraphs reach the prompt once.
 4. The response is published to the `pageContents` PubSub channel, keyed by URL.
 5. `getFormattedSearchResults` (`client/modules/textGenerationUtilities.ts`)
    appends each excerpt under its result before the prompt is built.
@@ -89,7 +91,7 @@ anything written for one language:
 | --- | --- | --- |
 | Word boundaries | `Intl.Segmenter`, word granularity | `[^\p{L}\p{N}]+` cut Brahmic scripts and Thai at every combining vowel mark and dropped the marks, and it finds no boundary at all in Chinese, Japanese or Thai, which write none: a whole sentence arrived as one token that matched nothing, scoring fell through to document order, and the page's own navigation won |
 | Sentence boundaries | `Intl.Segmenter`, sentence granularity | `[.!?]` never matches `。`, `！`, `？` or `।`, so long CJK and Indic blocks were cut at an arbitrary character mid-sentence |
-| Uninformative words | Inverse document frequency over the passages of the page being read | A stop-word list only covers the language it was written in. A term found in most passages of a page cannot say which passage to quote, in any language, and this needs no word list and no language detection |
+| Uninformative words | Inverse document frequency over the pooled passages of all pages read for the search | A stop-word list only covers the language it was written in. A term found in most passages of a pool cannot say which passage to quote, in any language, and this needs no word list and no language detection |
 | Inflection | A query term and a page word match when one is a prefix of the other, from 3 characters and within 3 | Stripping `-ing`, `-es`, `-s` is English morphology applied to every language: it turned the Portuguese `mães` into `mã` and never matched `mãe` |
 
 Both segmenters are script-driven, so the locale is left unset and the result
@@ -134,7 +136,9 @@ anything.
 | Per-page deadline, redirects included | 6 s | `REQUEST_TIMEOUT_MS` |
 | Redirects followed | 3, each re-validated | `MAX_REDIRECTS` |
 | Body read per page | 1.5 MB | `MAX_RESPONSE_BYTES` |
-| Extracted text per page | 6,000 characters | `MAX_PAGE_CHARS` |
+| Excerpt cap per URL | 6,000 characters | `MAX_PAGE_CHARS`, `selectPassagesAcrossPages` |
+| Global excerpt budget | `MAX_PAGE_CHARS × pages` | `fetchPageContents` |
+| Near-duplicate threshold | 0.9 Jaccard | `JACCARD_THRESHOLD` |
 | Minimum usable text | 200 characters | `MIN_USEFUL_CHARS` |
 | Passage size | 180-1,200 characters | `MIN_PASSAGE_CHARS`, `MAX_PASSAGE_CHARS` |
 | Excerpt share of the context | 35% | `pageContentTokenBudgetRatio` |
@@ -228,7 +232,7 @@ this limit set where it should be", not "who read what":
 | `skipped.notADocument` | Are useful content types being turned away |
 | `skipped.blocked` | Are callers aiming at private space, deliberately or otherwise |
 | `bodiesTruncated` | Is the 1.5 MB body cap biting |
-| `excerptKeptRate` | How much of a page the 6,000-character budget keeps |
+| `excerptKeptRate` | How much of a page the per-URL cap and dedup keep |
 
 A counter can only be read in aggregate, so a single search cannot be recovered
 from it. The weakest point is an instance nobody else is using, where one search
@@ -248,6 +252,8 @@ grounded on before:
 | `/page-content` fails or times out | Answer falls back to snippets |
 | Setting turned off, or AI responses off | No page is ever read |
 | A newer search starts while pages are still being read | The late result is dropped instead of grounding the new answer |
+| Every passage on a page duplicates passages that ranked higher in the pooled order | That page keeps its snippet-only line; no empty excerpt block is emitted |
+| | The pooled ranking uses a per-passage position prior, so a later result can keep a paragraph the higher-ranked one carries further down its page. |
 
 ## Related Topics
 

--- a/server/pageContentService.test.ts
+++ b/server/pageContentService.test.ts
@@ -184,7 +184,7 @@ describe("splitIntoPassages", () => {
       p.startsWith("Second block"),
     );
     expect(secondBlockPassage).toBeDefined();
-    expect(secondBlockPassage!.startsWith("First block")).toBe(false);
+    expect(secondBlockPassage?.startsWith("First block")).toBe(false);
   });
 });
 
@@ -364,6 +364,72 @@ describe("selectPassages across scripts", () => {
       expect(selected).toEqual([onTopic]);
     });
   }
+});
+
+describe("selectPassagesAcrossPages", () => {
+  // Helper to call the internal selector indirectly through fetchPageContents.
+  async function selectFrom(urls: string[], htmls: string[]) {
+    fetchMock.mockReset();
+    for (const html of htmls) {
+      fetchMock.mockResolvedValueOnce(
+        new Response(html, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      );
+    }
+    return fetchPageContents("test query", urls);
+  }
+
+  it("suppresses a syndicated paragraph that appears on multiple pages", async () => {
+    const syndicated =
+      "This paragraph is syndicated across many sites. ".repeat(10);
+    const uniqueA = "Unique content on page A. ".repeat(10);
+    const uniqueB = "Unique content on page B. ".repeat(10);
+
+    const contents = await selectFrom(
+      ["https://example.com/a", "https://example.com/b"],
+      [
+        `<article><p>${uniqueA}</p><p>${syndicated}</p></article>`,
+        `<article><p>${syndicated}</p><p>${uniqueB}</p></article>`,
+      ],
+    );
+
+    // The syndicated paragraph should appear in only one of the two responses.
+    // Text extraction trims trailing whitespace, so match a trimmed marker
+    // rather than the exact paragraph text.
+    const marker = syndicated.trimEnd();
+    const aText = contents.find((c) => c.url.includes("/a"))?.content ?? "";
+    const bText = contents.find((c) => c.url.includes("/b"))?.content ?? "";
+    const count = (aText + bText).split(marker).length - 1;
+    expect(count).toBe(1);
+  });
+
+  it("drops a page whose passages are all near-duplicates of an earlier page", async () => {
+    // Page A has one passage. Page B has one near-duplicate passage
+    // (Jaccard >= 0.9). The new global dedup should suppress B's copy,
+    // leaving B with no selected passages so it vanishes from the response.
+    // The old per-page code would have returned both pages.
+    // Note: with a query that matches no terms, A wins purely on flatten
+    // order (lower global index), not on relevance. The test guards the
+    // dedup drop path, not the ranking order.
+    const base =
+      "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 ";
+    const passageA = base.repeat(15);
+    const passageB = `${base}word11 `.repeat(15);
+
+    const contents = await selectFrom(
+      ["https://example.com/a", "https://example.com/b"],
+      [
+        `<article><p>${passageA}</p></article>`,
+        `<article><p>${passageB}</p></article>`,
+      ],
+    );
+
+    // Only page A should survive; page B's sole passage is a near-duplicate.
+    expect(contents).toHaveLength(1);
+    expect(contents[0].url).toContain("/a");
+  });
 });
 
 describe("page read counters", () => {

--- a/server/pageContentService.ts
+++ b/server/pageContentService.ts
@@ -98,6 +98,21 @@ export interface PageContent {
   content: string;
 }
 
+interface RankedPassage {
+  url: string;
+  text: string;
+  score: number;
+  index: number;
+  tokens: Set<string>;
+}
+
+interface FetchedPage {
+  url: string;
+  passages: string[];
+  durationMs: number;
+  bodyTruncated: boolean;
+}
+
 function isRedirect(status: number): boolean {
   return (
     status === 301 ||
@@ -408,13 +423,13 @@ function matchingPassages(
 
 /**
  * Weighs each query term by inverse document frequency across the passages of
- * this one page, and returns how much weight each passage matched along with
- * the total available.
+ * the current pool, and returns how much weight each passage matched along
+ * with the total available.
  *
  * This is what replaced a stop-word list, which could only ever cover the one
- * language it was written in: a term found in most passages of a page cannot
+ * language it was written in: a term found in most passages of a pool cannot
  * say which passage to quote, and a term confined to a few of them can, and
- * that holds whatever language the page is in.
+ * that holds whatever language the pool is in.
  */
 function weighTerms(
   queryTerms: string[],
@@ -441,9 +456,9 @@ function scorePassage(
   matchedWeight: number,
   totalWeight: number,
   termCount: number,
-  index: number,
+  positionInPage: number,
 ): number {
-  const position = 1 / (1 + index);
+  const position = 1 / (1 + positionInPage);
   if (termCount === 0) return position;
 
   // Lead passages carry the definition or summary on most pages, so they get a
@@ -451,6 +466,109 @@ function scorePassage(
   // intro of a page whose body never repeats the query, never enough to
   // outrank a passage that covers more of it.
   return matchedWeight / totalWeight + (0.5 * position) / termCount;
+}
+
+/**
+ * Ranks passages by how well they cover the query, using IDF weighting over
+ * the whole pool.
+ *
+ * @param passages - Candidate passages with their source URLs. The ranking is
+ * relative to this global pool, so term statistics are computed across all
+ * pages, not per page.
+ */
+function rankPassages(
+  query: string,
+  passages: { url: string; text: string; positionInPage: number }[],
+): RankedPassage[] {
+  const passageWords = passages.map((p) => new Set(tokenize(p.text)));
+  const queryTerms = [...new Set(tokenize(query))];
+  const { matchedWeights, totalWeight } = weighTerms(queryTerms, passageWords);
+
+  return passages
+    .map((p, index) => ({
+      url: p.url,
+      text: p.text,
+      score: scorePassage(
+        matchedWeights[index],
+        totalWeight,
+        queryTerms.length,
+        p.positionInPage,
+      ),
+      index,
+      tokens: passageWords[index],
+    }))
+    .sort((a, b) => b.score - a.score || a.index - b.index);
+}
+
+const JACCARD_THRESHOLD = 0.9;
+
+/**
+ * Selects passages from a globally ranked pool, applying a per-URL character
+ * cap and suppressing near-duplicates via token-set Jaccard similarity.
+ *
+ * The same paragraph that appears on several pages reaches the prompt once.
+ * Passages that are near-duplicates of already-selected ones from a *different*
+ * URL are skipped, so a page whose passages all overlap with earlier picks
+ * keeps its snippet-only line with no empty excerpt block.
+ */
+function selectPassagesAcrossPages(
+  ranked: RankedPassage[],
+  maxChars: number,
+  maxCharsPerUrl: number,
+): Map<string, string[]> {
+  const selectedByUrl = new Map<string, string[]>();
+  // Track every selected passage's tokens for cross-URL dedup.
+  // Passages from the same page are allowed to coexist; dedup is only for
+  // syndicated paragraphs that appear on different pages.
+  const selectedTokens: { url: string; tokens: Set<string> }[] = [];
+  let usedChars = 0;
+  const usedPerUrl = new Map<string, number>();
+
+  for (const passage of ranked) {
+    if (usedChars + passage.text.length > maxChars) continue;
+    if (
+      (usedPerUrl.get(passage.url) ?? 0) + passage.text.length >
+      maxCharsPerUrl
+    )
+      continue;
+
+    // Check against all selected passages from other URLs.
+    // Size prefilter: Jaccard ≥ 0.9 requires sizes within 10×, so skip
+    // comparisons where the ratio is too small.
+    let isDuplicate = false;
+    for (const { url: otherUrl, tokens: otherTokens } of selectedTokens) {
+      if (otherUrl === passage.url) continue;
+      const minSize = Math.min(passage.tokens.size, otherTokens.size);
+      const maxSize = Math.max(passage.tokens.size, otherTokens.size);
+      if (minSize * 10 < maxSize * 9) continue;
+      const intersection = [...passage.tokens].filter((t) =>
+        otherTokens.has(t),
+      ).length;
+      // union = a.size + b.size - intersection; avoids allocating a Set.
+      const union = passage.tokens.size + otherTokens.size - intersection;
+      if (union > 0 && intersection / union >= JACCARD_THRESHOLD) {
+        isDuplicate = true;
+        break;
+      }
+    }
+
+    if (isDuplicate) continue;
+
+    const existing = selectedByUrl.get(passage.url);
+    if (existing === undefined) {
+      selectedByUrl.set(passage.url, [passage.text]);
+    } else {
+      existing.push(passage.text);
+    }
+    selectedTokens.push({ url: passage.url, tokens: passage.tokens });
+    usedChars += passage.text.length + 1;
+    usedPerUrl.set(
+      passage.url,
+      (usedPerUrl.get(passage.url) ?? 0) + passage.text.length + 1,
+    );
+  }
+
+  return selectedByUrl;
 }
 
 /**
@@ -462,49 +580,32 @@ function scorePassage(
  * article is its navigation and its infobox, so the ranking below decided only
  * what was transferred and never what the model read.
  *
- * @param passages - Candidate passages from a single page, which is the scope
- * the weighting below is relative to
+ * @param passages - Candidate passages from a single page; the wrapper feeds
+ * them through the production selector so tests exercise the real code path.
  */
 export function selectPassages(
   query: string,
   passages: string[],
   maxChars: number,
 ): string[] {
-  const passageWords = passages.map((text) => new Set(tokenize(text)));
-  const queryTerms = [...new Set(tokenize(query))];
-  const { matchedWeights, totalWeight } = weighTerms(queryTerms, passageWords);
+  // Single-page wrapper over the production selector so tests exercise the
+  // real code path.
+  const input = passages.map((text, index) => ({
+    url: "",
+    text,
+    positionInPage: index,
+  }));
 
-  const ranked = passages
-    .map((text, index) => ({
-      index,
-      text,
-      score: scorePassage(
-        matchedWeights[index],
-        totalWeight,
-        queryTerms.length,
-        index,
-      ),
-    }))
-    .sort((a, b) => b.score - a.score || a.index - b.index);
-
-  const selected: string[] = [];
-  let usedChars = 0;
-
-  for (const passage of ranked) {
-    // Skipping rather than stopping lets a shorter passage further down the
-    // ranking still fill what is left of the budget.
-    if (usedChars + passage.text.length > maxChars) continue;
-    selected.push(passage.text);
-    usedChars += passage.text.length + 1;
-  }
-
-  return selected;
+  const ranked = rankPassages(query, input);
+  return selectPassagesAcrossPages(ranked, maxChars, maxChars).get("") ?? [];
 }
 
-async function fetchPageContent(
-  query: string,
-  url: string,
-): Promise<PageContent | null> {
+async function fetchPageContent(url: string): Promise<{
+  url: string;
+  passages: string[];
+  durationMs: number;
+  bodyTruncated: boolean;
+} | null> {
   const startedAt = performance.now();
   const since = () => performance.now() - startedAt;
 
@@ -518,13 +619,9 @@ async function fetchPageContent(
   const { bodyTruncated } = download;
 
   try {
-    const passages = splitIntoPassages(
-      download.text !== undefined
-        ? download.text
-        : extractReadableText(download.html!),
-    );
-    const selected = selectPassages(query, passages, MAX_PAGE_CHARS);
-    const content = selected.join("\n");
+    const html = download.text ?? extractReadableText(download.html ?? "");
+    const passages = splitIntoPassages(html);
+    const content = passages.join("\n");
 
     if (content.length < MIN_USEFUL_CHARS) {
       recordPageRead({
@@ -535,19 +632,14 @@ async function fetchPageContent(
       return null;
     }
 
-    recordPageRead({
-      outcome: "read",
-      durationMs: since(),
-      bodyTruncated,
-      passagesKept: selected.length,
-      passagesAvailable: passages.length,
-    });
-
-    return { url, content };
+    // Don't record passage stats here — selection happens globally in
+    // fetchPageContents, and we need to report how many passages actually
+    // survived the global budget, not how many the page yielded.
+    return { url, passages, durationMs: since(), bodyTruncated };
   } catch {
     recordPageRead({
       outcome: "failed",
-      durationMs: since(),
+      durationMs: performance.now() - startedAt,
       bodyTruncated,
     });
     return null;
@@ -558,6 +650,10 @@ async function fetchPageContent(
  * Reads the given pages and returns the passages most relevant to the query.
  * Pages that fail, time out, or carry no readable text are left out instead of
  * failing the batch: a partial set of excerpts still grounds the answer.
+ *
+ * Passages from all pages are ranked together, then selected with a per-URL
+ * character cap and near-duplicate suppression, so syndicated paragraphs that
+ * appear on several pages reach the prompt once.
  *
  * Nothing here is logged. Every read is counted instead, by outcome, in
  * `pageReadsSinceLastRestart`, since a line naming the query or the URL would
@@ -570,9 +666,43 @@ export async function fetchPageContents(
   query: string,
   urls: string[],
 ): Promise<PageContent[]> {
-  const contents = await Promise.all(
-    urls.map((url) => fetchPageContent(query, url)),
+  const results = await Promise.all(urls.map((url) => fetchPageContent(url)));
+
+  const pages = results.filter((r): r is FetchedPage => r !== null);
+
+  if (pages.length === 0) return [];
+
+  const allPassages = pages.flatMap((p) =>
+    p.passages.map((text, passageIndex) => ({
+      url: p.url,
+      text,
+      positionInPage: passageIndex,
+    })),
   );
 
-  return contents.filter((content): content is PageContent => content !== null);
+  const ranked = rankPassages(query, allPassages);
+  const selectedByUrl = selectPassagesAcrossPages(
+    ranked,
+    MAX_PAGE_CHARS * pages.length,
+    MAX_PAGE_CHARS,
+  );
+
+  // Record page-read stats now that we know how many passages were kept.
+  for (const page of pages) {
+    const selected = selectedByUrl.get(page.url) ?? [];
+    recordPageRead({
+      outcome: "read",
+      durationMs: page.durationMs,
+      bodyTruncated: page.bodyTruncated,
+      passagesKept: selected.length,
+      passagesAvailable: page.passages.length,
+    });
+  }
+
+  return pages
+    .map((p) => {
+      const selected = selectedByUrl.get(p.url) ?? [];
+      return { url: p.url, content: selected.join("\n") };
+    })
+    .filter((c) => c.content.length > 0);
 }


### PR DESCRIPTION
Rank passages of all pages in one pool, then select with a per-URL cap and near-duplicate suppression (token-set Jaccard ≥ 0.9). Syndicated paragraphs that appear on several pages now reach the prompt once, and pages whose passages are all near-duplicates of earlier picks keep their snippet-only line with no empty excerpt block.

## What changed

- `server/pageContentService.ts` — split `selectPassages` into `rankPassages` (global IDF ranking) and `selectPassagesAcrossPages` (per-URL cap + Jaccard dedup). `fetchPageContent` now returns raw passages; `fetchPageContents` does the global selection. `selectPassages` is preserved as a single-page wrapper for backward compat.
- `server/pageContentService.test.ts` — two new tests for cross-page behavior.
- `docs/page-content.md`, `docs/overview.md` — updated to reflect pooled IDF, per-URL cap, dedup threshold, and the new failure path.

## Why

Previously each page was ranked independently against its own passages. Two problems:
1. The same syndicated paragraph wasted an excerpt slot on every page it appeared on.
2. A page with many short passages could crowd out a page with one highly relevant passage, because the client's shortest-first split shares the token budget by excerpt length, not relevance. (The server-side fix bounds each page at `MAX_PAGE_CHARS`; the client-side split is left as-is per the issue's "keep both" guidance.)

## Where to start

Most of the diff is in `server/pageContentService.ts` (236 lines) and its test file (68 lines). The behavior change is the new `selectPassagesAcrossPages` function (~60 lines) plus the restructured `fetchPageContents`.

Two decisions worth a look:
- **Jaccard threshold 0.9**: chosen to catch near-identical syndicated paragraphs while allowing paraphrases. The constant is module-scoped for easy tuning.
- **Same-URL dedup is skipped**: passages from the same page are allowed to coexist; dedup is only for cross-URL syndication.

What's intentionally left out:
- The client-side shortest-first split (`client/modules/textGenerationUtilities.ts`) is unchanged. The issue explicitly keeps both server per-page cap and client cross-page token cap.
- A page-rank prior in the scorer was considered but deferred: the position prior can let a later result keep a paragraph the higher-ranked one carries further down its page. This is documented in `docs/page-content.md`.

## How to test

1. `npm run test` — 663 tests pass.
2. `npm run lint` — clean.
3. `npm run format:check` — clean.
4. The new dedup test verifies that a paragraph appearing on two pages reaches the prompt once.
5. The new drop-path test verifies that a page whose sole passage is a near-duplicate of an earlier page's is removed from the response.

## Follow-ups

- Consider adding a small page-rank bonus to `scorePassage` so syndicated-paragraph dedup prefers the top result's copy. Documented as a limitation in the docs.
- The `excerptKeptRate` metric now reflects dedup as well as the per-URL cap; the doc already says this.
