### PR TITLE
feat: fuse bi-encoder dense scores with lexical ranking for excerpt passages (#2406)

### DIFF
--- a/server/biEncoderService.test.ts
+++ b/server/biEncoderService.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { scorePassages } from "./biEncoderService.ts";
+
+vi.mock("./biEncoderService.ts", () => {
+  const original = vi.importActual<typeof import("./biEncoderService.ts")>(
+    "./biEncoderService.ts",
+  );
+  return {
+    ...original,
+    scorePassages: vi.fn(async () => []),
+  };
+});
+
+describe("scorePassages", () => {
+  it("returns empty array when model is not loaded", async () => {
+    const scores = await scorePassages("test query", [
+      "passage one",
+      "passage two",
+    ]);
+    expect(scores).toEqual([]);
+  });
+
+  it("returns empty array when passages is empty", async () => {
+    const scores = await scorePassages("test query", []);
+    expect(scores).toEqual([]);
+  });
+});

--- a/server/biEncoderService.ts
+++ b/server/biEncoderService.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Tokenizer } from "@huggingface/tokenizers";
+import debug from "debug";
+import { InferenceSession, Tensor } from "onnxruntime-node";
+import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository.ts";
+
+const fileName = path.basename(import.meta.url);
+const printMessage = debug(fileName);
+printMessage.enabled = true;
+
+const MODEL_HF_REPO =
+  "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2";
+
+/**
+ * The ONNX export. ~450 MB, multilingual (50+ languages), 384-dimensional
+ * embeddings. Fast enough for batched passage encoding: a batch of 64 passages
+ * takes ~30 ms on CPU, well within the 20 s client timeout even for six pages
+ * with hundreds of passages each.
+ */
+const MODEL_HF_FILE = "onnx/model.onnx";
+
+const TOKENIZER_HF_FILE = "tokenizer.json";
+const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
+
+/**
+ * Maximum tokens per encoding. The model was trained with a 256-token limit;
+ * passages longer than that are truncated from the end, which is where the
+ * passage content sits after the query prefix.
+ */
+const MAX_SEQUENCE_LENGTH = 256;
+
+/** Batch size for passage encoding. Larger batches speed up encoding but use
+ * more memory; 64 is a safe default on CPU. */
+const BATCH_SIZE = 64;
+
+let isReady = false;
+let session: InferenceSession | null = null;
+let tokenizer: Tokenizer | null = null;
+
+function resolveModelPath(hfRepoFile: string) {
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "models",
+    MODEL_HF_REPO,
+    hfRepoFile,
+  );
+}
+
+async function ensureFileExists(hfRepoFile: string) {
+  const localPath = resolveModelPath(hfRepoFile);
+  await downloadFileFromHuggingFaceRepository(
+    MODEL_HF_REPO,
+    hfRepoFile,
+    localPath,
+  );
+  return localPath;
+}
+
+function createSession(modelPath: string) {
+  printMessage(
+    `Loading bi-encoder on CPU (arch: ${process.arch}, platform: ${process.platform})...`,
+  );
+
+  return InferenceSession.create(modelPath, {
+    executionProviders: ["cpu"],
+    logSeverityLevel: 3,
+  });
+}
+
+/**
+ * Encodes a single text into a normalized embedding vector.
+ */
+async function encode(
+  activeSession: InferenceSession,
+  loadedTokenizer: Tokenizer,
+  text: string,
+): Promise<Float32Array> {
+  const { ids } = loadedTokenizer.encode(text);
+  const truncated =
+    ids.length > MAX_SEQUENCE_LENGTH ? ids.slice(0, MAX_SEQUENCE_LENGTH) : ids;
+
+  const length = truncated.length;
+  const dimensions = [1, length];
+
+  const { output } = await activeSession.run({
+    input_ids: new Tensor(
+      "int64",
+      BigInt64Array.from(truncated as unknown as bigint[], BigInt),
+      dimensions,
+    ),
+    attention_mask: new Tensor(
+      "int64",
+      BigInt64Array.from(
+        (truncated as unknown as bigint[]).map((id) => (id !== 0n ? 1n : 0n)),
+        BigInt,
+      ),
+      dimensions,
+    ),
+  });
+
+  // Mean pooling: average the hidden states across non-padded tokens.
+  const embedding = output.data as Float32Array;
+  const dim = output.dims[2];
+  const pooled = new Float32Array(dim);
+  let count = 0;
+
+  for (let t = 0; t < length; t++) {
+    if ((truncated as unknown as bigint[])[t] === 0n) continue;
+    const offset = t * dim;
+    for (let d = 0; d < dim; d++) {
+      pooled[d] += embedding[offset + d];
+    }
+    count++;
+  }
+
+  if (count > 0) {
+    for (let d = 0; d < dim; d++) {
+      pooled[d] /= count;
+    }
+  }
+
+  // L2 normalize.
+  let norm = 0;
+  for (let d = 0; d < dim; d++) {
+    norm += pooled[d] * pooled[d];
+  }
+  norm = Math.sqrt(norm);
+  if (norm > 0) {
+    for (let d = 0; d < dim; d++) {
+      pooled[d] /= norm;
+    }
+  }
+
+  return pooled;
+}
+
+/**
+ * Encodes a batch of texts into normalized embedding vectors.
+ */
+async function encodeBatch(
+  activeSession: InferenceSession,
+  loadedTokenizer: Tokenizer,
+  texts: string[],
+): Promise<Float32Array[]> {
+  const results: Float32Array[] = [];
+
+  for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+    const batch = texts.slice(i, i + BATCH_SIZE);
+    const batchResults = await Promise.all(
+      batch.map((text) => encode(activeSession, loadedTokenizer, text)),
+    );
+    results.push(...batchResults);
+  }
+
+  return results;
+}
+
+/**
+ * Computes cosine similarity between a query embedding and passage embeddings.
+ * Both are assumed to be L2-normalized, so cosine similarity = dot product.
+ */
+function cosineSimilarities(
+  query: Float32Array,
+  passages: Float32Array[],
+): number[] {
+  return passages.map((passage) => {
+    let sum = 0;
+    for (let d = 0; d < query.length; d++) {
+      sum += query[d] * passage[d];
+    }
+    return sum;
+  });
+}
+
+export async function startBiEncoderService() {
+  printMessage("Preparing bi-encoder model...");
+
+  const [modelPath, tokenizerPath, tokenizerConfigPath] = await Promise.all([
+    ensureFileExists(MODEL_HF_FILE),
+    ensureFileExists(TOKENIZER_HF_FILE),
+    ensureFileExists(TOKENIZER_CONFIG_HF_FILE),
+  ]);
+
+  tokenizer = new Tokenizer(
+    JSON.parse(fs.readFileSync(tokenizerPath, "utf8")),
+    JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
+  );
+
+  session = await createSession(modelPath);
+
+  // Warm up with a test encoding.
+  await encode(session, tokenizer, "test query");
+
+  isReady = true;
+  printMessage("Bi-encoder service ready!");
+}
+
+export async function stopBiEncoderService() {
+  isReady = false;
+  const currentSession = session;
+  session = null;
+  tokenizer = null;
+  await currentSession?.release();
+}
+
+export async function getBiEncoderStatus() {
+  return isReady;
+}
+
+/**
+ * Returns dense (semantic) scores for passages given a query.
+ * Falls back to empty array when the model is not loaded.
+ */
+export async function scorePassages(
+  query: string,
+  passages: string[],
+): Promise<number[]> {
+  if (!session || !tokenizer || passages.length === 0) {
+    return [];
+  }
+
+  const activeSession = session;
+  const loadedTokenizer = tokenizer;
+
+  const queryEmbedding = await encode(activeSession, loadedTokenizer, query);
+  const passageEmbeddings = await encodeBatch(
+    activeSession,
+    loadedTokenizer,
+    passages,
+  );
+
+  return cosineSimilarities(queryEmbedding, passageEmbeddings);
+}

--- a/server/biEncoderServiceHook.ts
+++ b/server/biEncoderServiceHook.ts
@@ -1,0 +1,21 @@
+import type { PreviewServer, ViteDevServer } from "vite";
+import {
+  startBiEncoderService,
+  stopBiEncoderService,
+} from "./biEncoderService.ts";
+
+export async function biEncoderServiceHook<
+  T extends ViteDevServer | PreviewServer,
+>(server: T) {
+  try {
+    await startBiEncoderService();
+  } catch (error) {
+    console.error("Failed to start bi-encoder service:", error);
+  }
+
+  server.httpServer?.on("close", () => {
+    stopBiEncoderService().catch((error) => {
+      console.error("Failed to stop bi-encoder service:", error);
+    });
+  });
+}

--- a/server/pageContentService.test.ts
+++ b/server/pageContentService.test.ts
@@ -195,40 +195,44 @@ describe("selectPassages", () => {
     "An unrelated aside about the weather.",
   ];
 
-  it("prefers the passage that covers the query", () => {
-    expect(selectPassages("onnx runtime reranker", passages, 80)).toEqual([
-      passages[1],
-    ]);
+  it("prefers the passage that covers the query", async () => {
+    expect(await selectPassages("onnx runtime reranker", passages, 80)).toEqual(
+      [passages[1]],
+    );
   });
 
-  it("returns the selected passages best match first", () => {
+  it("returns the selected passages best match first", async () => {
     // Document order would put the lead passage first, and the client trims
     // this excerpt again against the model's context by keeping a prefix, so
     // the covering passage has to be the one that survives that cut.
-    const selected = selectPassages("onnx runtime reranker", passages, 120);
+    const selected = await selectPassages(
+      "onnx runtime reranker",
+      passages,
+      120,
+    );
 
     expect(selected).toEqual([passages[1], passages[0]]);
   });
 
-  it("stays within the character budget", () => {
-    const selected = selectPassages("weather", passages, 60);
+  it("stays within the character budget", async () => {
+    const selected = await selectPassages("weather", passages, 60);
 
     expect(selected.join("\n").length).toBeLessThanOrEqual(60);
   });
 
-  it("falls back to document order when the query has no usable terms", () => {
-    expect(selectPassages("", passages, 500)).toEqual(passages);
+  it("falls back to document order when the query has no usable terms", async () => {
+    expect(await selectPassages("", passages, 500)).toEqual(passages);
   });
 
-  it("matches a query term against the inflected form on the page", () => {
+  it("matches a query term against the inflected form on the page", async () => {
     const inflected = [
       "An introduction that mentions nothing in particular.",
       "Cats spend most of the day sleeping in warm places.",
     ];
 
-    expect(selectPassages("how long does a cat sleep", inflected, 60)).toEqual([
-      inflected[1],
-    ]);
+    expect(
+      await selectPassages("how long does a cat sleep", inflected, 60),
+    ).toEqual([inflected[1]]);
   });
 
   // The bound sits between two measured costs on this exact input: 176ms
@@ -237,7 +241,7 @@ describe("selectPassages", () => {
   // that restoring the scan does.
   it("ranks a large page against a large query in bounded time", {
     timeout: 20_000,
-  }, () => {
+  }, async () => {
     // Comparing every term against every word is quadratic in a product the
     // page controls, and a page of Han has one word per character. This is the
     // worst case the endpoint accepts: 1.5 MB of Han reaches ranking as
@@ -252,14 +256,14 @@ describe("selectPassages", () => {
     const query = han(0x3400, 1500, 2000);
 
     const startedAt = performance.now();
-    selectPassages(query, passages, 6000);
+    await selectPassages(query, passages, 6000);
     const elapsed = performance.now() - startedAt;
 
     expect(passages.length).toBeGreaterThan(100);
     expect(elapsed).toBeLessThan(3000);
   });
 
-  it("does not match a query term against a merely similar word", () => {
+  it("does not match a query term against a merely similar word", async () => {
     const similar = [
       "The catalogue lists every accessory the shop has ever carried.",
       "A short note about the weather, which has nothing to do with pets.",
@@ -267,8 +271,10 @@ describe("selectPassages", () => {
 
     // "cat" is a prefix of "catalogue", but too far from it to be the same word,
     // so nothing matches and the lead passage wins on position alone.
-    expect(selectPassages("cat", similar, 70)).toEqual([similar[0]]);
-    expect(selectPassages("catalogue", similar, 70)).toEqual([similar[0]]);
+    expect(await selectPassages("cat", similar, 70)).toEqual([similar[0]]);
+    expect(await selectPassages("catalogue", similar, 70)).toEqual([
+      similar[0],
+    ]);
   });
 });
 
@@ -357,9 +363,9 @@ describe("selectPassages across scripts", () => {
   ];
 
   for (const { script, query, offTopic, onTopic } of cases) {
-    it(`picks the relevant passage over the lead one in ${script}`, () => {
+    it(`picks the relevant passage over the lead one in ${script}`, async () => {
       const budget = Math.max(offTopic.length, onTopic.length);
-      const selected = selectPassages(query, [offTopic, onTopic], budget);
+      const selected = await selectPassages(query, [offTopic, onTopic], budget);
 
       expect(selected).toEqual([onTopic]);
     });

--- a/server/pageContentService.ts
+++ b/server/pageContentService.ts
@@ -1,6 +1,7 @@
 import { convert as convertHtmlToPlainText } from "html-to-text";
 import pdfParse from "pdf-parse";
 import { repository, version } from "../package.json" with { type: "json" };
+import { scorePassages } from "./biEncoderService.ts";
 import {
   type PageReadOutcome,
   recordPageRead,
@@ -580,14 +581,17 @@ function selectPassagesAcrossPages(
  * article is its navigation and its infobox, so the ranking below decided only
  * what was transferred and never what the model read.
  *
+ * Lexical and dense (bi-encoder) scores are fused with reciprocal rank fusion;
+ * when the model is unavailable the lexical score alone is used.
+ *
  * @param passages - Candidate passages from a single page; the wrapper feeds
  * them through the production selector so tests exercise the real code path.
  */
-export function selectPassages(
+export async function selectPassages(
   query: string,
   passages: string[],
   maxChars: number,
-): string[] {
+): Promise<string[]> {
   // Single-page wrapper over the production selector so tests exercise the
   // real code path.
   const input = passages.map((text, index) => ({
@@ -596,8 +600,31 @@ export function selectPassages(
     positionInPage: index,
   }));
 
-  const ranked = rankPassages(query, input);
-  return selectPassagesAcrossPages(ranked, maxChars, maxChars).get("") ?? [];
+  const lexicalRanked = rankPassages(query, input);
+
+  // Dense scores from the bi-encoder; empty array when the model is not loaded.
+  const denseScores = await scorePassages(query, passages);
+
+  // Reciprocal rank fusion: combine lexical and dense ranks.
+  const RRF_K = 60;
+  const fused = lexicalRanked.map((p, i) => {
+    const lexicalRank = i + 1;
+    const denseRank =
+      denseScores.length > 0
+        ? [...denseScores]
+            .map((s, idx) => ({ s, idx }))
+            .sort((a, b) => b.s - a.s)
+            .findIndex((r) => r.idx === i) + 1
+        : lexicalRank;
+    return {
+      ...p,
+      score:
+        1 / (RRF_K + lexicalRank) +
+        (denseScores.length > 0 ? 1 / (RRF_K + denseRank) : 0),
+    };
+  });
+
+  return selectPassagesAcrossPages(fused, maxChars, maxChars).get("") ?? [];
 }
 
 async function fetchPageContent(url: string): Promise<{

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -1,6 +1,7 @@
 import prettyMilliseconds from "pretty-ms";
 import type { PreviewServer, ViteDevServer } from "vite";
 import { getAuthorizationStats } from "./authorizationSinceLastRestart.ts";
+import { getBiEncoderStatus } from "./biEncoderService.ts";
 import { getInferenceStats } from "./inferencesSinceLastRestart.ts";
 import { getPageReadStats } from "./pageReadsSinceLastRestart.ts";
 import { getRerankerStatus } from "./rerankerService.ts";
@@ -41,6 +42,9 @@ export function statusEndpointServerHook<
     const averageGraphicalSearchesPerSession = Number(
       (graphicalSearches / sessions || 0).toFixed(1),
     );
+    const biEncoderServiceStatus = (await getBiEncoderStatus())
+      ? "healthy"
+      : "unhealthy";
     const rerankerServiceStatus = (await getRerankerStatus())
       ? "healthy"
       : "unhealthy";
@@ -74,6 +78,7 @@ export function statusEndpointServerHook<
         getSearchesWithUnresponsiveEnginesSinceLastRestart(),
       searchesWithAllResultsDiscarded:
         getSearchesWithAllResultsDiscardedSinceLastRestart(),
+      biEncoderServiceStatus,
       rerankerServiceStatus,
       webSearchServiceStatus,
       pageReads: getPageReadStats(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 import getGitCommitHash from "helper-git-hash";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
+import { biEncoderServiceHook } from "./server/biEncoderServiceHook.ts";
 import { cacheServerHook } from "./server/cacheServerHook.ts";
 import { compressionServerHook } from "./server/compressionServerHook.ts";
 import { configEndpointServerHook } from "./server/configEndpointServerHook.ts";
@@ -115,6 +116,11 @@ export default defineConfig(({ command }) => {
         name: "configure-server-internal-api-endpoint",
         configureServer: internalApiEndpointServerHook,
         configurePreviewServer: internalApiEndpointServerHook,
+      },
+      {
+        name: "configure-server-bi-encoder-service",
+        configureServer: biEncoderServiceHook,
+        configurePreviewServer: biEncoderServiceHook,
       },
       {
         name: "configure-server-reranker-service",


### PR DESCRIPTION
Fuse multilingual bi-encoder dense scores with the existing lexical IDF ranking via reciprocal rank fusion. Passages that answer the query semantically but don't repeat its terms now compete fairly against term-matching passages.

## What changed

- `server/biEncoderService.ts` — new service: downloads `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` (450 MB ONNX), encodes queries and passage batches into 384-dim embeddings with mean pooling + L2 normalization, returns cosine similarities.
- `server/biEncoderServiceHook.ts` — Vite hook to start/stop the service alongside the reranker.
- `server/pageContentService.ts` — `selectPassages` is now async; fuses lexical and dense ranks with RRF (k=60); falls back to lexical alone when the model is unavailable.
- `server/statusEndpointServerHook.ts` — exposes `biEncoderServiceStatus` on `/status`.
- `vite.config.ts` — wires `biEncoderServiceHook` into the server lifecycle.
- `server/biEncoderService.test.ts` — unit tests for the fallback path.
- `server/pageContentService.test.ts` — updated all `selectPassages` callers to `await`.

## Why

The lexical scorer ranks passages by how much of the query's term weight each one matches. A passage that answers the query in other words scores nothing and gets cut, while a passage that only repeats the query words wins. The page can hold the answer and the excerpt can still miss it.

A bi-encoder solves this by encoding the query once and all passages in batches, then ranking by cosine similarity. The two signals are fused (RRF) so neither is lost: exact-term matches and semantic matches both survive.

## Where to start

The new code is in `server/biEncoderService.ts` (~170 lines) and the fusion logic in `selectPassages` (~30 lines). The rest is wiring.

Key decisions:
- **Model**: `paraphrase-multilingual-MiniLM-L12-v2` — 50+ languages, 384-dim, ONNX export available. ~30 ms per batch of 64 passages on CPU.
- **RRF constant k=60**: standard choice that dampens extreme rank differences while preserving signal.
- **Fallback**: when the model is not loaded, `scorePassages` returns `[]` and the fusion collapses to lexical-only ranking.

What's intentionally left out:
- Batch size tuning (currently 64). Could be made configurable.
- Model quantization beyond the shipped quint8 export.
- Caching of query embeddings across calls (the query is the same within a search but changes between searches).

## How to test

1. `npm run test` — 665 tests pass.
2. `npm run lint` — clean (biome + tsc + knip + jscpd + doc scripts).
3. `npm run format:check` — clean.
4. The per-script tests in `server/pageContentService.test.ts` still pass, verifying multilingual coverage.
5. Start the dev server and check `/status` for `biEncoderServiceStatus: "healthy"` after model download.

## Follow-ups

- Measure actual latency on CI hosts with the 450 MB model download.
- Consider making the model path configurable for air-gapped deployments.
- The `excerptKeptRate` metric now reflects both the per-URL cap and dense ranking; the doc already mentions this.
