### PR TITLE
fix: serve the search token at runtime and keep it stable per process

### DIFF
--- a/client/components/App/App.test.tsx
+++ b/client/components/App/App.test.tsx
@@ -28,6 +28,7 @@ const serverConfig: ServerConfig = {
   internalApiEnabled: false,
   internalApiName: "Internal API",
   defaultInferenceType: "browser",
+  searchToken: "a".repeat(64),
 };
 
 describe("App", () => {

--- a/client/modules/config.test.ts
+++ b/client/modules/config.test.ts
@@ -11,6 +11,7 @@ const serverConfig: ServerConfig = {
   internalApiEnabled: true,
   internalApiName: "Custom LLM",
   defaultInferenceType: "internal",
+  searchToken: "a".repeat(64),
 };
 
 /** Imports a fresh copy of the module so its cache starts empty. */

--- a/client/modules/config.ts
+++ b/client/modules/config.ts
@@ -19,6 +19,10 @@ export type { ServerConfig };
  * Config to assume only where running without the server's values is harmless.
  * It is deliberately not used for `accessKeysEnabled`: treating an unreachable
  * server as "access keys are off" would skip the access key page entirely.
+ *
+ * `searchToken` has no harmless stand-in, so it is empty here. Anything that
+ * needs it goes through `getConfig`, which rejects rather than handing back a
+ * token the server would turn away.
  */
 export const FALLBACK_CONFIG: ServerConfig = {
   accessKeysEnabled: false,
@@ -27,6 +31,7 @@ export const FALLBACK_CONFIG: ServerConfig = {
   internalApiEnabled: false,
   internalApiName: DEFAULT_INTERNAL_API_NAME,
   defaultInferenceType: DEFAULT_INFERENCE_TYPE,
+  searchToken: "",
 };
 
 const FETCH_TIMEOUT_MS = 5000;

--- a/client/modules/searchTokenHash.test.ts
+++ b/client/modules/searchTokenHash.test.ts
@@ -14,7 +14,9 @@ vi.mock("./pubSub", () => ({
 
 const searchToken = "a".repeat(64);
 
-vi.stubGlobal("VITE_SEARCH_TOKEN", searchToken);
+vi.mock("./config", () => ({
+  getConfig: () => Promise.resolve({ searchToken }),
+}));
 
 /** Digest length in bytes, read from the trailing field of the encoded hash. */
 function getDigestLength(encodedHash: string) {

--- a/client/modules/searchTokenHash.ts
+++ b/client/modules/searchTokenHash.ts
@@ -1,9 +1,10 @@
 import { argon2id, argon2Verify } from "hash-wasm";
+import { getConfig } from "./config";
 import { addLogEntry } from "./logEntries";
 import { getLastSearchTokenHash, updateLastSearchTokenHash } from "./pubSub";
 
 export async function getSearchTokenHash() {
-  const password = VITE_SEARCH_TOKEN;
+  const { searchToken: password } = await getConfig();
   const lastSearchTokenHash = getLastSearchTokenHash();
 
   try {

--- a/client/modules/settings.test.ts
+++ b/client/modules/settings.test.ts
@@ -14,6 +14,7 @@ const mockConfig: ServerConfig = {
   internalApiEnabled: false,
   internalApiName: "Internal API",
   defaultInferenceType: "browser",
+  searchToken: "a".repeat(64),
 };
 
 describe("Settings Module", () => {

--- a/client/types.d.ts
+++ b/client/types.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
 
-declare const VITE_SEARCH_TOKEN: string;
 declare const VITE_BUILD_DATE_TIME: number;
 declare const VITE_COMMIT_SHORT_HASH: string;

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -163,7 +163,7 @@ Content-Type: application/json
 }
 ```
 
-The token is passed as a URL query parameter (`?token=`), verified server-side with Argon2 against the build-time `VITE_SEARCH_TOKEN`, not as an `Authorization: Bearer` header. The model field is optional; if `INTERNAL_OPENAI_COMPATIBLE_API_MODEL` is unset, the server fetches and randomly selects from the upstream's available models.
+The token is passed as a URL query parameter (`?token=`), verified server-side with Argon2 against the token the server is holding, not as an `Authorization: Bearer` header. The model field is optional; if `INTERNAL_OPENAI_COMPATIBLE_API_MODEL` is unset, the server fetches and randomly selects from the upstream's available models.
 
 **Observability:** what happens to these requests is counted on `/status`
 under `inference`: how many answers finished, how many failed before or after

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,7 +243,6 @@ Client-facing configuration (access keys, inference type, internal API settings)
 
 | Value | Resolved At | Notes |
 |-------|-------------|-------|
-| `VITE_SEARCH_TOKEN` | Build time | CSRF protection token, regenerated on each build |
 | `VITE_BUILD_DATE_TIME` | Build time | Epoch milliseconds when the build occurred |
 | `VITE_COMMIT_SHORT_HASH` | Build time | Git commit hash at build time (if available) |
 | `ACCESS_KEYS` | Runtime | Read from `/api/config` |
@@ -251,10 +250,12 @@ Client-facing configuration (access keys, inference type, internal API settings)
 | `WLLAMA_DEFAULT_MODEL_ID` | Runtime | Read from `/api/config` |
 | `INTERNAL_OPENAI_COMPATIBLE_API_*` | Runtime | Read from `/api/config` (except `API_KEY` which is server-only) |
 | `DEFAULT_INFERENCE_TYPE` | Runtime | Read from `/api/config` |
+| Search token | Runtime | Read from `/api/config`, so a reload picks up the token of whichever server answers |
 
 ### Security Considerations
 
-- `VITE_SEARCH_TOKEN`, `VITE_BUILD_DATE_TIME`, and `VITE_COMMIT_SHORT_HASH` are bundled into the client JavaScript as build-time constants (CSRF token and build metadata)
+- `VITE_BUILD_DATE_TIME` and `VITE_COMMIT_SHORT_HASH` are bundled into the client JavaScript as build-time constants (build metadata only)
+- The CSRF token is served at runtime like the rest of the config. It reaches any caller that can reach `/api/config`, which is the same exposure it had while it was compiled into the bundle
 - All other configuration is fetched at runtime from `/api/config` and never appears in the bundled JavaScript
 - Server-only variables like `INTERNAL_OPENAI_COMPATIBLE_API_KEY` are never exposed to the client
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,7 +8,7 @@ Codebase-specific terms, jargon, and domain concepts used in MiniSearch.
 
 A security mechanism used to authorize communication between the client and the internal search/AI endpoints.
 
-- **Search Token**: A string generated at build time (`VITE_SEARCH_TOKEN`). Used to verify that requests to the server originate from a trusted build.
+- **Search Token**: A random string held by the running server, served to the client at runtime through `/api/config`. Used to verify that requests to the server come from a client that server handed the token to.
 - **Search Token Hash**: To avoid exposing the raw token in all requests, the client generates a hash of the token. Managed via the `lastSearchTokenHashPubSub` channel.
 - **Verification**: The server verifies these tokens to prevent unauthorized access to the search API. Stored in `server/verifiedTokens.ts` as an in-memory `Set<string>`.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -122,13 +122,16 @@ The `textGeneration` module orchestrates the entire search-to-response flow, man
 
 ### Search Token Lifecycle
 
-CSRF protection uses a build-time generated token:
+CSRF protection uses a token the server owns for its lifetime:
 
-1. **Generation**: Token created at build time in `vite.config.ts` and injected as `VITE_SEARCH_TOKEN`
-2. **Storage**: Server stores token file at `{os.tempdir()}/minisearch-token`
-3. **Client Hashing**: Client hashes token before sending in requests (never sends raw token)
-4. **Verification**: Server compares request hash against stored token
-5. **Caching**: Verified tokens stored in `server/verifiedTokens.ts` (in-memory `Map` of token to last-seen time) to avoid redundant cryptographic operations
+1. **Generation**: `regenerateSearchToken()` writes a random token at build time, and on first use if the file is absent
+2. **Storage**: Server stores token file at `{os.tempdir()}/minisearch-token`, read once per process and held in memory from then on
+3. **Distribution**: Server serves the token to the client at runtime through `/api/config`, so a client always holds the token of the server answering it
+4. **Client Hashing**: Client hashes token before sending in requests (never sends raw token)
+5. **Verification**: Server compares request hash against the token it is holding
+6. **Caching**: Verified tokens stored in `server/verifiedTokens.ts` (in-memory `Map` of token to last-seen time) to avoid redundant cryptographic operations
+
+Rewriting the token file under a running server does not re-key it: the server keeps the token it is already handing out, and logs once that the file diverged if a request is rejected while it has.
 
 ## Data Flow and Communication
 
@@ -158,7 +161,7 @@ MiniSearch uses a PubSub-based architecture where state flows through independen
 ### API Request Authentication
 
 1. Client retrieves cached token hash from `lastSearchTokenHashPubSub` (localStorage-backed)
-2. If expired or missing, generates new hash from `VITE_SEARCH_TOKEN`
+2. If expired or missing, generates new hash from the `searchToken` in `/api/config`
 3. Request includes hashed token as query parameter
 4. Server hook verifies token against stored value
 5. On success, token added to `verifiedTokens` Set for subsequent requests
@@ -436,8 +439,8 @@ Lightweight state persisted across sessions via `createLocalStoragePubSub` patte
 ### Server-Side Bootstrap (vite.config.ts)
 
 1. Loads environment variables via `dotenv.config`
-2. Generates/retrieves search token for CSRF protection
-3. Injects environment-based constants as compile-time replacements (`VITE_SEARCH_TOKEN`, `VITE_ACCESS_KEYS_ENABLED`, etc.)
+2. Regenerates the search token used for CSRF protection, on build only
+3. Injects build metadata as compile-time replacements (`VITE_BUILD_DATE_TIME`, `VITE_COMMIT_SHORT_HASH`)
 4. Registers all middleware hooks (see Server Hook System above)
 
 ### Client-Side Bootstrap (client/index.tsx)

--- a/docs/security.md
+++ b/docs/security.md
@@ -34,7 +34,7 @@ can reach the instance, so keep secrets out of that interface.
 Every HTTP request from client to backend carries a `token` query parameter for CSRF protection:
 
 1. **Token Generation**: On build/startup, `regenerateSearchToken()` writes a random token to `{os.tempdir()}/minisearch-token`, readable only by the user running the build (`0600`)
-2. **Client Injection**: The token is injected as `VITE_SEARCH_TOKEN` compile-time constant via Vite's `define` option
+2. **Client Distribution**: The server reads the file once, holds that token for the life of the process, and serves it as `searchToken` in `/api/config`
 3. **Per-Request Auth**: Client includes token as `?token=` parameter on all `/search/text`, `/search/images` and `/page-content` requests
 4. **Server Verification**: `handleTokenVerification()` in `searchEndpointServerHook.ts` validates the token before proxying to SearXNG
 5. **Session Tracking**: Validated tokens are stored in an in-memory `Set<string>` (`verifiedTokens.ts`) for session counting

--- a/server/configEndpointServerHook.ts
+++ b/server/configEndpointServerHook.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_WLLAMA_MODEL_ID,
   type ServerConfig,
 } from "../shared/serverConfig.ts";
+import { getSearchToken } from "./searchToken.ts";
 
 /**
  * Vite server hook that serves runtime server config at /api/config.
@@ -32,6 +33,10 @@ export function configEndpointServerHook<
         DEFAULT_INTERNAL_API_NAME,
       defaultInferenceType:
         process.env.DEFAULT_INFERENCE_TYPE || DEFAULT_INFERENCE_TYPE,
+      // Served here rather than compiled into the bundle so a client always
+      // gets the token of the server answering it, and a reload is enough to
+      // pick up a new one.
+      searchToken: getSearchToken(),
     };
 
     res.setHeader("Content-Type", "application/json");

--- a/server/searchToken.test.ts
+++ b/server/searchToken.test.ts
@@ -21,6 +21,9 @@ vi.mock("node:fs", () => ({
 vi.mock("temp-dir", () => ({ default: "/tmp" }));
 
 beforeEach(() => {
+  // The module holds the token for the life of the process, so every test
+  // needs its own copy of it.
+  vi.resetModules();
   vi.clearAllMocks();
   mockExistsSync.mockReset();
   mockReadFileSync.mockReset();
@@ -52,16 +55,41 @@ describe("searchToken", () => {
 
     const { getSearchToken } = await import("./searchToken");
 
-    // First call — file doesn't exist, should regenerate
-    getSearchToken();
+    const token = getSearchToken();
+
     expect(mockWriteFileSync).toHaveBeenCalled();
+    expect(token).toBe(mockWriteFileSync.mock.calls[0][1]);
+  });
 
-    // Now file exists
+  it("should keep the token it read at startup when the file changes", async () => {
     mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue("new-token-456");
+    mockReadFileSync.mockReturnValue("token-from-startup");
 
-    const token2 = getSearchToken();
-    expect(token2).toBe("new-token-456");
+    const { getSearchToken } = await import("./searchToken");
+
+    expect(getSearchToken()).toBe("token-from-startup");
+
+    // Another process rewriting the file must not re-key this one: the clients
+    // already holding the old token have no way of being told about a new one.
+    mockReadFileSync.mockReturnValue("token-from-another-process");
+
+    expect(getSearchToken()).toBe("token-from-startup");
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("should serve the new token after regenerating it", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("token-from-startup");
+    mockWriteFileSync.mockReturnValue(undefined);
+
+    const { getSearchToken, regenerateSearchToken } = await import(
+      "./searchToken"
+    );
+
+    getSearchToken();
+    regenerateSearchToken();
+
+    expect(getSearchToken()).toBe(mockWriteFileSync.mock.calls[0][1]);
   });
 
   it("regenerateSearchToken should draw the token from a cryptographic source", async () => {
@@ -94,5 +122,57 @@ describe("searchToken", () => {
     // A file left behind by an earlier build keeps its old permissions,
     // which `mode` alone would not correct.
     expect(mockChmodSync).toHaveBeenCalledWith(filePath, 0o600);
+  });
+});
+
+describe("hasSearchTokenFileChanged", () => {
+  it("should be false before a token has been read", async () => {
+    const { hasSearchTokenFileChanged } = await import("./searchToken");
+
+    expect(hasSearchTokenFileChanged()).toBe(false);
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it("should be false while the file still holds this process's token", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("token-from-startup");
+
+    const { getSearchToken, hasSearchTokenFileChanged } = await import(
+      "./searchToken"
+    );
+
+    getSearchToken();
+
+    expect(hasSearchTokenFileChanged()).toBe(false);
+  });
+
+  it("should be true once another process rewrites the file", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("token-from-startup");
+
+    const { getSearchToken, hasSearchTokenFileChanged } = await import(
+      "./searchToken"
+    );
+
+    getSearchToken();
+    mockReadFileSync.mockReturnValue("token-from-another-process");
+
+    expect(hasSearchTokenFileChanged()).toBe(true);
+  });
+
+  it("should be true when the file is gone", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("token-from-startup");
+
+    const { getSearchToken, hasSearchTokenFileChanged } = await import(
+      "./searchToken"
+    );
+
+    getSearchToken();
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(hasSearchTokenFileChanged()).toBe(true);
   });
 });

--- a/server/searchToken.ts
+++ b/server/searchToken.ts
@@ -7,11 +7,28 @@ function getSearchTokenFilePath() {
   return path.resolve(temporaryDirectory, "minisearch-token");
 }
 
-/** The shared search token, generated on first use and kept across restarts with 0600 permissions. */
-export const getSearchToken = () => {
-  if (!existsSync(getSearchTokenFilePath())) regenerateSearchToken();
-  return readFileSync(getSearchTokenFilePath(), "utf8");
-};
+let processToken: string | null = null;
+
+/**
+ * The shared search token, generated on first use and kept across restarts with
+ * 0600 permissions.
+ *
+ * Read once and then held for the life of the process. Reading the file on
+ * every request let anything that rewrote it re-key a running server: the
+ * clients holding the previous token were rejected from that moment on, and so
+ * was every new page load, because the token being handed out had been captured
+ * when the server started. A server that keeps its own token instead can still
+ * verify the clients it handed that token to.
+ */
+export function getSearchToken() {
+  if (processToken !== null) return processToken;
+
+  if (!existsSync(getSearchTokenFilePath())) return regenerateSearchToken();
+
+  processToken = readFileSync(getSearchTokenFilePath(), "utf8");
+
+  return processToken;
+}
 
 export function regenerateSearchToken() {
   const filePath = getSearchTokenFilePath();
@@ -20,4 +37,25 @@ export function regenerateSearchToken() {
   // `mode` only applies when the file is created, so a token file left behind
   // by an earlier build would keep its old, world-readable permissions.
   chmodSync(filePath, 0o600);
+  processToken = newToken;
+
+  return newToken;
+}
+
+/**
+ * Whether the file no longer holds the token this process verifies against,
+ * which means another process rewrote it. Not a failure in itself, since this
+ * server keeps serving and verifying its own token; it is the one thing that
+ * explains a client being rejected while holding a token that was valid
+ * somewhere else.
+ */
+export function hasSearchTokenFileChanged() {
+  if (processToken === null) return false;
+
+  try {
+    return readFileSync(getSearchTokenFilePath(), "utf8") !== processToken;
+  } catch (error) {
+    void error;
+    return true;
+  }
 }

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -28,6 +28,7 @@ vi.mock("rate-limiter-flexible", () => ({
 
 vi.mock("./searchToken", () => ({
   getSearchToken: vi.fn().mockReturnValue("dummy-token"),
+  hasSearchTokenFileChanged: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock("./verifiedTokens", () => ({

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -1,9 +1,15 @@
 import type { IncomingMessage } from "node:http";
 import { isIP } from "node:net";
+import path from "node:path";
+import debug from "debug";
 import { argon2Verify } from "hash-wasm";
 import { RateLimiterMemory } from "rate-limiter-flexible";
-import { getSearchToken } from "./searchToken.ts";
+import { getSearchToken, hasSearchTokenFileChanged } from "./searchToken.ts";
 import { addVerifiedToken, isVerifiedToken } from "./verifiedTokens.ts";
+
+const fileName = path.basename(import.meta.url);
+const printMessage = debug(fileName);
+printMessage.enabled = true;
 
 export const RATE_LIMIT_POINTS = 10;
 export const RATE_LIMIT_DURATION_SECONDS = 10;
@@ -91,6 +97,24 @@ export async function consumeRateLimitPoint(
   }
 }
 
+let hasReportedTokenFileChange = false;
+
+/**
+ * Says once, on the way out, why a client holding a real token is being turned
+ * away. Without it the only trace is a 401 per request, which reads as a broken
+ * search rather than as two processes holding different tokens. The file is
+ * only read on a request that is already being rejected, which has just paid
+ * for an argon2 verification, so the read costs nothing next to it.
+ */
+function reportTokenFileChangeOnce() {
+  if (hasReportedTokenFileChange || !hasSearchTokenFileChanged()) return;
+
+  hasReportedTokenFileChange = true;
+  printMessage(
+    "Rejected a token that does not match this server's. The token file was rewritten after startup, so a client that took its token from another process keeps being rejected here until this server restarts.",
+  );
+}
+
 export async function verifyTokenAndRateLimit(
   token: string | null,
   request?: IncomingMessage,
@@ -134,6 +158,8 @@ export async function verifyTokenAndRateLimit(
     }
 
     if (!isValidToken) {
+      reportTokenFileChangeOnce();
+
       return {
         isAuthorized: false,
         statusCode: 401,

--- a/shared/serverConfig.ts
+++ b/shared/serverConfig.ts
@@ -5,6 +5,8 @@ export interface ServerConfig {
   internalApiEnabled: boolean;
   internalApiName: string;
   defaultInferenceType: string;
+  /** The CSRF token to hash into the `?token=` of every request to this server. */
+  searchToken: string;
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ import { internalApiEndpointServerHook } from "./server/internalApiEndpointServe
 import { pageContentEndpointServerHook } from "./server/pageContentEndpointServerHook.ts";
 import { rerankerServiceHook } from "./server/rerankerServiceHook.ts";
 import { searchEndpointServerHook } from "./server/searchEndpointServerHook.ts";
-import { getSearchToken, regenerateSearchToken } from "./server/searchToken.ts";
+import { regenerateSearchToken } from "./server/searchToken.ts";
 import { statusEndpointServerHook } from "./server/statusEndpointServerHook.ts";
 import { validateAccessKeyServerHook } from "./server/validateAccessKeyServerHook.ts";
 
@@ -30,7 +30,6 @@ export default defineConfig(({ command }) => {
   return {
     root: "./client",
     define: {
-      VITE_SEARCH_TOKEN: JSON.stringify(getSearchToken()),
       VITE_BUILD_DATE_TIME: Date.now(),
       VITE_COMMIT_SHORT_HASH: JSON.stringify(getGitCommitHash({ short: true })),
     },


### PR DESCRIPTION
## Description

Currently, rewriting `{os.tmpdir()}/minisearch-token` under a running server re-keys it mid-flight and breaks search until the server restarts. `getSearchToken()` read the file on every request, while the client's copy was compiled into the bundle when the Vite config was evaluated, at startup. So anything that rewrote that file rejected every client from that moment on, including brand-new page loads in a fresh browser profile, because the token being handed out was still the one captured at startup. The only trace was a `401 {"error":"Invalid token."}` per request, which reads as a broken search feature rather than as two processes holding different tokens.

This PR makes two changes, either of which alone would have prevented it:

- The server reads the file once and holds that token for the life of the process, so nothing can re-key it while it is answering requests. A build still regenerates the file, and the next process picks it up.
- The token is served to the client at runtime in `/api/config`, alongside the rest of the runtime config, instead of through Vite's `define`. A client always holds the token of the server answering it, and a reload is enough to pick up a new one. It also takes the last secret out of the bundle, which is what that endpoint exists for.

Rejections now explain themselves. When a token is turned away while the file no longer matches what this process verifies against, the server logs that once, naming the cause.

### Where to start

`server/searchToken.ts` is the whole behavior change. Of the rest, 93 lines are tests and 18 are docs; the remaining edits are one field threaded through `ServerConfig`, `/api/config` and `getSearchTokenHash`, plus four `ServerConfig` fixtures that needed the new field.

The token reaches any caller that can reach `/api/config`. That is the same exposure it had while compiled into a bundle served to those same callers, so it is not a change in who can obtain it. The endpoint already sends `Cache-Control: no-store`.

## How to test

1. `docker compose up`, open the app, and search. `curl -s localhost:7860/api/config` now carries a `searchToken` field.
2. Rotate the file under the running server: `docker compose exec development-server node -e 'require("node:fs").writeFileSync("/tmp/minisearch-token", require("node:crypto").randomBytes(32).toString("hex"), {mode:0o600})'`
3. Search again, without reloading. It still works. On `main` this step 401s every search from then on, in every tab and every fresh browser profile, until the server restarts.
4. Present a token from another process (hash the rotated file's token with argon2id and pass it as `?token=`). The request is refused with a 401, and the log says once: `Rejected a token that does not match this server's. The token file was rewritten after startup, ...`
5. `docker compose exec development-server npm run lint` and `npm test` (57 files, 669 tests).

Verified in the browser at each step, including step 3 with results rendering and no console errors.
