### PR TITLE
fix: reject mismatched Argon2 token parameters

### DIFF
--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -99,6 +99,24 @@ describe("verifyTokenAndRateLimit", () => {
     expect(hashWasm.argon2Verify).not.toHaveBeenCalled();
   });
 
+  it("should verify a token hash with the client parameters normally", async () => {
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const hashWasm = await import("hash-wasm");
+    const token =
+      "$argon2id$v=19$m=512,t=16,p=1$c29tZXNhbHRzb21lc2FsdA$0000000000000000000000000000000000000000000";
+
+    const result = await verifyTokenAndRateLimit(token);
+
+    expect(result).toEqual({ isAuthorized: true });
+    expect(hashWasm.argon2Verify).toHaveBeenCalledWith({
+      password: "dummy-token",
+      hash: token,
+    });
+  });
+
   it("refuses an already rejected token without a second argon2 verification", async () => {
     mockArgon2VerifyResult = false;
     vi.resetModules();

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -79,6 +79,26 @@ describe("verifyTokenAndRateLimit", () => {
     });
   });
 
+  it("should reject a token hash with parameters different from the client defaults before verification", async () => {
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const hashWasm = await import("hash-wasm");
+    const token =
+      "$argon2id$v=19$m=4194304,t=1000,p=1$c29tZXNhbHRzb21lc2FsdA$0000000000000000000000000000000000000000000";
+
+    const result = await verifyTokenAndRateLimit(token);
+
+    expect(result).toEqual({
+      isAuthorized: false,
+      statusCode: 401,
+      error: "Invalid token.",
+      reason: "invalidToken",
+    });
+    expect(hashWasm.argon2Verify).not.toHaveBeenCalled();
+  });
+
   it("refuses an already rejected token without a second argon2 verification", async () => {
     mockArgon2VerifyResult = false;
     vi.resetModules();

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -19,6 +19,13 @@ printMessage.enabled = true;
 export const RATE_LIMIT_POINTS = 10;
 export const RATE_LIMIT_DURATION_SECONDS = 10;
 
+const CLIENT_ARGON2_PARAMETERS = "m=512,t=16,p=1";
+
+function hasUnsupportedArgon2Parameters(token: string): boolean {
+  const parameters = /^\$argon2id\$v=19\$([^$]+)\$/.exec(token)?.[1];
+  return parameters !== undefined && parameters !== CLIENT_ARGON2_PARAMETERS;
+}
+
 const rateLimiter = new RateLimiterMemory({
   points: RATE_LIMIT_POINTS,
   duration: RATE_LIMIT_DURATION_SECONDS,
@@ -159,6 +166,15 @@ export async function verifyTokenAndRateLimit(
       // which is the case it was written for.
       recordRejectedTokenCacheHit();
 
+      return {
+        isAuthorized: false,
+        statusCode: 401,
+        error: "Invalid token.",
+        reason: "invalidToken",
+      };
+    }
+
+    if (hasUnsupportedArgon2Parameters(token)) {
       return {
         isAuthorized: false,
         statusCode: 401,


### PR DESCRIPTION
## Issue

Closes #2452.

## Summary

Argon2 verification previously accepted the cost parameters embedded in a client-supplied token hash. An unauthenticated request could therefore choose expensive memory and iteration values before verification.

This change rejects Argon2id hashes whose parameter block differs from the fixed client parameters (`m=512,t=16,p=1`) before calling `argon2Verify`. Non-Argon2 or malformed tokens continue through the existing invalid-token path.

## Testing

- `git diff --check` — passed.
- `npm test -- server/verifyTokenAndRateLimit.test.ts` — not run successfully: npm dependencies could not be installed in the host environment due to an `ENOTEMPTY` error from a stale `node_modules` directory, and Docker image setup was blocked by a registry download timeout.
- `npm run lint` — not run for the same dependency/environment limitation.

The regression test asserts that a mismatched parameter block returns the existing 401 response without invoking `argon2Verify`.