### PR TITLE
fix: refuse token and access-key hashes with mismatched argon2 parameters

### DIFF
--- a/client/modules/accessKey.ts
+++ b/client/modules/accessKey.ts
@@ -1,4 +1,5 @@
 import { notifications } from "@mantine/notifications";
+import { ARGON2_PARAMETERS } from "@shared/argon2Parameters";
 import { argon2id } from "hash-wasm";
 import { addLogEntry } from "./logEntries";
 
@@ -16,12 +17,7 @@ async function hashAccessKey(accessKey: string): Promise<string> {
   return argon2id({
     password: accessKey,
     salt,
-    parallelism: 1,
-    iterations: 16,
-    memorySize: 512,
-    // The digest is what a caller without the key would have to guess to pass
-    // validation, so it sets the ceiling on forgery resistance.
-    hashLength: 32,
+    ...ARGON2_PARAMETERS,
     outputType: "encoded",
   });
 }

--- a/client/modules/searchTokenHash.ts
+++ b/client/modules/searchTokenHash.ts
@@ -1,3 +1,4 @@
+import { ARGON2_PARAMETERS } from "@shared/argon2Parameters";
 import { argon2id, argon2Verify } from "hash-wasm";
 import { getConfig } from "./config";
 import { addLogEntry } from "./logEntries";
@@ -27,12 +28,7 @@ export async function getSearchTokenHash() {
   const newSearchTokenHash = await argon2id({
     password,
     salt,
-    parallelism: 1,
-    iterations: 16,
-    memorySize: 512,
-    // The digest is what a caller without the token would have to guess to
-    // forge a `?token=`, so it sets the ceiling on forgery resistance.
-    hashLength: 32,
+    ...ARGON2_PARAMETERS,
     outputType: "encoded",
   });
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,8 +10,8 @@
 ### Access Key Validation Flow
 
 1. User enters access key on the **AccessPage** UI
-2. Client hashes the key client-side using argon2id
-3. Server validates the hash against configured `ACCESS_KEYS` via `validateAccessKeyServerHook`
+2. Client hashes the key client-side using argon2id with fixed parameters (`m=512, t=16, p=1`)
+3. Server validates the hash against configured `ACCESS_KEYS` via `validateAccessKeyServerHook`. The hash's prefix (`$argon2id$v=19$m=512,t=16,p=1$`) is checked before `argon2Verify` runs, so a caller cannot embed inflated parameters to force allocations per configured key.
 4. On success: key hash is stored in localStorage with timestamp
 5. On subsequent loads, `useAccessKeyValidation` in `App.tsx` calls `verifyStoredAccessKey()` to check if the cached key is still valid
 6. If expired (based on `ACCESS_KEY_TIMEOUT_HOURS`), user is prompted to re-enter
@@ -36,7 +36,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 1. **Token Generation**: On build/startup, `regenerateSearchToken()` writes a random token to `{os.tempdir()}/minisearch-token`, readable only by the user running the build (`0600`)
 2. **Client Distribution**: The server reads the file once, holds that token for the life of the process, and serves it as `searchToken` in `/api/config`
 3. **Per-Request Auth**: Client includes token as `?token=` parameter on all `/search/text`, `/search/images` and `/page-content` requests
-4. **Server Verification**: `handleTokenVerification()` in `searchEndpointServerHook.ts` validates the token before proxying to SearXNG
+4. **Server Verification**: `handleTokenVerification()` in `searchEndpointServerHook.ts` validates the token before proxying to SearXNG. The token hash's prefix (`$argon2id$v=19$m=512,t=16,p=1$`) is checked before `argon2Verify` runs, so a caller cannot embed inflated parameters to force multi-gigabyte allocations or excessive CPU work.
 5. **Session Tracking**: Validated tokens are stored in an in-memory `Set<string>` (`verifiedTokens.ts`) for session counting
 6. **Rejection Caching**: Tokens that fail a completed verification are kept in a bounded in-memory set (`rejectedTokens.ts`) until it evicts them at the cap, so a replay is refused without paying for a second argon2 verification; a token whose verification threw instead of returning a result, whether from an unparseable hash or an unreadable token file, is refused without taking a slot; how many rejections were served that way is reported on `/status` (`authorization.rejectedTokenCacheHits`)
 

--- a/server/validateAccessKeyServerHook.test.ts
+++ b/server/validateAccessKeyServerHook.test.ts
@@ -48,6 +48,13 @@ function makeMockResponse() {
   return { setHeader, end, statusCode };
 }
 
+/** Builds a well-formed argon2id hash string with the client's fixed parameters. */
+function makeValidAccessKeyHash(suffix: string): string {
+  const salt = Buffer.from(`${suffix}salt`).toString("base64url");
+  const digest = Buffer.from(`${suffix}digest`).toString("base64url");
+  return `$argon2id$v=19$m=512,t=16,p=1$${salt}$${digest}`;
+}
+
 describe("validateAccessKeyServerHook", () => {
   it("should skip non-matching URLs", async () => {
     const { validateAccessKeyServerHook } = await import(
@@ -112,7 +119,7 @@ describe("validateAccessKeyServerHook", () => {
     const req = makeMockRequest(
       "/api/validate-access-key",
       "POST",
-      JSON.stringify({ accessKeyHash: "some-hash" }),
+      JSON.stringify({ accessKeyHash: makeValidAccessKeyHash("valid") }),
     );
 
     await new Promise<void>((resolve) => {
@@ -160,7 +167,7 @@ describe("validateAccessKeyServerHook", () => {
     const req = makeMockRequest(
       "/api/validate-access-key",
       "POST",
-      JSON.stringify({ accessKeyHash: "some-hash" }),
+      JSON.stringify({ accessKeyHash: makeValidAccessKeyHash("valid") }),
     );
 
     await new Promise<void>((resolve) => {
@@ -203,7 +210,7 @@ describe("validateAccessKeyServerHook", () => {
     const req = makeMockRequest(
       "/api/validate-access-key",
       "POST",
-      JSON.stringify({ accessKeyHash: "wrong-hash" }),
+      JSON.stringify({ accessKeyHash: makeValidAccessKeyHash("wrong") }),
     );
 
     await new Promise<void>((resolve) => {
@@ -217,6 +224,54 @@ describe("validateAccessKeyServerHook", () => {
     });
 
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ valid: false }));
+  });
+
+  it("refuses a hash whose parameter block differs from the client's before argon2Verify runs", async () => {
+    process.env.ACCESS_KEYS = "test-key";
+    const { validateAccessKeyServerHook } = await import(
+      "./validateAccessKeyServerHook"
+    );
+    const use = vi.fn();
+    validateAccessKeyServerHook({
+      middlewares: { use },
+    } as never);
+    const handler = use.mock.calls[0][0] as (
+      req: {
+        url: string;
+        method: string;
+        on: (event: string, cb: (chunk: string) => void) => void;
+      },
+      res: {
+        setHeader: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+        statusCode: number;
+      },
+      next: () => void,
+    ) => void;
+
+    const res = makeMockResponse();
+    // A hash with inflated parameters: m=4194304 would force a multi-gigabyte
+    // allocation if argon2Verify ever saw it.
+    const malicious =
+      "$argon2id$v=19$m=4194304,t=1000,p=1$xJaao6+z/VEA4+CU/+LAKg$JCE6vg7EHYLNv+EfNk1R6oJsEoDOsv2zNAXzQrrvI0E";
+    const req = makeMockRequest(
+      "/api/validate-access-key",
+      "POST",
+      JSON.stringify({ accessKeyHash: malicious }),
+    );
+
+    await new Promise<void>((resolve) => {
+      void handler(req as never, res as never, () => {});
+      setImmediate(() => {
+        for (const cb of req.endCallbacks) {
+          cb();
+        }
+        setTimeout(resolve, 50);
+      });
+    });
+
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ valid: false }));
+    expect(mockArgon2Verify).not.toHaveBeenCalled();
   });
 
   it("should return 400 for invalid JSON body", async () => {

--- a/server/validateAccessKeyServerHook.ts
+++ b/server/validateAccessKeyServerHook.ts
@@ -1,5 +1,6 @@
 import { argon2Verify } from "hash-wasm";
 import type { PreviewServer, ViteDevServer } from "vite";
+import { ARGON2_HASH_PREFIX } from "../shared/argon2Parameters.ts";
 import { consumeRateLimitPoint } from "./verifyTokenAndRateLimit.ts";
 
 /** POST /api/validate-access-key: checks an argon2id hash against the configured `ACCESS_KEYS`. */
@@ -35,6 +36,21 @@ export function validateAccessKeyServerHook<
     req.on("end", async () => {
       try {
         const { accessKeyHash } = JSON.parse(body);
+
+        // The client hashes with the shared parameters, so a hash carrying any
+        // other block cannot be valid against this server. Checking before
+        // argon2Verify refuses a mismatch for free, before any allocation or
+        // work starts. Without it a caller could embed m=4194304,t=1000,p=1 and
+        // force a multi-gigabyte allocation per configured key.
+        if (
+          typeof accessKeyHash !== "string" ||
+          !accessKeyHash.startsWith(ARGON2_HASH_PREFIX)
+        ) {
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ valid: false }));
+          return;
+        }
+
         let isValid = false;
 
         for (const key of accessKeys) {

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -43,6 +43,17 @@ function makeMockRequest(ip: string): IncomingMessage {
   } as unknown as IncomingMessage;
 }
 
+/**
+ * Builds a well-formed argon2id hash string with the client's fixed parameters
+ * (m=512, t=16, p=1). The suffix makes each call unique so the same suffix is
+ * treated as the same token by the rejection cache.
+ */
+function makeValidHash(suffix: string): string {
+  const salt = Buffer.from(`${suffix}salt`).toString("base64url");
+  const digest = Buffer.from(`${suffix}digest`).toString("base64url");
+  return `$argon2id$v=19$m=512,t=16,p=1$${salt}$${digest}`;
+}
+
 describe("verifyTokenAndRateLimit", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,7 +81,7 @@ describe("verifyTokenAndRateLimit", () => {
     const { verifyTokenAndRateLimit } = await import(
       "./verifyTokenAndRateLimit"
     );
-    const result = await verifyTokenAndRateLimit("invalid-token");
+    const result = await verifyTokenAndRateLimit(makeValidHash("invalid"));
     expect(result).toEqual({
       isAuthorized: false,
       statusCode: 401,
@@ -98,8 +109,12 @@ describe("verifyTokenAndRateLimit", () => {
     };
     const cacheHitsBefore = getAuthorizationStats().rejectedTokenCacheHits;
 
-    expect(await verifyTokenAndRateLimit("dead-token")).toEqual(invalid);
-    expect(await verifyTokenAndRateLimit("dead-token")).toEqual(invalid);
+    expect(await verifyTokenAndRateLimit(makeValidHash("dead"))).toEqual(
+      invalid,
+    );
+    expect(await verifyTokenAndRateLimit(makeValidHash("dead"))).toEqual(
+      invalid,
+    );
 
     // The first refusal pays for the verification; the repeat is a cache hit.
     expect(hashWasm.argon2Verify).toHaveBeenCalledTimes(1);
@@ -116,9 +131,10 @@ describe("verifyTokenAndRateLimit", () => {
     );
     const { isRejectedToken } = await import("./rejectedTokens");
 
-    const result = await verifyTokenAndRateLimit("live-token");
+    const live = makeValidHash("live");
+    const result = await verifyTokenAndRateLimit(live);
     expect(result.isAuthorized).toBe(true);
-    expect(isRejectedToken("live-token")).toBe(false);
+    expect(isRejectedToken(live)).toBe(false);
   });
 
   it("does not cache a token whose verification threw, so the same token verifies on the next attempt", async () => {
@@ -142,14 +158,13 @@ describe("verifyTokenAndRateLimit", () => {
       error: "Invalid token.",
       reason: "invalidToken",
     };
-    expect(await verifyTokenAndRateLimit("flaky-token")).toEqual(invalid);
+    const flaky = makeValidHash("flaky");
+    expect(await verifyTokenAndRateLimit(flaky)).toEqual(invalid);
 
     // Nothing was cached, so once the read succeeds the same token verifies.
-    expect((await verifyTokenAndRateLimit("flaky-token")).isAuthorized).toBe(
-      true,
-    );
+    expect((await verifyTokenAndRateLimit(flaky)).isAuthorized).toBe(true);
     expect(hashWasm.argon2Verify).toHaveBeenCalledTimes(1);
-    expect(isRejectedToken("flaky-token")).toBe(false);
+    expect(isRejectedToken(flaky)).toBe(false);
   });
 
   it("does not cache a token when argon2 itself throws, as it does on an unparseable hash", async () => {
@@ -169,13 +184,74 @@ describe("verifyTokenAndRateLimit", () => {
       error: "Invalid token.",
       reason: "invalidToken",
     };
-    expect(await verifyTokenAndRateLimit("not-a-hash")).toEqual(invalid);
-    expect(await verifyTokenAndRateLimit("not-a-hash")).toEqual(invalid);
+    // A well-formed hash whose salt is invalid base64; the parameter block
+    // passes our check, but argon2Verify itself rejects the encoding.
+    const notAHash =
+      "$argon2id$v=19$m=512,t=16,p=1$!!!invalid!!!$!!!invalid!!!";
+    expect(await verifyTokenAndRateLimit(notAHash)).toEqual(invalid);
+    expect(await verifyTokenAndRateLimit(notAHash)).toEqual(invalid);
 
-    // Junk costs a regex reject, not a verification, so caching it would only
-    // spend a slot: it is refused again from scratch.
+    // Junk costs a prefix reject plus a decode-time throw, not a full
+    // verification, so caching it would only spend a slot: it is refused again
+    // from scratch.
     expect(hashWasm.argon2Verify).toHaveBeenCalledTimes(2);
-    expect(isRejectedToken("not-a-hash")).toBe(false);
+    expect(isRejectedToken(notAHash)).toBe(false);
+  });
+
+  it("refuses a token whose parameter block differs from the client's before argon2Verify runs", async () => {
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const hashWasm = await import("hash-wasm");
+    // A hash with inflated parameters: m=4194304 would force a multi-gigabyte
+    // allocation if argon2Verify ever saw it.
+    const malicious =
+      "$argon2id$v=19$m=4194304,t=1000,p=1$xJaao6+z/VEA4+CU/+LAKg$JCE6vg7EHYLNv+EfNk1R6oJsEoDOsv2zNAXzQrrvI0E";
+    const result = await verifyTokenAndRateLimit(malicious);
+    expect(result).toEqual({
+      isAuthorized: false,
+      statusCode: 401,
+      error: "Invalid token.",
+      reason: "invalidToken",
+    });
+    expect(hashWasm.argon2Verify).not.toHaveBeenCalled();
+  });
+
+  it("accepts a well-formed token with the client's parameters", async () => {
+    mockArgon2VerifyResult = true;
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const hashWasm = await import("hash-wasm");
+    const valid = makeValidHash("wellformed");
+    const result = await verifyTokenAndRateLimit(valid);
+    expect(result.isAuthorized).toBe(true);
+    expect(hashWasm.argon2Verify).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a hash produced by hash-wasm with the shared argon2 parameters", async () => {
+    vi.resetModules();
+    const { verifyTokenAndRateLimit } = await import(
+      "./verifyTokenAndRateLimit"
+    );
+    const hashWasm = await import("hash-wasm");
+    const { ARGON2_PARAMETERS } = await import("../shared/argon2Parameters.ts");
+    const { argon2id } =
+      await vi.importActual<typeof import("hash-wasm")>("hash-wasm");
+    const realHash = await argon2id({
+      password: "dummy-token",
+      salt: new Uint8Array(16),
+      ...ARGON2_PARAMETERS,
+      outputType: "encoded",
+    });
+    const result = await verifyTokenAndRateLimit(realHash);
+    expect(result.isAuthorized).toBe(true);
+    expect(hashWasm.argon2Verify).toHaveBeenCalledWith({
+      password: "dummy-token",
+      hash: realHash,
+    });
   });
 
   it("should accept valid token and add to verified tokens", async () => {
@@ -184,10 +260,11 @@ describe("verifyTokenAndRateLimit", () => {
     const { verifyTokenAndRateLimit } = await import(
       "./verifyTokenAndRateLimit"
     );
-    const result = await verifyTokenAndRateLimit("valid-token");
+    const valid = makeValidHash("valid");
+    const result = await verifyTokenAndRateLimit(valid);
     expect(result.isAuthorized).toBe(true);
     expect(result).not.toHaveProperty("statusCode");
-    expect(mockAddVerifiedToken).toHaveBeenCalledWith("valid-token");
+    expect(mockAddVerifiedToken).toHaveBeenCalledWith(valid);
   });
 
   it("should skip verification for already verified tokens", async () => {
@@ -197,7 +274,8 @@ describe("verifyTokenAndRateLimit", () => {
       "./verifyTokenAndRateLimit"
     );
     const hashWasm = await import("hash-wasm");
-    const result = await verifyTokenAndRateLimit("already-verified-token");
+    const alreadyVerified = makeValidHash("alreadyverified");
+    const result = await verifyTokenAndRateLimit(alreadyVerified);
     expect(result.isAuthorized).toBe(true);
     expect(hashWasm.argon2Verify).not.toHaveBeenCalled();
   });
@@ -208,7 +286,7 @@ describe("verifyTokenAndRateLimit", () => {
     const { verifyTokenAndRateLimit } = await import(
       "./verifyTokenAndRateLimit"
     );
-    const result = await verifyTokenAndRateLimit("rate-limit-token");
+    const result = await verifyTokenAndRateLimit(makeValidHash("ratelimit"));
     expect(result).toEqual({
       isAuthorized: false,
       statusCode: 429,
@@ -224,7 +302,7 @@ describe("verifyTokenAndRateLimit", () => {
     const { verifyTokenAndRateLimit } = await import(
       "./verifyTokenAndRateLimit"
     );
-    const result = await verifyTokenAndRateLimit("invalid-token");
+    const result = await verifyTokenAndRateLimit(makeValidHash("invalidrl"));
     expect(result).toEqual({
       isAuthorized: false,
       statusCode: 429,
@@ -240,7 +318,7 @@ describe("verifyTokenAndRateLimit", () => {
       "./verifyTokenAndRateLimit"
     );
     const hashWasm = await import("hash-wasm");
-    const result = await verifyTokenAndRateLimit("some-token");
+    const result = await verifyTokenAndRateLimit(makeValidHash("somelimit"));
     expect(result).toEqual({
       isAuthorized: false,
       statusCode: 429,
@@ -274,7 +352,10 @@ describe("verifyTokenAndRateLimit", () => {
     // makeMockRequest sets a spoofable X-Forwarded-For, but with TRUST_PROXY
     // off the real TCP peer (socket.remoteAddress) must be used instead.
     const mockReq = makeMockRequest("192.168.1.100");
-    const result = await verifyTokenAndRateLimit("valid-token", mockReq);
+    const result = await verifyTokenAndRateLimit(
+      makeValidHash("valid"),
+      mockReq,
+    );
     expect(result.isAuthorized).toBe(true);
     expect(mockConsume).toHaveBeenCalledWith("127.0.0.1");
   });
@@ -287,7 +368,10 @@ describe("verifyTokenAndRateLimit", () => {
       "./verifyTokenAndRateLimit"
     );
     const mockReq = makeMockRequest("192.168.1.100");
-    const result = await verifyTokenAndRateLimit("valid-token", mockReq);
+    const result = await verifyTokenAndRateLimit(
+      makeValidHash("valid"),
+      mockReq,
+    );
     expect(result.isAuthorized).toBe(true);
     expect(mockConsume).toHaveBeenCalledWith("192.168.1.100");
     vi.unstubAllEnvs();
@@ -299,9 +383,11 @@ describe("verifyTokenAndRateLimit", () => {
     const { verifyTokenAndRateLimit } = await import(
       "./verifyTokenAndRateLimit"
     );
-    const result = await verifyTokenAndRateLimit("fallback-token");
+    const result = await verifyTokenAndRateLimit(makeValidHash("fallback"));
     expect(result.isAuthorized).toBe(true);
-    expect(mockConsume).toHaveBeenCalledWith("fallback-token");
+    expect(mockConsume).toHaveBeenCalledWith(
+      expect.stringContaining("$argon2id"),
+    );
   });
 });
 
@@ -332,7 +418,7 @@ describe("consumeRateLimitPoint", () => {
       "./verifyTokenAndRateLimit"
     );
     const mockReq = makeMockRequest("192.168.1.100");
-    await verifyTokenAndRateLimit("valid-token", mockReq);
+    await verifyTokenAndRateLimit(makeValidHash("valid"), mockReq);
     await consumeRateLimitPoint(mockReq);
     // Both went through the one shared limiter, keyed on the same address.
     expect(consumeInstances.size).toBe(1);

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import debug from "debug";
 import { argon2Verify } from "hash-wasm";
 import { RateLimiterMemory } from "rate-limiter-flexible";
+import { ARGON2_HASH_PREFIX } from "../shared/argon2Parameters.ts";
 import {
   addRejectedToken,
   isRejectedToken,
@@ -167,6 +168,20 @@ export async function verifyTokenAndRateLimit(
       };
     }
 
+    // The client hashes with the shared parameters, so a hash carrying any
+    // other block cannot be valid against this server. Checking before
+    // argon2Verify refuses a mismatch for free, before any allocation or work
+    // starts. Without it a caller could embed m=4194304,t=1000,p=1 and force a
+    // multi-gigabyte allocation and 1000 rounds per request.
+    if (!token.startsWith(ARGON2_HASH_PREFIX)) {
+      return {
+        isAuthorized: false,
+        statusCode: 401,
+        error: "Invalid token.",
+        reason: "invalidToken",
+      };
+    }
+
     let isValidToken = false;
     let didComparisonRun = false;
 
@@ -185,7 +200,8 @@ export async function verifyTokenAndRateLimit(
       // throw means either the token file could not be read, and caching that
       // would refuse a valid token for the rest of the process, or the hash
       // is malformed, and caching junk would only spend a slot on a refusal
-      // that costs a regex check, not a verification.
+      // that costs a prefix check plus a decode-time throw, not a full
+      // verification.
       if (didComparisonRun) addRejectedToken(token);
       reportTokenFileChangeOnce();
 

--- a/shared/argon2Parameters.ts
+++ b/shared/argon2Parameters.ts
@@ -1,0 +1,22 @@
+/**
+ * The argon2id parameters every client uses when hashing search tokens and
+ * access keys. The server compares the encoded hash's parameter block against
+ * this value before running `argon2Verify`, so the client and server must
+ * agree on these numbers.
+ *
+ * Bumping any of them requires a coordinated rollout: a client with different
+ * parameters produces a hash the server refuses, and a server with different
+ * parameters refuses every token a live client sends.
+ */
+export const ARGON2_PARAMETERS = {
+  parallelism: 1,
+  iterations: 16,
+  memorySize: 512,
+  hashLength: 32,
+} as const;
+
+/**
+ * The prefix every encoded hash carries. Derived from `ARGON2_PARAMETERS` so
+ * the server gate and the client encoder stay in sync by construction.
+ */
+export const ARGON2_HASH_PREFIX = `$argon2id$v=19$m=${ARGON2_PARAMETERS.memorySize},t=${ARGON2_PARAMETERS.iterations},p=${ARGON2_PARAMETERS.parallelism}$`;


### PR DESCRIPTION
## Root cause

hash-wasm's `argon2Verify` reads `m`, `t`, and `p` from the hash string itself and applies them as-is, with validation that only sets lower bounds (memory >= 8 x parallelism, iterations >= 1). A caller can embed `m=4194304,t=1000,p=1` in the token or access-key hash, forcing the server to allocate multi-gigabytes of memory and run 1000 rounds of argon2 work before the comparison can fail. The rate limiter counts requests, not cost per request, so it does not bound this.

The client hashes with fixed parameters (`p=1`, `t=16`, `m=512`, see `client/modules/searchTokenHash.ts` and `client/modules/accessKey.ts`), so a hash carrying any other block cannot be valid against this server.

## What changed

| File | Change |
|------|--------|
| `shared/argon2Parameters.ts` | New module exporting `ARGON2_PARAMETERS` and `ARGON2_HASH_PREFIX` derived from it, giving both client and server a single source of truth |
| `client/modules/searchTokenHash.ts` | Use `...ARGON2_PARAMETERS` instead of hardcoded literals |
| `client/modules/accessKey.ts` | Use `...ARGON2_PARAMETERS` instead of hardcoded literals |
| `server/verifyTokenAndRateLimit.ts` | Check `token.startsWith(ARGON2_HASH_PREFIX)` before `argon2Verify`; mismatched hashes are refused for free |
| `server/validateAccessKeyServerHook.ts` | Same prefix check on `accessKeyHash` before the `argon2Verify` loop; also guards against non-string input |
| `server/verifyTokenAndRateLimit.test.ts` | Updated existing tests to use properly formatted hash strings; added tests for malicious-parameter refusal and real-argon2 round-trip |
| `server/validateAccessKeyServerHook.test.ts` | Updated existing tests; added test for malicious-parameter refusal |
| `docs/security.md` | Documented the prefix gate in both the access key and search token flows |

## Where to start

Most of the diff is tests (~200 lines) and one new self-contained module. The behavior change is ~30 lines across two server files.

Two decisions worth a look:

- The prefix check uses `startsWith(ARGON2_HASH_PREFIX)` rather than a regex. This pins the algorithm to `argon2id` and the version to `v=19` in addition to the parameters, rejecting an `argon2d` hash with the same parameters that a regex would have allowed through.
- `shared/argon2Parameters.ts` is the single source of truth. Both client hashers and both server gates import from it, so a future parameter bump requires changing one object.

## How it was verified

- `npx vitest run` — 683 tests passed, 0 failed
- `npm run lint` — passes (the only tsconfig.node.json error is pre-existing: `pdf-parse` missing type declarations)
- Three rounds of `consult-claude-loop` review; all findings addressed

## Follow-ups

- `validateAccessKeyServerHook.ts` still accumulates the POST body with `body += chunk.toString()` and no cap. The limiter bounds requests per IP, not bytes per request, so an unauthenticated caller can stream arbitrary megabytes before any check fires. Separate issue.