### PR TITLE
Retry the next model when an OpenAI stream reports an error

### DIFF
--- a/client/modules/textGenerationWithOpenAi.test.ts
+++ b/client/modules/textGenerationWithOpenAi.test.ts
@@ -52,8 +52,16 @@ vi.mock("@shared/openaiModels", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-function sseResponse(lines: unknown[]) {
-  const body = `${lines.map((line) => `data: ${JSON.stringify(line)}\n\n`).join("")}data: [DONE]\n\n`;
+/**
+ * A stream without a `finish_reason` counts as truncated, and the provider
+ * turns that into an error part, so the closing chunk is part of a well-formed
+ * response and only the truncation test leaves it out.
+ */
+function sseResponse(lines: unknown[], { truncated = false } = {}) {
+  const chunks = truncated
+    ? lines
+    : [...lines, { choices: [{ delta: {}, finish_reason: "stop" }] }];
+  const body = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`;
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -189,6 +197,48 @@ describe("textGenerationWithOpenAi", () => {
       expect(addLogEntry).toHaveBeenCalledWith(
         expect.stringContaining('retrying with "model-b"'),
       );
+    });
+
+    it("keeps the content already streamed when the stream is truncated", async () => {
+      const { generateChatWithOpenAi } = await import(
+        "./textGenerationWithOpenAi"
+      );
+
+      mockFetch.mockResolvedValueOnce(
+        sseResponse([{ choices: [{ delta: { content: "partial" } }] }], {
+          truncated: true,
+        }),
+      );
+
+      const result = await generateChatWithOpenAi(
+        [{ role: "user", content: "Hi" }],
+        vi.fn(),
+      );
+
+      expect(result).toBe("partial");
+      expect(addLogEntry).toHaveBeenCalledWith(
+        expect.stringContaining("keeping what arrived"),
+      );
+    });
+
+    it("gives up once no untried model is left", async () => {
+      mockSettings({ openAiApiModel: "" });
+      vi.mocked(listOpenAiCompatibleModels).mockResolvedValue([
+        { id: "model-a" },
+      ]);
+      vi.mocked(selectRandomModel).mockReturnValueOnce("model-a");
+
+      mockFetch.mockResolvedValue(
+        sseResponse([{ error: { message: "model overloaded" } }]),
+      );
+
+      const { generateChatWithOpenAi } = await import(
+        "./textGenerationWithOpenAi"
+      );
+
+      await expect(
+        generateChatWithOpenAi([{ role: "user", content: "Hi" }], vi.fn()),
+      ).rejects.toThrow();
     });
   });
 });

--- a/client/modules/textGenerationWithOpenAi.ts
+++ b/client/modules/textGenerationWithOpenAi.ts
@@ -22,6 +22,10 @@ import type { ChatMessage } from "@/modules/types";
 
 let currentAbortController: AbortController | null = null;
 
+function describeError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 interface StreamOptions {
   messages: ChatMessage[];
   onUpdate: (text: string, reasoningContent?: string) => void;
@@ -81,7 +85,6 @@ async function createOpenAiStream({
     currentAttempt++;
 
     currentAbortController = new AbortController();
-    let shouldRetry = false;
 
     try {
       const result = streamText({
@@ -92,36 +95,12 @@ async function createOpenAiStream({
         topP: params.top_p,
         abortSignal: currentAbortController.signal,
         maxRetries: 0,
-        onError: async (error: unknown) => {
-          if (
-            getTextGenerationState() === "interrupted" ||
-            (error instanceof DOMException && error.name === "AbortError")
-          ) {
-            throw new Error("Chat generation interrupted");
-          }
-
-          if (availableModels.length > 0 && currentAttempt < maxRetries) {
-            const nextModel = selectRandomModel(
-              availableModels,
-              attemptedModels,
-            );
-            if (nextModel) {
-              addLogEntry(
-                `Model "${effectiveModel}" failed, retrying with "${nextModel}" (Attempt ${currentAttempt}/${maxRetries})`,
-              );
-              effectiveModel = nextModel;
-              shouldRetry = true;
-              await sleep(100 * currentAttempt);
-              throw error;
-            }
-          }
-
-          throw error;
-        },
       });
 
       let text = "";
       let reasoning = "";
+      let streamError: unknown;
+
       for await (const part of result.stream) {
         if (getTextGenerationState() === "interrupted") {
           currentAbortController.abort();
@@ -134,6 +113,33 @@ async function createOpenAiStream({
         } else if (part.type === "text-delta") {
           text += part.text;
           onUpdate(text, reasoning);
+        } else if (part.type === "error") {
+          streamError = part.error;
+        }
+      }
+
+      // A failing stream reports the problem as a part instead of rejecting,
+      // and the SDK swallows whatever `onError` throws, so the retry decision
+      // belongs here, once the stream is drained.
+      if (streamError !== undefined) {
+        if (text.length > 0 || reasoning.length > 0) {
+          addLogEntry(
+            `Model "${effectiveModel}" errored after streaming some content, keeping what arrived: ${describeError(streamError)}`,
+          );
+        } else {
+          const nextModel =
+            availableModels.length > 0 && currentAttempt < maxRetries
+              ? selectRandomModel(availableModels, attemptedModels)
+              : undefined;
+
+          if (!nextModel) throw streamError;
+
+          addLogEntry(
+            `Model "${effectiveModel}" failed, retrying with "${nextModel}" (Attempt ${currentAttempt}/${maxRetries})`,
+          );
+          effectiveModel = nextModel;
+          await sleep(100 * currentAttempt);
+          return tryNextModel();
         }
       }
 
@@ -144,10 +150,6 @@ async function createOpenAiStream({
         (error instanceof DOMException && error.name === "AbortError")
       ) {
         throw new Error("Chat generation interrupted");
-      }
-
-      if (shouldRetry) {
-        return tryNextModel();
       }
 
       throw error;


### PR DESCRIPTION
## Description

Currently, when an OpenAI-compatible endpoint reports an error mid-stream, the answer comes back empty and no retry happens, even though the log says `Model "x" failed, retrying with "y"`.

The retry worked by throwing from the `streamText` `onError` callback, so the exception would break out of the stream loop and the `catch` could call the next model. The `ai` bump to 7.0.71 (#2462) landed this change: "Prevent exceptions in streaming `onChunk` and `onError` callbacks from terminating the stream or masking provider errors." The throw is now swallowed, the loop finishes with no content, and `{ text: "" }` is returned as a success.

This PR collects stream errors as parts while draining the stream and makes the retry decision afterwards, so it no longer depends on an exception escaping a callback. A stream that errors after already sending content now keeps what arrived instead of throwing it away.

Two things that come along with the rewrite:

- The abort check in the `catch` was reading `error instanceof DOMException` against the SDK's `{ error }` wrapper, so it was always false. It gets the real error now.
- `sseResponse` in the tests appends a `finish_reason` chunk, because `@ai-sdk/openai-compatible` 3.0.33 (#2461) reports a stream without one as truncated. Pass `{ truncated: true }` to leave it out.

This is what has been failing CI on `main` since 4e8e86a.

## How to test

1. Run `npx vitest run client/modules/textGenerationWithOpenAi.test.ts` (7 passing, 3 of which fail on `main`).
2. Check out `main` for `client/modules/textGenerationWithOpenAi.ts` and run it again to see the 3 failures.
3. Run the full suite with `npm run test` (58 files, 685 tests).

Note: the retry path itself was verified against mocked endpoints only. I did not point it at a real OpenAI-compatible server with a flaky model.
