### PR TITLE
feat: keep the reranker relevance score and tag results in the prompt

### DIFF
--- a/client/modules/textGenerationUtilities.test.ts
+++ b/client/modules/textGenerationUtilities.test.ts
@@ -175,12 +175,13 @@ describe("getFormattedSearchResults", () => {
   });
 
   it("adds no tag or relevance note when the results carry no score", () => {
-    // History-restored and eval results have no score; the prompt must stay
-    // exactly what it was before the score existed.
+    // History-restored and eval results have no score; their prompt must stay
+    // exactly what it was before the score existed, disclaimer aside.
     const formatted = getFormattedSearchResults(true);
 
     expect(formatted).toBe(
-      "• [First](https://a.example/) | first snippet\n" +
+      `${disclaimer}\n\n` +
+        "• [First](https://a.example/) | first snippet\n" +
         "• [Second](https://b.example/) | second snippet",
     );
     expect(formatted).not.toContain("relevance:");

--- a/client/modules/textGenerationUtilities.test.ts
+++ b/client/modules/textGenerationUtilities.test.ts
@@ -154,6 +154,71 @@ describe("getFormattedSearchResults", () => {
     // not, so an untrimmed excerpt is what pins that the setting was read.
     expect(getFormattedSearchResults(true)).not.toContain("…");
   });
+
+  it("tags each result with its relative relevance when scores are present", () => {
+    state.searchResults = [
+      ["First", "first snippet", "https://a.example/", 5.0],
+      ["Second", "second snippet", "https://b.example/", 1.0],
+    ];
+
+    const formatted = getFormattedSearchResults(true);
+
+    expect(formatted).toContain(
+      "• [First](https://a.example/) | first snippet (relevance: high)",
+    );
+    expect(formatted).toContain(
+      "• [Second](https://b.example/) | second snippet (relevance: low)",
+    );
+    expect(formatted).toContain(
+      "Each result is tagged with how well it matched the query relative to the others in this batch",
+    );
+  });
+
+  it("adds no tag or relevance note when the results carry no score", () => {
+    // History-restored and eval results have no score; the prompt must stay
+    // exactly what it was before the score existed.
+    const formatted = getFormattedSearchResults(true);
+
+    expect(formatted).toBe(
+      "• [First](https://a.example/) | first snippet\n" +
+        "• [Second](https://b.example/) | second snippet",
+    );
+    expect(formatted).not.toContain("relevance:");
+    expect(formatted).not.toContain("tagged with how well it matched");
+  });
+
+  it("tags every result medium when all scores are equal", () => {
+    state.searchResults = [
+      ["First", "first snippet", "https://a.example/", 3.0],
+      ["Second", "second snippet", "https://b.example/", 3.0],
+    ];
+
+    const formatted = getFormattedSearchResults(true);
+
+    expect(formatted).toContain("(relevance: medium)");
+    expect(formatted).not.toContain("(relevance: high)");
+    expect(formatted).not.toContain("(relevance: low)");
+  });
+
+  it("spreads high, medium and low across a batch with a clear spread", () => {
+    state.searchResults = [
+      ["A", "a", "https://a.example/", 10.0],
+      ["B", "b", "https://b.example/", 9.0],
+      ["C", "c", "https://c.example/", 8.0],
+    ];
+
+    const formatted = getFormattedSearchResults(true);
+
+    expect(formatted).toContain(
+      "• [A](https://a.example/) | a (relevance: high)",
+    );
+    expect(formatted).toContain(
+      "• [B](https://b.example/) | b (relevance: medium)",
+    );
+    expect(formatted).toContain(
+      "• [C](https://c.example/) | c (relevance: low)",
+    );
+  });
 });
 
 describe("allocatePageExcerpts", () => {

--- a/client/modules/textGenerationUtilities.ts
+++ b/client/modules/textGenerationUtilities.ts
@@ -8,7 +8,7 @@ import {
   updateTextGenerationState,
 } from "./pubSub";
 import { getSystemPrompt } from "./systemPrompt";
-import type { ChatMessage } from "./types";
+import type { ChatMessage, TextSearchResult } from "./types";
 
 export const defaultContextSize = 4096;
 
@@ -105,8 +105,46 @@ function formatExcerpt(excerpt: string) {
 }
 
 /**
+ * Explains the per-result relevance tags. The tags are relative to the batch,
+ * not absolute: the reranker's raw score range depends on the model, so only
+ * a result's position within the batch is a stable signal for the model.
+ */
+const relevanceDisclaimer =
+  "Each result is tagged with how well it matched the query relative to the others in this batch: high, medium, or low. Weigh the low ones less, and treat a batch of low results as a sign the results may not cover the question.";
+
+// Z-score cutoffs against the batch's own mean and standard deviation, the
+// same statistics the server's score filter is calibrated on.
+const RELEVANCE_HIGH_Z = 0.5;
+const RELEVANCE_LOW_Z = -0.5;
+
+function getRelevanceTags(
+  searchResults: TextSearchResult[],
+): (string | undefined)[] {
+  const scores = searchResults
+    .map(([, , , score]) => score)
+    .filter((score): score is number => score !== undefined);
+
+  if (scores.length === 0) return searchResults.map(() => undefined);
+
+  const mean = scores.reduce((sum, score) => sum + score, 0) / scores.length;
+  const standardDeviation = Math.sqrt(
+    scores.reduce((sum, score) => sum + (score - mean) ** 2, 0) / scores.length,
+  );
+
+  return searchResults.map(([, , , score]) => {
+    if (score === undefined) return undefined;
+    if (standardDeviation === 0) return "medium";
+    const z = (score - mean) / standardDeviation;
+    if (z >= RELEVANCE_HIGH_Z) return "high";
+    if (z <= RELEVANCE_LOW_Z) return "low";
+    return "medium";
+  });
+}
+
+/**
  * Formats the results for the prompt, appending the excerpt read from each
- * page when one is available for it.
+ * page when one is available for it, and a relative relevance tag when the
+ * results carry a reranker score.
  */
 export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
   const searchResults = getLlmTextSearchResults();
@@ -119,17 +157,28 @@ export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
     getPageContentTokenBudget(),
   );
 
+  const relevanceTags = getRelevanceTags(searchResults);
+
   const formattedResults = searchResults
     .map(([title, snippet, url], index) => {
       const heading = shouldIncludeUrl
         ? `• [${title}](${url}) | ${snippet}`
         : `• ${title} | ${snippet}`;
+      const tag = relevanceTags[index];
+      const taggedHeading = tag ? `${heading} (relevance: ${tag})` : heading;
       const excerpt = excerpts[index];
-      return excerpt ? `${heading}\n${formatExcerpt(excerpt)}` : heading;
+      return excerpt
+        ? `${taggedHeading}\n${formatExcerpt(excerpt)}`
+        : taggedHeading;
     })
     .join("\n");
 
-  return `${untrustedTextDisclaimer}\n\n${formattedResults}`;
+  const disclaimers = [
+    untrustedTextDisclaimer,
+    relevanceTags.some(Boolean) ? relevanceDisclaimer : undefined,
+  ].filter((disclaimer): disclaimer is string => disclaimer !== undefined);
+
+  return `${disclaimers.join("\n\n")}\n\n${formattedResults}`;
 }
 
 export async function canStartResponding() {

--- a/client/modules/types.ts
+++ b/client/modules/types.ts
@@ -3,7 +3,12 @@ export type ChatMessage = {
   content: string;
 };
 
-export type TextSearchResult = [title: string, snippet: string, url: string];
+export type TextSearchResult = [
+  title: string,
+  snippet: string,
+  url: string,
+  score?: number,
+];
 
 export type ImageSearchResult = [
   title: string,

--- a/server/rankSearchResults.test.ts
+++ b/server/rankSearchResults.test.ts
@@ -54,6 +54,52 @@ describe("rankSearchResults", () => {
     expect(result[0][0]).toBe("A");
   });
 
+  it("carries the reranker score through as a fourth tuple element", async () => {
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 9 },
+      { index: 1, relevance_score: 8.9 },
+      { index: 2, relevance_score: 8.8 },
+    ] as { index: number; relevance_score: number }[]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const result = await rankSearchResults("query", [
+      ["A", "a", "https://a.com"],
+      ["B", "b", "https://b.com"],
+      ["C", "c", "https://c.com"],
+    ]);
+    // C is dropped by the score filter; the survivors keep their scores.
+    expect(result).toEqual([
+      ["A", "a", "https://a.com", 9],
+      ["B", "b", "https://b.com", 8.9],
+    ]);
+  });
+
+  it("carries the score through when preserving the top result", async () => {
+    mockRerank.mockResolvedValue([
+      { index: 0, relevance_score: 1 },
+      { index: 1, relevance_score: 9 },
+      { index: 2, relevance_score: 8.9 },
+      { index: 3, relevance_score: 8.8 },
+    ] as { index: number; relevance_score: number }[]);
+    const { rankSearchResults } = await import("./rankSearchResults");
+    const result = await rankSearchResults(
+      "query",
+      [
+        ["Top", "top", "https://top.com"],
+        ["A", "a", "https://a.com"],
+        ["B", "b", "https://b.com"],
+        ["C", "c", "https://c.com"],
+      ],
+      true,
+    );
+    // The pinned top result keeps its own (lowest) score, and every survivor
+    // carries its score as the fourth element.
+    expect(result).toEqual([
+      ["Top", "top", "https://top.com", 1],
+      ["A", "a", "https://a.com", 9],
+      ["B", "b", "https://b.com", 8.9],
+    ]);
+  });
+
   it("should preserve top result when preserveTopResults is true", async () => {
     // Index 0 has the LOWER score, so a plain descending sort would put
     // "Other" first; only the pin keeps "Top" first. (A vacuous version gives

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -5,7 +5,7 @@ export async function rankSearchResults(
   query: string,
   searchResults: [title: string, content: string, url: string][],
   preserveTopResults = false,
-): Promise<[title: string, content: string, url: string, score: number][]> {
+): Promise<ScoredSearchResultTuple[]> {
   const documents = searchResults.map(
     ([title, snippet]) => `${title}\n${snippet}`,
   );
@@ -44,7 +44,7 @@ export async function rankSearchResults(
   if (!preserveTopResults) {
     const ranked = filterResults(scoredResults)
       .sort((a, b) => b.score - a.score)
-      .map(({ result, score }) => [...result, score]);
+      .map(({ result, score }): ScoredSearchResultTuple => [...result, score]);
     report(scoredResults.length, ranked.length);
     return ranked;
   }
@@ -64,13 +64,14 @@ export async function rankSearchResults(
     .sort((a, b) => b.score - a.score);
 
   const ranked = [firstResult, ...nextTopResults, ...remainingResults].map(
-    ({ result, score }) => [...result, score],
+    ({ result, score }): ScoredSearchResultTuple => [...result, score],
   );
   report(scoredResults.length, ranked.length);
   return ranked;
 }
 
 type SearchResultTuple = [title: string, content: string, url: string];
+type ScoredSearchResultTuple = [...SearchResultTuple, score: number];
 type ScoredResultItem = { result: SearchResultTuple; score: number };
 type ScoredResultItemWithNormalizedScore = ScoredResultItem & {
   normalizedScore: number;

--- a/server/rankSearchResults.ts
+++ b/server/rankSearchResults.ts
@@ -5,7 +5,7 @@ export async function rankSearchResults(
   query: string,
   searchResults: [title: string, content: string, url: string][],
   preserveTopResults = false,
-) {
+): Promise<[title: string, content: string, url: string, score: number][]> {
   const documents = searchResults.map(
     ([title, snippet]) => `${title}\n${snippet}`,
   );
@@ -44,7 +44,7 @@ export async function rankSearchResults(
   if (!preserveTopResults) {
     const ranked = filterResults(scoredResults)
       .sort((a, b) => b.score - a.score)
-      .map(({ result }) => result);
+      .map(({ result, score }) => [...result, score]);
     report(scoredResults.length, ranked.length);
     return ranked;
   }
@@ -64,7 +64,7 @@ export async function rankSearchResults(
     .sort((a, b) => b.score - a.score);
 
   const ranked = [firstResult, ...nextTopResults, ...remainingResults].map(
-    ({ result }) => result,
+    ({ result, score }) => [...result, score],
   );
   report(scoredResults.length, ranked.length);
   return ranked;

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -92,8 +92,8 @@ describe("searchEndpointServerHook", () => {
       shouldContinue: true,
     });
     vi.mocked(getRerankerStatus).mockResolvedValue(false);
-    vi.mocked(rankSearchResults).mockImplementation(
-      async (_query, results) => results,
+    vi.mocked(rankSearchResults).mockImplementation(async (_query, results) =>
+      results.map(([title, content, url]) => [title, content, url, 0]),
     );
   });
 
@@ -215,8 +215,8 @@ describe("searchEndpointServerHook", () => {
     ]);
     vi.mocked(getRerankerStatus).mockResolvedValue(true);
     vi.mocked(rankSearchResults).mockResolvedValue([
-      ["B", "snippet b", "https://b.com"],
-      ["A", "snippet a", "https://a.com"],
+      ["B", "snippet b", "https://b.com", 0.9],
+      ["A", "snippet a", "https://a.com", 0.5],
     ]);
 
     const handler = getRegisteredHandler();
@@ -239,8 +239,8 @@ describe("searchEndpointServerHook", () => {
     );
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify([
-        ["B", "snippet b", "https://b.com"],
-        ["A", "snippet a", "https://a.com"],
+        ["B", "snippet b", "https://b.com", 0.9],
+        ["A", "snippet a", "https://a.com", 0.5],
       ]),
     );
   });
@@ -426,7 +426,12 @@ describe("searchEndpointServerHook", () => {
       vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
       vi.mocked(getRerankerStatus).mockResolvedValue(true);
       vi.mocked(rankSearchResults).mockResolvedValue([
-        ["Cat picture", "", "https://example.com/not-in-the-result-set.jpg"],
+        [
+          "Cat picture",
+          "",
+          "https://example.com/not-in-the-result-set.jpg",
+          0.5,
+        ],
       ]);
 
       const handler = getRegisteredHandler();

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -113,7 +113,7 @@ async function handleRanking(
   query: string,
   results: [title: string, content: string, url: string][],
   isTextSearch?: boolean,
-): Promise<[title: string, content: string, url: string][]> {
+): Promise<[title: string, content: string, url: string, score?: number][]> {
   const isRerankerHealthy = await getRerankerStatus();
   if (!isRerankerHealthy) {
     recordRerankSkipped();


### PR DESCRIPTION
## Description

`rankSearchResults` asks the reranker for a relevance score per result, uses it to filter and sort, and then drops it in both `.map(({ result }) => result)` calls. We pay for that signal on every search and throw it away.

This PR keeps the score and feeds it to the prompt:

- `rankSearchResults` appends the score as a fourth tuple element, and `TextSearchResult` gains an optional fourth element. Every call site destructures positionally and takes at most three, so nothing else had to change.
- `getFormattedSearchResults` tags each result `high`, `medium` or `low`, and explains above the list that the tags are relative to the batch.

The tags come from a z-score against the batch's own mean and standard deviation, not from an absolute threshold, since the reranker's range depends on the model. Results without a score (restored from IndexedDB by `client/modules/history.ts`) get no tag and no note, so their prompt stays byte-identical to what it was before.

### Where to start

123 of the 187 lines are tests. The behavior is `getRelevanceTags` in `client/modules/textGenerationUtilities.ts` and the two `.map` calls in `server/rankSearchResults.ts`.

## How to test

1. Run `npm run lint` and `npx vitest run`. 691 tests pass, with 6 new ones: the three tag cases, the no-score case, and two proving the score survives both ranking paths (including the pinned top result keeping its own lowest score).
2. Run a search and check that a clearly off-topic result in the batch is tagged `low`.

Note: the golden set answers were not re-measured, since the answer eval needs a served model. The UI part of the open question is not included; this is the prompt-only start the issue recommends.

Closes #2468
