### PR TITLE
docs: warn that a bare tsc skips server and eval

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -185,8 +185,10 @@ Need to:
 
 Before any change:
 ```bash
-docker compose exec development-server npm run lint
+npm run lint
 ```
+
+Inside the dev container, the same command is `docker compose exec development-server npm run lint`.
 
 This runs:
 - Biome (formatting/linting)
@@ -195,6 +197,18 @@ This runs:
 - jscpd (copy-paste detection)
 - Custom architectural linter
 - Doc gardening and documentation validator scripts
+
+### A bare `tsc` is not a full typecheck
+
+The project is split across three TypeScript configs, and the default one covers less than its name suggests:
+
+| Config | Covers |
+| --- | --- |
+| `tsconfig.json` | `client`, `shared`, `test` |
+| `tsconfig.node.json` | `vite.config.ts`, `server`, `shared` |
+| `tsconfig.eval.json` | `eval`, `shared` |
+
+So `npx tsc --noEmit` reports success while type errors sit in `server/` or `eval/`, and CI then fails on a change that looked clean locally. Only `npm run lint` runs all three configs. Never treat a bare `tsc` as a green typecheck.
 
 ## Agent-First Principles
 


### PR DESCRIPTION
## Description

`npx tsc --noEmit` looks like a full typecheck and isn't. `tsconfig.json` includes only `client`, `shared` and `test`, so a bare `tsc` reports success while type errors sit in `server/` or `eval/`, which have their own configs. Nothing in `agents.md` or `docs/` mentioned the split, so the trap was invisible.

It caught me on #2476: a type error in `server/rankSearchResults.ts` passed `npx tsc --noEmit` locally and failed CI on `build-test`.

This PR adds a table of what each config covers and says plainly that only `npm run lint` runs all three.

It also shows the gate as `npm run lint` with the `docker compose exec` form as the container variant, rather than only the container form. `npm run lint` runs fine on the host, and an agent without a running dev container would otherwise fail that command or skip the gate.

## How to test

1. Run `npm run lint`. It exits 0 (7 pre-existing doc-age warnings, 0 errors).
2. Check the table against `tsconfig.json`, `tsconfig.node.json` and `tsconfig.eval.json`.

Note: this is docs only, no behavior change. Two other ideas came up and are deliberately left out, since neither is backed by evidence from this repo: pinning the working directory to stop agents building absolute paths to the repo, and adding guidance on how much to read before acting. Happy to open either as a follow-up.
