### PR TITLE
fix: degrade to cached and image results when the search engines are down

### DIFF
--- a/client/components/Search/Results/Textual/TextSearchResults.tsx
+++ b/client/components/Search/Results/Textual/TextSearchResults.tsx
@@ -2,7 +2,11 @@ import { Alert, Button, Group } from "@mantine/core";
 import { IconInfoCircle, IconRefresh } from "@tabler/icons-react";
 import { usePubSub } from "create-pubsub/react";
 import {
+  imageSearchResultsPubSub,
+  imageSearchStatePubSub,
+  settingsPubSub,
   textSearchResultsPubSub,
+  textSearchStalePubSub,
   textSearchStatePubSub,
 } from "@/modules/pubSub";
 import { searchAndRespond } from "@/modules/textGeneration";
@@ -13,6 +17,10 @@ import TextResultsLoadingState from "./TextResultsLoadingState";
 export default function TextSearchResults() {
   const [searchState] = usePubSub(textSearchStatePubSub);
   const [results] = usePubSub(textSearchResultsPubSub);
+  const [stale] = usePubSub(textSearchStalePubSub);
+  const [imageState] = usePubSub(imageSearchStatePubSub);
+  const [imageResults] = usePubSub(imageSearchResultsPubSub);
+  const [settings] = usePubSub(settingsPubSub);
 
   if (searchState === "running") {
     return <TextResultsLoadingState />;
@@ -20,7 +28,23 @@ export default function TextSearchResults() {
 
   if (searchState === "completed") {
     if (results.length > 0) {
-      return <SearchResultsList searchResults={results} />;
+      return (
+        <>
+          {stale && (
+            <Alert
+              variant="light"
+              color="yellow"
+              title="Showing cached results"
+              icon={<IconInfoCircle />}
+              mb="sm"
+            >
+              The live search is temporarily unavailable, so some of these
+              results are from an earlier search and may be out of date.
+            </Alert>
+          )}
+          <SearchResultsList searchResults={results} />
+        </>
+      );
     }
 
     return (
@@ -36,14 +60,27 @@ export default function TextSearchResults() {
   }
 
   if (searchState === "failed") {
+    const imagesAvailable =
+      imageState === "completed" && imageResults.length > 0;
+    const usedImagesForAnswer = imagesAvailable && settings.enableAiResponse;
+
     return (
       <Alert
         variant="light"
         color="red"
-        title="Search failed"
+        title="Text search unavailable"
         icon={<IconInfoCircle />}
       >
-        Failed to fetch text results. Please try again.
+        <span>
+          The text search is temporarily unavailable, so no live text results
+          could be fetched. This usually clears on its own.
+        </span>
+        {usedImagesForAnswer && (
+          <span>
+            {" "}
+            The answer above was grounded on the image results instead.
+          </span>
+        )}
         <Group mt="sm">
           <Button
             onClick={searchAndRespond}

--- a/client/hooks/useHistoryRestore.ts
+++ b/client/hooks/useHistoryRestore.ts
@@ -23,6 +23,7 @@ import {
   updateSuppressNextFollowUp,
   updateTextGenerationState,
   updateTextSearchResults,
+  updateTextSearchStale,
   updateTextSearchState,
 } from "../modules/pubSub";
 import type { ImageSearchResults, TextSearchResults } from "../modules/types";
@@ -49,6 +50,7 @@ export function useHistoryRestore(
       updatePageContents({});
       updateFollowUpQuestion("");
       updateChatInput("");
+      updateTextSearchStale(false);
 
       const queryString = `q=${encodeURIComponent(selectedQuery)}`;
       postMessageToParentWindow({ queryString, hash: "" });

--- a/client/modules/chatHelpers.test.ts
+++ b/client/modules/chatHelpers.test.ts
@@ -15,6 +15,7 @@ vi.mock("./pubSub", () => ({
   updateImageSearchResults: vi.fn(),
   updateLlmTextSearchResults: vi.fn(),
   updateTextSearchResults: vi.fn(),
+  updateTextSearchStale: vi.fn(),
 }));
 vi.mock("./relatedSearchQuery", () => ({
   generateRelatedSearchQuery: vi.fn(() => Promise.resolve("")),
@@ -37,6 +38,7 @@ import {
   updateImageSearchResults,
   updateLlmTextSearchResults,
   updateTextSearchResults,
+  updateTextSearchStale,
 } from "./pubSub";
 import { searchImages, searchText } from "./search";
 import type { ImageSearchResults, TextSearchResults } from "./types";
@@ -47,6 +49,7 @@ const mockSaveChat = vi.mocked(saveChatMessageForQuery);
 const mockUpdateText = vi.mocked(updateTextSearchResults);
 const mockUpdateImage = vi.mocked(updateImageSearchResults);
 const mockUpdateLlmText = vi.mocked(updateLlmTextSearchResults);
+const mockUpdateTextStale = vi.mocked(updateTextSearchStale);
 
 describe("refreshTextSearchResults", () => {
   it("deduplicates by URL and appends fresh results", async () => {
@@ -58,7 +61,7 @@ describe("refreshTextSearchResults", () => {
       ["Duplicate", "snippet", "https://existing.com"],
     ];
 
-    mockSearchText.mockResolvedValueOnce(fresh);
+    mockSearchText.mockResolvedValueOnce({ results: fresh, stale: false });
 
     await refreshTextSearchResults("query", 10, existing);
 
@@ -66,6 +69,7 @@ describe("refreshTextSearchResults", () => {
       ["Existing", "snippet", "https://existing.com"],
       ["New", "snippet", "https://new.com"],
     ]);
+    expect(mockUpdateTextStale).toHaveBeenCalledWith(false);
   });
 
   it("skips updates when all fresh results are duplicates", async () => {
@@ -74,7 +78,7 @@ describe("refreshTextSearchResults", () => {
     ];
     const fresh: TextSearchResults = [["Title", "snippet", "https://dup.com"]];
 
-    mockSearchText.mockResolvedValueOnce(fresh);
+    mockSearchText.mockResolvedValueOnce({ results: fresh, stale: false });
 
     await refreshTextSearchResults("query", 10, existing);
 
@@ -82,13 +86,24 @@ describe("refreshTextSearchResults", () => {
   });
 
   it("skips updates when there are no fresh results", async () => {
-    mockSearchText.mockResolvedValueOnce([]);
+    mockSearchText.mockResolvedValueOnce({ results: [], stale: false });
 
     await refreshTextSearchResults("query", 10, []);
 
     expect(mockUpdateText).not.toHaveBeenCalled();
-    // An empty refresh must not blank what the model was given either.
     expect(mockUpdateLlmText).not.toHaveBeenCalled();
+    expect(mockUpdateTextStale).not.toHaveBeenCalled();
+  });
+
+  it("raises the stale banner when the fresh batch was served from the cache", async () => {
+    mockSearchText.mockResolvedValueOnce({
+      results: [["New", "snippet", "https://new.com"]],
+      stale: true,
+    });
+
+    await refreshTextSearchResults("query", 10, []);
+
+    expect(mockUpdateTextStale).toHaveBeenCalledWith(true);
   });
 });
 
@@ -102,7 +117,7 @@ describe("refreshImageSearchResults", () => {
       ["Duplicate", "https://existing.com", "thumb", "source"],
     ];
 
-    mockSearchImages.mockResolvedValueOnce(fresh);
+    mockSearchImages.mockResolvedValueOnce({ results: fresh, stale: false });
 
     await refreshImageSearchResults("query", 10, existing);
 
@@ -113,7 +128,7 @@ describe("refreshImageSearchResults", () => {
   });
 
   it("skips updates when there are no fresh results", async () => {
-    mockSearchImages.mockResolvedValueOnce([]);
+    mockSearchImages.mockResolvedValueOnce({ results: [], stale: false });
 
     await refreshImageSearchResults("query", 10, []);
 
@@ -144,9 +159,10 @@ describe("runFollowUpSearch", () => {
     }) as unknown as Parameters<typeof runFollowUpSearch>[2];
 
   it("refreshes text results when enabled", async () => {
-    mockSearchText.mockResolvedValueOnce([
-      ["Title", "snippet", "https://new.com"],
-    ]);
+    mockSearchText.mockResolvedValueOnce({
+      results: [["Title", "snippet", "https://new.com"]],
+      stale: false,
+    });
 
     await runFollowUpSearch(
       [{ role: "user", content: "hello" }],

--- a/client/modules/chatHelpers.ts
+++ b/client/modules/chatHelpers.ts
@@ -10,6 +10,7 @@ import {
   updateImageSearchResults,
   updateLlmTextSearchResults,
   updateTextSearchResults,
+  updateTextSearchStale,
 } from "./pubSub";
 import { searchImages, searchText } from "./search";
 import type { defaultSettings } from "./settings";
@@ -31,9 +32,14 @@ export async function refreshTextSearchResults(
   resultsLimit: number,
   existingResults: TextSearchResults,
 ): Promise<void> {
-  const freshResults = await searchText(searchQuery, resultsLimit);
+  const { results: freshResults, stale } = await searchText(
+    searchQuery,
+    resultsLimit,
+  );
 
   if (freshResults.length === 0) return;
+
+  updateTextSearchStale(stale);
 
   updateLlmTextSearchResults(freshResults.slice(0, searchResultsToConsider));
 
@@ -69,7 +75,10 @@ export async function refreshImageSearchResults(
   resultsLimit: number,
   existingResults: ImageSearchResults,
 ): Promise<void> {
-  const imageResults = await searchImages(searchQuery, resultsLimit);
+  const { results: imageResults } = await searchImages(
+    searchQuery,
+    resultsLimit,
+  );
 
   if (imageResults.length === 0) return;
 

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -149,6 +149,11 @@ export const [updateLlmTextSearchResults, , getLlmTextSearchResults] =
 
 export const [updateImageSearchResults] = imageSearchResultsPubSub;
 
+export const textSearchStalePubSub = createPubSub<boolean>(false);
+
+export const [updateTextSearchStale, , getTextSearchStale] =
+  textSearchStalePubSub;
+
 const pageContentsPubSub = createPubSub<PageContents>({});
 
 export const [updatePageContents, , getPageContents] = pageContentsPubSub;

--- a/client/modules/search.test.ts
+++ b/client/modules/search.test.ts
@@ -328,12 +328,12 @@ describe("Search Module", () => {
 
       // First call — cache miss, fetches from network.
       const firstResults = await searchModule.searchText("cached query");
-      expect(firstResults).toEqual(mockResults);
+      expect(firstResults).toEqual({ results: mockResults, stale: false });
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       // Second call with the same query — should be a cache hit.
       const secondResults = await searchModule.searchText("cached query");
-      expect(secondResults).toEqual(mockResults);
+      expect(secondResults).toEqual({ results: mockResults, stale: false });
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(addLogEntry).toHaveBeenCalledWith(
         expect.stringContaining("Text search: Reused 1 results from the cache"),
@@ -353,11 +353,11 @@ describe("Search Module", () => {
       });
 
       const firstResults = await searchModule.searchImages("cached images");
-      expect(firstResults).toEqual(mockResults);
+      expect(firstResults).toEqual({ results: mockResults, stale: false });
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const secondResults = await searchModule.searchImages("cached images");
-      expect(secondResults).toEqual(mockResults);
+      expect(secondResults).toEqual({ results: mockResults, stale: false });
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(addLogEntry).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -413,7 +413,7 @@ describe("Search Module", () => {
       searchModule.searchServiceInstance.updateCacheConfig({ ttl: 0 });
 
       const secondResults = await searchModule.searchText("ttl query");
-      expect(secondResults).toEqual(mockResults);
+      expect(secondResults).toEqual({ results: mockResults, stale: false });
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
@@ -452,6 +452,75 @@ describe("Search Module", () => {
       await searchModule.searchImages("cross-store query");
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
+  });
+
+  describe("Stale Result Fallback", () => {
+    it("should serve stale cached results when a repeated query's live search fails", async () => {
+      const mockResults: string[][] = [
+        ["Title", "Snippet", "https://example.com"],
+      ];
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(mockResults),
+      });
+
+      // First call: cache miss, fetches and caches.
+      const first = await searchModule.searchText("stale query");
+      expect(first).toEqual({ results: mockResults, stale: false });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Expire the entry and make the live search fail.
+      searchModule.searchServiceInstance.updateCacheConfig({ ttl: 0 });
+      mockFetch.mockRejectedValue(new Error("upstream refused the connection"));
+
+      const second = await searchModule.searchText("stale query");
+      expect(second.results).toEqual(mockResults);
+      expect(second.stale).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(addLogEntry).toHaveBeenCalledWith(
+        expect.stringContaining("from a previous search"),
+      );
+    });
+
+    it("should still fail when the live search fails and nothing is cached to serve", async () => {
+      // No prior successful search for this query, so a failure has no stale
+      // result to fall back on and must surface as a failed search.
+      mockFetch.mockRejectedValue(new Error("upstream refused the connection"));
+
+      await expect(
+        searchModule.searchText("never cached query"),
+      ).rejects.toThrow("upstream refused the connection");
+    });
+
+    it("should not serve a cached entry past the stale retention even when the live search fails", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const mockResults: string[][] = [
+        ["Title", "Snippet", "https://example.com"],
+      ];
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(mockResults),
+      });
+
+      try {
+        // Cache an entry, then move past the 24-hour stale retention.
+        await searchModule.searchText("aging query");
+        vi.setSystemTime(Date.now() + 25 * 60 * 60 * 1000);
+        mockFetch.mockRejectedValue(
+          new Error("upstream refused the connection"),
+        );
+
+        await expect(searchModule.searchText("aging query")).rejects.toThrow(
+          "upstream refused the connection",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    // The read-side recheck is the backup for a cleanup pass that failed;
+    // pinning it alone would require reaching the internal database, which is
+    // not exported, so this test pins the pair (cleanup plus recheck).
   });
 
   describe("URL Construction", () => {

--- a/client/modules/search.ts
+++ b/client/modules/search.ts
@@ -12,6 +12,7 @@ const CACHE_CONFIG = {
   METRICS_LOG_INTERVAL: 10,
   REQUEST_TIMEOUT: 30000,
   MAX_QUERY_LENGTH: 2000,
+  MAX_STALE_RETENTION: 24 * 60 * 60 * 1000,
 } as const;
 
 const cacheConfig: {
@@ -123,12 +124,17 @@ interface SearchOperations<T extends SearchResults> {
   ) => Promise<T>;
 }
 
+interface CachedSearchOutcome<T> {
+  results: T;
+  stale: boolean;
+}
+
 async function executeCachedSearch<T extends SearchResults>(
   query: string,
   limit: number | undefined,
   context: SearchExecutionConfig,
   operations: SearchOperations<T>,
-): Promise<T> {
+): Promise<CachedSearchOutcome<T>> {
   await db.cleanExpiredCache(context.storeName);
 
   const key = await operations.hashQuery(query, limit);
@@ -143,26 +149,43 @@ async function executeCachedSearch<T extends SearchResults>(
     );
 
     logAndMaybeResetMetrics();
-    return cachedData.results;
+    return { results: cachedData.results, stale: false };
   }
 
   incrementCacheMetric(context.missMetric);
   cacheMetrics.incrementTotalOperations();
 
-  const results = await operations.performSearch(
-    context.endpoint,
-    query,
-    limit,
-  );
+  try {
+    const results = await operations.performSearch(
+      context.endpoint,
+      query,
+      limit,
+    );
 
-  await db.cacheResult(context.storeName, key, results);
-  logAndMaybeResetMetrics();
+    await db.cacheResult(context.storeName, key, results);
+    logAndMaybeResetMetrics();
 
-  addLogEntry(
-    `${context.logLabel}: Fetched ${results.length} results from the API`,
-  );
+    addLogEntry(
+      `${context.logLabel}: Fetched ${results.length} results from the API`,
+    );
 
-  return results;
+    return { results, stale: false };
+  } catch (error) {
+    if (
+      cachedData &&
+      cachedData.results.length > 0 &&
+      Date.now() - cachedData.timestamp < CACHE_CONFIG.MAX_STALE_RETENTION
+    ) {
+      logAndMaybeResetMetrics();
+      addLogEntry(
+        `${context.logLabel}: Live search failed (${
+          error instanceof Error ? error.message : String(error)
+        }); serving ${cachedData.results.length} result(s) from a previous search`,
+      );
+      return { results: cachedData.results, stale: true };
+    }
+    throw error;
+  }
 }
 
 interface SearchCacheEntry {
@@ -216,7 +239,10 @@ class SearchCacheDatabase extends Dexie {
 
   async cleanExpiredCache(
     storeName: "textSearchHistory" | "imageSearchHistory",
-    timeToLive: number = cacheConfig.ttl,
+    retention: number = Math.max(
+      cacheConfig.ttl,
+      CACHE_CONFIG.MAX_STALE_RETENTION,
+    ),
   ): Promise<void> {
     const currentTime = Date.now();
     const store = this[storeName];
@@ -224,7 +250,7 @@ class SearchCacheDatabase extends Dexie {
     try {
       const expiredItems = await store
         .where("timestamp")
-        .below(currentTime - timeToLive)
+        .below(currentTime - retention)
         .toArray();
 
       if (expiredItems.length > 0) {
@@ -272,7 +298,7 @@ class SearchCacheDatabase extends Dexie {
   async getCachedResult<T extends TextSearchResults | ImageSearchResults>(
     storeName: "textSearchHistory" | "imageSearchHistory",
     key: string,
-  ): Promise<{ results: T; fresh: boolean } | null> {
+  ): Promise<{ results: T; fresh: boolean; timestamp: number } | null> {
     if (!cacheConfig.enabled) return null;
 
     try {
@@ -285,7 +311,11 @@ class SearchCacheDatabase extends Dexie {
       if (!cachedItem) return null;
 
       const fresh = Date.now() - cachedItem.timestamp < cacheConfig.ttl;
-      return { results: cachedItem.results, fresh };
+      return {
+        results: cachedItem.results,
+        fresh,
+        timestamp: cachedItem.timestamp,
+      };
     } catch (error) {
       addLogEntry(
         `Error retrieving from cache: ${error instanceof Error ? error.message : String(error)}`,
@@ -416,7 +446,10 @@ const searchService = {
     }
   },
 
-  async searchText(query: string, limit?: number): Promise<TextSearchResults> {
+  async searchText(
+    query: string,
+    limit?: number,
+  ): Promise<CachedSearchOutcome<TextSearchResults>> {
     try {
       return await executeCachedSearch<TextSearchResults>(
         query,
@@ -446,7 +479,7 @@ const searchService = {
   async searchImages(
     query: string,
     limit?: number,
-  ): Promise<ImageSearchResults> {
+  ): Promise<CachedSearchOutcome<ImageSearchResults>> {
     try {
       return await executeCachedSearch<ImageSearchResults>(
         query,

--- a/client/modules/textGeneration.degradation.test.ts
+++ b/client/modules/textGeneration.degradation.test.ts
@@ -10,6 +10,7 @@ const harness = vi.hoisted(() => {
     llmTextSearchResults: [] as unknown[],
     pageContents: {} as Record<string, string>,
     searchRunId: "run-1",
+    staleFlag: false,
     searchPromise: Promise.resolve({}) as Promise<unknown>,
     settings: {
       inferenceType: "internal",
@@ -33,6 +34,8 @@ const harness = vi.hoisted(() => {
 
 vi.mock("./pubSub", () => ({
   getConversationSummary: () => ({ conversationId: "", summary: "" }),
+  getLlmTextSearchResults: () => harness.state.llmTextSearchResults,
+  getPageContents: () => harness.state.pageContents,
   getQuery: () => harness.state.query,
   getResponse: () => harness.state.response,
   getSettings: () => harness.state.settings,
@@ -65,6 +68,10 @@ vi.mock("./pubSub", () => ({
   updateTextSearchState: (value: string) => {
     harness.state.textSearchState = value;
   },
+  updateTextSearchStale: vi.fn((value: boolean) => {
+    harness.state.staleFlag = value;
+  }),
+  getTextSearchStale: () => harness.state.staleFlag,
 }));
 
 vi.mock("./config", () => ({
@@ -87,8 +94,8 @@ vi.mock("./pageContent", () => ({
 }));
 
 vi.mock("./search", () => ({
-  searchImages: vi.fn(() => Promise.resolve([])),
-  searchText: vi.fn(() => Promise.resolve([])),
+  searchImages: vi.fn(() => Promise.resolve({ results: [], stale: false })),
+  searchText: vi.fn(() => Promise.resolve({ results: [], stale: false })),
 }));
 
 vi.mock("./searchTokenHash", () => ({
@@ -112,6 +119,7 @@ vi.mock("./textGenerationUtilities", () => ({
     max_tokens: 1000,
   })),
   getFormattedSearchResults: vi.fn(() => "None."),
+  imageResultTag: "(image) ",
   searchResultsToConsider: 6,
 }));
 
@@ -121,9 +129,10 @@ vi.mock("gpt-tokenizer", () => ({
 
 import { saveLlmResponseForQuery } from "./history";
 import { fetchPageContents } from "./pageContent";
+import { updateTextSearchStale } from "./pubSub";
 import { searchImages, searchText } from "./search";
 import { searchAndRespond } from "./textGeneration";
-import type { TextSearchResults } from "./types";
+import type { ImageSearchResults, TextSearchResults } from "./types";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -154,8 +163,10 @@ describe("search degradation", () => {
     harness.state.textSearchState = "idle";
     harness.state.textSearchResults = [];
     harness.state.llmTextSearchResults = [];
+    harness.state.staleFlag = false;
     harness.state.settings.enableAiResponse = false;
     harness.state.settings.enableTextSearch = true;
+    harness.state.settings.enableImageSearch = false;
     harness.stateTransitions.length = 0;
     harness.onResponseUpdate.current = () => {};
   });
@@ -165,8 +176,8 @@ describe("search degradation", () => {
       ["Beginner languages", "A snippet", "https://example.com"],
     ];
     vi.mocked(searchText)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(fallbackResults);
+      .mockResolvedValueOnce({ results: [], stale: false })
+      .mockResolvedValueOnce({ results: fallbackResults, stale: false });
 
     await searchAndRespond();
     await harness.state.searchPromise;
@@ -184,7 +195,7 @@ describe("search degradation", () => {
   });
 
   it("keeps the text search completed when the keyword fallback is also empty", async () => {
-    vi.mocked(searchText).mockResolvedValue([]);
+    vi.mocked(searchText).mockResolvedValue({ results: [], stale: false });
 
     await searchAndRespond();
     await harness.state.searchPromise;
@@ -194,10 +205,178 @@ describe("search degradation", () => {
     expect(harness.state.textSearchState).toBe("completed");
   });
 
+  it("grounds the LLM on image results when the text search fails", async () => {
+    vi.mocked(searchText).mockRejectedValue(
+      new Error("HTTP error! status: 502"),
+    );
+    // The grounding only happens for the answer path.
+    harness.state.settings.enableAiResponse = true;
+    vi.mocked(searchImages).mockResolvedValue({
+      results: [
+        [
+          "Image A",
+          "https://img.example.com/a",
+          "thumb",
+          "https://img.example.com/a",
+        ],
+        [
+          "Image B",
+          "https://img.example.com/b",
+          "thumb",
+          "https://img.example.com/b",
+        ],
+      ],
+      stale: false,
+    });
+    harness.state.settings.enableImageSearch = true;
+
+    const responded = searchAndRespond();
+    // The grounding has to wait for the awaited image search, so the channel
+    // is only populated once the search promise settles.
+    await responded;
+    await harness.state.searchPromise;
+
+    expect(harness.state.textSearchState).toBe("failed");
+    expect(harness.state.llmTextSearchResults).toEqual([
+      ["(image) Image A", "", "https://img.example.com/a"],
+      ["(image) Image B", "", "https://img.example.com/b"],
+    ]);
+
+    // The tagged line as the prompt actually renders it, through the real
+    // formatter.
+    const { getFormattedSearchResults } = await vi.importActual<
+      typeof import("./textGenerationUtilities")
+    >("./textGenerationUtilities");
+    const promptResults = getFormattedSearchResults(true);
+    expect(promptResults).toContain(
+      "\u2022 [(image) Image A](https://img.example.com/a) | ",
+    );
+    expect(promptResults).toContain("image search fallback");
+  });
+
+  it("marks completed results as stale when the live search degraded to the cache", async () => {
+    vi.mocked(searchText).mockResolvedValue({
+      results: [["T", "S", "https://example.com"]],
+      stale: true,
+    });
+
+    await searchAndRespond();
+    await harness.state.searchPromise;
+
+    expect(harness.state.textSearchState).toBe("completed");
+    // The banner is about the final state: the reset publishes false first,
+    // so only the last call says anything about what is on screen.
+    expect(vi.mocked(updateTextSearchStale)).toHaveBeenLastCalledWith(true);
+
+    // The UI saying the results are stale is not enough: the prompt the LLM
+    // is built from has to carry the same caveat, through the real formatter.
+    const { getFormattedSearchResults } = await vi.importActual<
+      typeof import("./textGenerationUtilities")
+    >("./textGenerationUtilities");
+    expect(getFormattedSearchResults(true)).toContain(
+      "cached from an earlier search",
+    );
+  });
+
+  it("lets a newer search keep the grounding channel when an older image fallback resolves last", async () => {
+    // Run 1: text fails, image in flight.
+    vi.mocked(searchText).mockRejectedValueOnce(
+      new Error("HTTP error! status: 502"),
+    );
+    let releaseImages: (value: {
+      results: ImageSearchResults;
+      stale: boolean;
+    }) => void = () => {};
+    vi.mocked(searchImages).mockReturnValueOnce(
+      new Promise<{ results: ImageSearchResults; stale: boolean }>(
+        (resolve) => {
+          releaseImages = resolve;
+        },
+      ),
+    );
+    harness.state.settings.enableAiResponse = true;
+    harness.state.settings.enableImageSearch = true;
+
+    const first = searchAndRespond();
+    await vi.waitFor(() => expect(searchImages).toHaveBeenCalled());
+
+    // Run 2 (a retry): text succeeds and repopulates the channel.
+    harness.state.query = "retry query";
+    vi.mocked(searchText).mockResolvedValueOnce({
+      results: [["Fresh", "snippet", "https://fresh.example.com"]],
+      stale: false,
+    });
+    const second = searchAndRespond();
+    await second;
+    await harness.state.searchPromise;
+
+    // Run 1's image search now lands, after run 2 already owns the channel.
+    releaseImages({
+      results: [
+        ["Late", "https://late.example.com", "t", "https://late.example.com"],
+      ],
+      stale: false,
+    });
+    // Let run 1's in-flight continuation fully drain: without the guard its
+    // publish lands on later microtasks, after the test's own `await` has
+    // resumed, so asserting without draining would race the very write the
+    // guard blocks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await first;
+
+    expect(harness.state.llmTextSearchResults).toEqual([
+      ["Fresh", "snippet", "https://fresh.example.com"],
+    ]);
+  });
+
+  it("keeps restored grounding when an older image fallback resolves after a restore", async () => {
+    vi.mocked(searchText).mockRejectedValueOnce(
+      new Error("HTTP error! status: 502"),
+    );
+    let releaseImages:
+      | ((value: { results: ImageSearchResults; stale: boolean }) => void)
+      | undefined;
+    vi.mocked(searchImages).mockReturnValueOnce(
+      new Promise<{ results: ImageSearchResults; stale: boolean }>(
+        (resolve) => {
+          releaseImages = resolve;
+        },
+      ),
+    );
+    harness.state.settings.enableAiResponse = true;
+    harness.state.settings.enableImageSearch = true;
+
+    const first = searchAndRespond();
+    await vi.waitFor(() => expect(searchImages).toHaveBeenCalled());
+
+    // A history restore changes the run id without starting a new search, so
+    // the invocation counter alone cannot invalidate the in-flight fallback.
+    harness.state.searchRunId = "run-2";
+    harness.state.llmTextSearchResults = [
+      ["Restored", "snippet", "https://restored.example.com"],
+    ];
+
+    releaseImages?.({
+      results: [
+        ["Late", "https://late.example.com", "t", "https://late.example.com"],
+      ],
+      stale: false,
+    });
+    // The publish sits behind the awaited image search; drain the
+    // continuation before asserting, as in the cross-run test above.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await first;
+
+    expect(harness.state.llmTextSearchResults).toEqual([
+      ["Restored", "snippet", "https://restored.example.com"],
+    ]);
+  });
+
   it("marks the text search as failed when the search request errors", async () => {
     vi.mocked(searchText).mockRejectedValue(
       new Error("HTTP error! status: 502"),
     );
+    harness.state.settings.enableImageSearch = true;
 
     // A previous search left the LLM grounding channel populated; the failed
     // search must clear it so the AI can't ground on stale results.
@@ -234,7 +413,10 @@ describe("page content grounding", () => {
     harness.state.settings.enableImageSearch = false;
     harness.state.settings.enableTextSearch = true;
     harness.state.settings.enablePageContentFetch = true;
-    vi.mocked(searchText).mockResolvedValue(textResults);
+    vi.mocked(searchText).mockResolvedValue({
+      results: textResults,
+      stale: false,
+    });
   });
 
   /** Holds the page read open so a test can observe what happens meanwhile. */

--- a/client/modules/textGeneration.ts
+++ b/client/modules/textGeneration.ts
@@ -25,6 +25,7 @@ import {
   updateSearchPromise,
   updateTextGenerationState,
   updateTextSearchResults,
+  updateTextSearchStale,
   updateTextSearchState,
 } from "./pubSub";
 import { searchImages, searchText } from "./search";
@@ -33,6 +34,7 @@ import {
   ChatGenerationError,
   defaultContextSize,
   getFormattedSearchResults,
+  imageResultTag,
   searchResultsToConsider,
 } from "./textGenerationUtilities";
 import type {
@@ -214,12 +216,16 @@ function summarizeDroppedMessages(
   return summary;
 }
 
+let searchInvocation = 0;
+
 /**
  * Runs the search for the current query and, when AI responses are enabled,
  * generates an answer with the configured backend after it completes.
  */
 export async function searchAndRespond() {
   if (getQuery() === "") return;
+
+  const invocation = ++searchInvocation;
 
   document.title = getQuery();
 
@@ -229,6 +235,8 @@ export async function searchAndRespond() {
 
   updateTextSearchResults([]);
 
+  updateTextSearchStale(false);
+
   updateLlmTextSearchResults([]);
 
   updateImageSearchResults([]);
@@ -237,7 +245,7 @@ export async function searchAndRespond() {
 
   updatePageContents({});
 
-  updateSearchPromise(startTextSearch(getQuery()));
+  updateSearchPromise(startTextSearch(getQuery(), invocation));
 
   if (!getSettings().enableAiResponse) return;
 
@@ -414,12 +422,14 @@ async function readPageContents(query: string, results: TextSearchResults) {
   updatePageContents(contents);
 }
 
-async function startTextSearch(query: string) {
+async function startTextSearch(query: string, invocation: number) {
+  const searchRunId = getCurrentSearchRunId();
   const results = {
     textResults: [] as TextSearchResults,
     imageResults: [] as ImageSearchResults,
   };
   let pageContentsRead = Promise.resolve();
+  let textSearchFailed = false;
 
   const searchQuery =
     query.length > 2000 ? (await getKeywords(query, 20)).join(" ") : query;
@@ -432,22 +442,24 @@ async function startTextSearch(query: string) {
     updateTextSearchState("running");
 
     try {
-      let textResults = await searchText(
+      let { results: textResults, stale } = await searchText(
         searchQuery,
         getSettings().searchResultsLimit,
       );
 
       if (textResults.length === 0) {
         const queryKeywords = await getKeywords(query, 10);
-        const keywordResults = await searchText(
+        const keywordOutcome = await searchText(
           queryKeywords.join(" "),
           getSettings().searchResultsLimit,
         );
-        textResults = keywordResults;
+        textResults = keywordOutcome.results;
+        stale = keywordOutcome.stale;
       }
 
       results.textResults = textResults;
 
+      updateTextSearchStale(stale);
       updateTextSearchState("completed");
       updateTextSearchResults(textResults);
 
@@ -467,14 +479,34 @@ async function startTextSearch(query: string) {
       // image search and the history write carry on.
       pageContentsRead = readPageContents(searchQuery, resultsForLlm);
     } catch {
-      // An outage (non-200 from /search/*) is not the same as a query with no
-      // results; only the former leaves the search in the failed state.
+      updateTextSearchStale(false);
       updateTextSearchState("failed");
+      textSearchFailed = true;
     }
   }
 
   if (getSettings().enableImageSearch) {
-    startImageSearch(searchQuery, results);
+    if (textSearchFailed && getSettings().enableAiResponse) {
+      await startImageSearch(searchQuery, results);
+
+      if (
+        results.imageResults.length > 0 &&
+        invocation === searchInvocation &&
+        searchRunId === getCurrentSearchRunId()
+      ) {
+        updateLlmTextSearchResults(
+          results.imageResults
+            .slice(0, searchResultsToConsider)
+            .map(([title, url]) => [
+              `${imageResultTag}${title.slice(0, 100)}`,
+              "",
+              url,
+            ]),
+        );
+      }
+    } else {
+      startImageSearch(searchQuery, results);
+    }
   }
 
   await pageContentsRead;
@@ -487,7 +519,7 @@ async function startImageSearch(
   results: { textResults: TextSearchResults; imageResults: ImageSearchResults },
 ) {
   try {
-    const imageResults = await searchImages(
+    const { results: imageResults } = await searchImages(
       searchQuery,
       getSettings().searchResultsLimit,
     );

--- a/client/modules/textGenerationUtilities.test.ts
+++ b/client/modules/textGenerationUtilities.test.ts
@@ -16,6 +16,7 @@ vi.mock("./pubSub", () => ({
   getQuery: () => "the query",
   getSearchPromise: vi.fn(),
   getSettings: () => state.settings,
+  getTextSearchStale: () => false,
   updateTextGenerationState: vi.fn(),
 }));
 

--- a/client/modules/textGenerationUtilities.ts
+++ b/client/modules/textGenerationUtilities.ts
@@ -5,6 +5,7 @@ import {
   getQuery,
   getSearchPromise,
   getSettings,
+  getTextSearchStale,
   updateTextGenerationState,
 } from "./pubSub";
 import { getSystemPrompt } from "./systemPrompt";
@@ -13,6 +14,8 @@ import type { ChatMessage, TextSearchResult } from "./types";
 export const defaultContextSize = 4096;
 
 export const searchResultsToConsider = 6;
+
+export const imageResultTag = "(image) ";
 
 export class ChatGenerationError extends Error {
   constructor(message: string) {
@@ -112,6 +115,11 @@ function formatExcerpt(excerpt: string) {
 const relevanceDisclaimer =
   "Each result is tagged with how well it matched the query relative to the others in this batch: high, medium, or low. Weigh the low ones less, and treat a batch of low results as a sign the results may not cover the question.";
 
+const imageResultsDisclaimer = `Results tagged ${imageResultTag.trim()} come from the image search fallback: they carry only titles and page links, no snippets, and may not cover the question.`;
+
+const staleResultsDisclaimer =
+  "These search results were cached from an earlier search because the live search failed; they may be outdated. If the answer depends on current information, say so.";
+
 // Z-score cutoffs against the batch's own mean and standard deviation, the
 // same statistics the server's score filter is calibrated on.
 const RELEVANCE_HIGH_Z = 0.5;
@@ -173,9 +181,15 @@ export function getFormattedSearchResults(shouldIncludeUrl: boolean) {
     })
     .join("\n");
 
+  const hasTaggedImageResults = searchResults.some(([title]) =>
+    title.startsWith(imageResultTag),
+  );
+
   const disclaimers = [
     untrustedTextDisclaimer,
     relevanceTags.some(Boolean) ? relevanceDisclaimer : undefined,
+    hasTaggedImageResults ? imageResultsDisclaimer : undefined,
+    getTextSearchStale() ? staleResultsDisclaimer : undefined,
   ].filter((disclaimer): disclaimer is string => disclaimer !== undefined);
 
   return `${disclaimers.join("\n\n")}\n\n${formattedResults}`;

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -12,8 +12,9 @@ needed.
 | --- | --- | --- |
 | SearXNG answers 500 once, then recovers | Retried with exponential backoff, results returned | `server/webSearchService.test.ts` › retry logic |
 | SearXNG answers 500 on every attempt | Retry cycle exhausts (4 requests) and costs a single circuit-breaker failure | `server/webSearchService.test.ts` › graceful degradation |
-| SearXNG answers 200 with no results and unresponsive engines once, then recovers | Retried with the same backoff, results returned, not counted as a failure | `server/webSearchService.test.ts` › retry logic |
-| SearXNG answers 200 with no results and unresponsive engines on every attempt | Retry cycle exhausts (4 requests), counts one failure, and `fetchSearXNG` throws with the engine reasons rather than an empty set, so the case takes the provider-down path below | `server/webSearchService.test.ts` › retry logic, graceful degradation |
+| SearXNG answers 200 with no results and a transiently unresponsive engine (e.g. a timeout) once, then recovers | Retried with the same backoff, results returned, not counted as a failure | `server/webSearchService.test.ts` › retry logic |
+| SearXNG answers 200 with no results and a non-suspending engine error (e.g. server API error) on every attempt | Retry cycle exhausts (4 requests), counts one failure, and `fetchSearXNG` throws with the engine reasons rather than an empty set, so the case takes the provider-down path below | `server/webSearchService.test.ts` › retry logic, graceful degradation |
+| SearXNG answers 200 with no results and every unresponsive engine under a long suspension (CAPTCHA, rate limit) | Fails fast on the first attempt (1 request, no backoff), counts one failure, and throws the same error: a suspension outlasts the whole backoff by hours to a day | `server/webSearchService.test.ts` › retry logic |
 | SearXNG fails five cycles in a row | Circuit opens; further searches short-circuit without calling the upstream | `server/webSearchService.test.ts` › graceful degradation |
 | SearXNG recovers after the reset timeout | One healthy response closes the circuit again | `server/webSearchService.test.ts` › graceful degradation |
 | SearXNG answers 200 with a non-JSON body | `fetchSearXNG` throws and the endpoint answers HTTP 502 | `server/webSearchService.test.ts` › graceful degradation |
@@ -30,7 +31,9 @@ needed.
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |
 | Keyword fallback also returns nothing | Text search state stays `completed` with the no-results alert | `client/modules/textGeneration.degradation.test.ts` |
 | SearXNG is down on the client | Text search state becomes `failed`, keyword fallback does not fire | `client/modules/textGeneration.degradation.test.ts` |
-| Client search fails after a previous search populated the LLM channel | The grounding channel is cleared, so the AI can't ground on the previous query's results | `client/modules/textGeneration.degradation.test.ts` |
+| Client search fails after a previous search populated the LLM channel | The grounding channel is cleared, so the AI can't ground on the previous query's results; when image search is on and it answers, the channel is repopulated with the (image)-tagged titles and URLs instead | `client/modules/textGeneration.degradation.test.ts` |
+| Text search fails and the image search answers | The answer waits for the image results and grounds on their (image)-tagged titles and URLs, and the failed-state alert says so | `client/modules/textGeneration.degradation.test.ts` › search degradation |
+| Live search fails but a stale cached result exists for the same query | The cached result is served flagged stale and the UI shows the "Showing cached results" banner | `client/modules/search.test.ts` › Stale Result Fallback |
 | Result page host resolves into a private range | Page skipped, no request is made | `server/pageContentService.test.ts` › fetchPageContents |
 | Result page redirects into a private range | Redirect not followed, page skipped | `server/pageContentService.test.ts` › fetchPageContents |
 | Result page errors, is not a document, or yields no text | That page is skipped, the others still return | `server/pageContentService.test.ts` › fetchPageContents |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -61,9 +61,9 @@ PubSub channels are created using the create-pubsub package and provide type-saf
 MiniSearch employs a dual-layer persistence approach:
 
 - **IndexedDB** - Local storage for search history, settings, cached results, and saved AI transcripts
-- **TTL-based caching** - 15-minute cache for search results to minimize API calls
+- **TTL-based caching** - 15-minute freshness cache for search results to minimize API calls, with a 24-hour stale retention as a fallback when the live search fails
 
-Search history is backed by a Dexie database that keeps three coordinated tables (search runs, LLM responses, chat turns) along with automatic retention/max-entry cleanup. See `docs/search-history.md` for the complete schema and invariants. The caching layer minimizes redundant API calls to SearXNG while maintaining fresh results. Search results cached in IndexedDB have a 15-minute TTL, after which new searches bypass the cache.
+Search history is backed by a Dexie database that keeps three coordinated tables (search runs, LLM responses, chat turns) along with automatic retention/max-entry cleanup. See `docs/search-history.md` for the complete schema and invariants. The caching layer minimizes redundant API calls to SearXNG while maintaining fresh results. Search results cached in IndexedDB have a 15-minute freshness TTL, after which new searches bypass the cache; an expired entry is kept for 24 hours so a failed live search can serve it, flagged stale, instead of failing.
 
 Long-running chat sessions use an in-memory conversation summary that rolls excess turns into a structured digest before continuing generation. Details about the token budgeting and summary refresh flow live in `docs/conversation-memory.md`.
 
@@ -98,7 +98,7 @@ The system executes two parallel flows when a user submits a query:
 5. `webSearchService.ts` forwards query to SearXNG at `http://127.0.0.1:8888`
 6. Raw results are deduplicated, cleaned, and optionally reranked
 7. Thumbnails are proxied and converted to base64 Data URLs to avoid CORS issues
-8. Results returned as structured JSON and cached in IndexedDB (15-minute TTL)
+8. Results returned as structured JSON and cached in IndexedDB (15-minute freshness TTL)
 
 ### AI Generation Flow
 
@@ -117,6 +117,7 @@ The `textGeneration` module orchestrates the entire search-to-response flow, man
 
 - **Circuit Breaker**: Opens after 5 consecutive failures, blocking requests for 60 seconds before attempting reset
 - **Retry Logic**: Exponential backoff for HTTP 500 errors, up to 3 retries
+- **Fail-Fast on Suspending Engines**: An empty response in which every unresponsive engine is under a long suspension (CAPTCHA, rate limit, access denied; SearXNG suspends them for an hour to a day) throws on the first attempt instead of spending the retry budget, which it could not possibly outlast. Transient engine errors (timeouts, server API errors) keep the full retry budget.
 - **Content Processing**: Converts HTML results to plain text, strips emojis for cleaner output
 - **Thumbnail Proxying**: Server fetches external thumbnails and converts to base64 Data URLs, avoiding CORS issues and improving loading stability
 
@@ -210,7 +211,7 @@ MiniSearch implements all server-side logic as Vite plugin hooks. Each hook regi
 
 Key server-side modules:
 
-- **`server/webSearchService.ts`**: Integrates with SearXNG at `http://127.0.0.1:8888`. Implements a circuit breaker (opens after 5 failures, resets after 60s) and retry logic (up to 3 retries with exponential backoff, for 500s and for empty responses naming unresponsive engines).
+- **`server/webSearchService.ts`**: Integrates with SearXNG at `http://127.0.0.1:8888`. Implements a circuit breaker (opens after 5 failures, resets after 60s) and retry logic (up to 3 retries with exponential backoff, for 500s and for empty responses naming transiently unresponsive engines; an all-suspended set fails fast on the first attempt, since SearXNG suspensions last an hour to a day).
 - **`server/pageContentService.ts`**: Reads result pages for answer grounding: SSRF-guarded fetches with a byte cap, readable-text extraction, and query-relevant passage selection.
 - **`server/searchToken.ts`**: Manages a token at `{os.tempdir()}/minisearch-token` used for CSRF protection on search requests.
 - **`server/verifiedTokens.ts`**: In-memory `Map` of verified session token to last-seen time, evicted after 30 idle minutes, plus a cumulative count of the distinct sessions seen since the last restart.
@@ -241,7 +242,7 @@ The `/status` endpoint returns a JSON object:
 | `averageTextualSearchesPerSession` | number | Text searches / sessions ratio |
 | `averageGraphicalSearchesPerSession` | number | Image searches / sessions ratio |
 | `searchesWithoutResults` | number | Searches, text and image together, that SearXNG answered with zero results and no unresponsive engines |
-| `searchesWithUnresponsiveEngines` | number | Searches, text and image together, that still came back with zero results and unresponsive engines after the retries were spent; one per search, not per attempt |
+| `searchesWithUnresponsiveEngines` | number | Searches, text and image together, that came back with zero results and unresponsive engines, whether the retries were spent or an all-suspended set failed fast; one per search, not per attempt |
 | `searchesWithAllResultsDiscarded` | number | Text searches whose results were all dropped during processing |
 | `rerankerServiceStatus` | string | `"healthy"` or `"unhealthy"` |
 | `webSearchServiceStatus` | string | `"healthy"` or `"unhealthy"` |
@@ -259,8 +260,9 @@ used to carry the query text. The log still names the unresponsive engines
 behind an empty response and the size and type of a discarded batch; how often
 each happens is read from here instead. `searchesWithoutResults` counts only
 the searches that genuinely matched nothing, since an empty response naming
-unresponsive engines fails the search rather than returning zero results once
-the retries are spent (see `docs/failure-injection.md`);
+unresponsive engines fails the search rather than returning zero results,
+after the retries are spent or immediately for an all-suspended set
+(see `docs/failure-injection.md`);
 `searchesWithUnresponsiveEngines` counts those, which is the way to tell
 whether the case is being over-classified. It undercounts a sustained
 outage, where the circuit breaker short-circuits before `performSearch` is
@@ -414,7 +416,8 @@ Two separate Dexie databases handle different persistence needs:
 
 | Constant | Value | Description |
 | ---------- | ------- | ------------- |
-| TTL | 15 minutes | Cache entry lifetime |
+| TTL | 15 minutes | Freshness window: a hit inside it skips the network |
+| MAX_STALE_RETENTION | 24 hours | How long an expired entry is kept, so a failed live search can still serve it flagged stale |
 | MAX_ENTRIES | 100 | Maximum cached queries per store |
 | ENABLED | true | Global cache toggle |
 | PRUNE_INTERVAL | 10 | Cache writes between LRU prune passes |

--- a/docs/search-history.md
+++ b/docs/search-history.md
@@ -55,7 +55,8 @@ Alongside the history database, MiniSearch uses a separate `SearchCacheDatabase`
 **Configuration:**
 | Parameter | Value | Description |
 |-----------|-------|-------------|
-| TTL | 15 minutes | Cache entry lifetime |
+| TTL | 15 minutes | Freshness window: a hit inside it skips the network |
+| MAX_STALE_RETENTION | 24 hours | How long an expired entry is kept, so a failed live search can serve it flagged stale |
 | MAX_ENTRIES | 100 | Maximum cached queries per store |
 | PRUNE_INTERVAL | 10 writes | Cache writes between LRU prune passes |
 | REQUEST_TIMEOUT | 30,000 ms | Search request timeout |

--- a/docs/security.md
+++ b/docs/security.md
@@ -54,7 +54,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 ## Data Protection
 
 - **Access Key Hashing**: Access keys hashed using argon2id before storage (via hash-wasm)
-- **TTL-based Cleanup**: Automatic cleanup of cached data
+- **Bounded Local Result Retention**: Results are kept at most 24 hours from cache write, of which the first 15 minutes count as fresh; past that they are served only as a clearly-flagged stale fallback when the live search fails,
 - **No PII Collection**: No personally identifiable information stored
 - **User Control**: Users can export and delete all their data
 

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -76,6 +76,7 @@ All state channels are defined in `client/modules/pubSub.ts`:
 | `llmTextSearchResultsPubSub` | `TextSearchResults` | LLM-reranked text results | Internal use |
 | `imageSearchResultsPubSub` | `ImageSearchResults` | Image search results | ImageResultsSection |
 | `textSearchStatePubSub` | `SearchState` | Text search state: `"idle" \| "running" \| "failed" \| "completed"` | SearchResultsSection, LoadingIndicators |
+| `textSearchStalePubSub` | `boolean` | Whether the text results on screen came from the cache because the live search failed | TextSearchResults |
 | `imageSearchStatePubSub` | `SearchState` | Image search state: `"idle" \| "running" \| "failed" \| "completed"` | ImageResultsSection |
 | `textGenerationStatePubSub` | `TextGenerationState` | AI generation state | AiResponseSection, StatusIndicators |
 | `modelLoadingProgressPubSub` | `number` | Model download progress (0-100) | AiResponseSection |

--- a/eval/promptConstruction.test.ts
+++ b/eval/promptConstruction.test.ts
@@ -36,6 +36,7 @@ vi.mock("../client/modules/pubSub", () => ({
   getPageContents: () => state.pageContents,
   getQuery: () => state.query,
   getSearchPromise: vi.fn(),
+  getTextSearchStale: () => false,
   updateTextGenerationState: vi.fn(),
 }));
 

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -193,13 +193,16 @@ describe("retry logic", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
-  it("retries an empty response with unresponsive engines and returns results on eventual success", async () => {
+  it("retries an empty response with a transiently unresponsive engine and returns results on eventual success", async () => {
     fetchMock
       .mockResolvedValueOnce(
         createMockResponse(
           JSON.stringify({
             results: [],
-            unresponsive_engines: [["google", "CAPTCHA"]],
+            // A timeout is transient: it can clear inside the backoff, so the
+            // search keeps the retry budget (unlike a suspension, which fails
+            // fast). See the fail-fast test below for the suspended case.
+            unresponsive_engines: [["google", "Timeout"]],
           }),
         ),
       )
@@ -216,6 +219,59 @@ describe("retry logic", () => {
     // A search that recovers on a retry is a search, not a failure.
     expect(getSearchesWithUnresponsiveEnginesSinceLastRestart()).toBe(
       searchesWithUnresponsiveEngines,
+    );
+  });
+
+  it("keeps the retry budget when the unresponsive engine reports a non-suspending error", async () => {
+    // "server API error" is not a suspension in SearXNG's exception
+    // vocabulary, so the search must not fail fast and has to spend the
+    // backoff like any transient failure.
+    fetchMock.mockResolvedValue(
+      createMockResponse(
+        JSON.stringify({
+          results: [],
+          unresponsive_engines: [["google", "server API error"]],
+        }),
+      ),
+    );
+
+    const promise = fetchSearXNG("test", "text");
+    const outcome = expect(promise).rejects.toThrow(
+      "Unresponsive engines: google (server API error)",
+    );
+    await vi.runAllTimersAsync();
+    await outcome;
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("fails fast without retrying when every unresponsive engine is under a long suspension", async () => {
+    fetchMock.mockResolvedValue(
+      createMockResponse(
+        JSON.stringify({
+          results: [],
+          unresponsive_engines: [
+            ["brave", "Suspended: too many requests"],
+            ["duckduckgo", "CAPTCHA"],
+          ],
+        }),
+      ),
+    );
+    const searchesWithUnresponsiveEngines =
+      getSearchesWithUnresponsiveEnginesSinceLastRestart();
+
+    const promise = fetchSearXNG("test", "text");
+    const outcome = expect(promise).rejects.toThrow(
+      "Unresponsive engines: brave (Suspended: too many requests), duckduckgo (CAPTCHA)",
+    );
+    // No backoff to drain: the all-suspended set throws on the first attempt
+    // rather than spending the retry budget it could not possibly outlast.
+    await vi.runAllTimersAsync();
+    await outcome;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getSearchesWithUnresponsiveEnginesSinceLastRestart()).toBe(
+      searchesWithUnresponsiveEngines + 1,
     );
   });
 
@@ -409,7 +465,7 @@ describe("graceful degradation", () => {
       createMockResponse(
         JSON.stringify({
           results: [],
-          unresponsive_engines: [["google", "CAPTCHA"]],
+          unresponsive_engines: [["google", "Timeout"]],
         }),
       ),
     );
@@ -418,14 +474,15 @@ describe("graceful degradation", () => {
       getSearchesWithUnresponsiveEnginesSinceLastRestart();
 
     const search = fetchSearXNG("failure injection", "text", 30, breaker);
-    const outcome = expect(search).rejects.toThrow("google (CAPTCHA)");
+    const outcome = expect(search).rejects.toThrow("google (Timeout)");
     await vi.advanceTimersByTimeAsync(RETRY_BACKOFF_TOTAL_MS);
     await outcome;
 
     expect(breaker.getState("searxng")).toBe("OPEN");
-    // Some of the reported cases (timeouts, rate-limit windows) clear inside
-    // the backoff, so the case gets the full retry budget before the search
-    // fails, and the counter lands when the attempts run out.
+    // A transient reason (a timeout) can clear inside the backoff, so this
+    // case keeps the full retry budget before the search fails, and the
+    // counter lands when the attempts run out. A suspended set would fail
+    // fast instead; that is covered separately in the retry logic tests.
     expect(fetchMock).toHaveBeenCalledTimes(ATTEMPTS_PER_CALL);
     expect(getSearchesWithoutResultsSinceLastRestart()).toBe(
       searchesWithoutResults,

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -135,6 +135,34 @@ export function describeUnresponsiveEngines(
     .join(", ");
 }
 
+const SUSPENSION_REASON = /captcha|too many request|access denied/i;
+
+/**
+ * Whether every unresponsive engine is under a long suspension rather than a
+ * transient error, so the whole set cannot recover within the retry backoff.
+ */
+function allEnginesSuspended(unresponsiveEngines: unknown): boolean {
+  if (!Array.isArray(unresponsiveEngines) || unresponsiveEngines.length === 0) {
+    return false;
+  }
+  return unresponsiveEngines.every((entry) => {
+    const reason = Array.isArray(entry) ? entry[1] : undefined;
+    return typeof reason === "string" && SUSPENSION_REASON.test(reason);
+  });
+}
+
+/**
+ * Counts the search as an unresponsive-engine failure and throws the error the
+ * endpoint turns into a non-200. The fail-fast and the retry-exhausted paths
+ * both end here, so a search costs one user-visible failure either way.
+ */
+function failWithUnresponsiveEngines(reason: string): never {
+  incrementSearchesWithUnresponsiveEnginesSinceLastRestart();
+  throw new Error(
+    `No results returned from SearXNG. Unresponsive engines: ${reason}`,
+  );
+}
+
 async function performSearch(
   query: string,
   searchType: SearchType,
@@ -174,19 +202,18 @@ async function performSearch(
       // rate-limited, suspended or CAPTCHA-challenged, so the only sign that
       // the search layer is down arrives in `unresponsive_engines`. Returned as
       // an empty array it is indistinguishable from a query that genuinely
-      // matches nothing. Some of the reported cases (timeouts, rate-limit
-      // windows) clear inside the backoff, so the case takes the same retry
-      // budget as a 500.
+      // matches nothing.
       if (reason) {
+        if (allEnginesSuspended(data.unresponsive_engines)) {
+          failWithUnresponsiveEngines(reason);
+        }
+
         if (attempt < MAX_RETRIES) {
           retryReason = `returned no results (${reason})`;
           continue;
         }
 
-        incrementSearchesWithUnresponsiveEnginesSinceLastRestart();
-        throw new Error(
-          `No results returned from SearXNG. Unresponsive engines: ${reason}`,
-        );
+        failWithUnresponsiveEngines(reason);
       }
 
       incrementSearchesWithoutResultsSinceLastRestart();


### PR DESCRIPTION
## Description

Currently, when every text-search engine fails (a rate limit or CAPTCHA suspends a SearXNG engine for an hour to a day), the search fails outright, even if the exact same query has a cached result, and the AI response has nothing to ground on.

This PR does three things:

- Serves the cached results of the same query when the live search fails, flagged stale (a banner in the results list and a disclaimer in the LLM prompt, so the model knows the results may be out of date).
- Falls back to the image search when the text search fails and image search is on: the answer waits for the image results and grounds on their titles and URLs, tagged `(image)` in the prompt.
- Makes the server fail fast (1 request, no backoff) when every unresponsive engine is under a long suspension, since they will not recover within the retry window.

## Where to start

Most of the diff is tests (11 new ones, +354 lines). The behavior changes are in `client/modules/search.ts` (stale fallback plus a read-time age check), `client/modules/textGeneration.ts` (the image-fallback grounding, and a guard so an older search cannot repopulate a newer one's grounding channel), `server/webSearchService.ts` (the fail-fast) and the banner in `client/components/Search/Results/Textual/TextSearchResults.tsx`.

## How to test

1. Run `npm test` (the new tests cover the stale fallback, the image grounding and the fail-fast).
2. Run `npm run lint`.
3. Note: a real outage needs the engines rate-limited or CAPTCHA'd, which cannot be forced locally, so the degraded UI is covered by tests only for now (the cases are in the `docs/failure-injection.md` matrix).