### PR TITLE
Load image result thumbnails lazily through a /thumbnail endpoint

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -129,6 +129,7 @@ Need to:
 
 ### Server Modules
 - `server/searchEndpointServerHook.ts` - `/search/text` and `/search/images` endpoints
+- `server/thumbnailEndpointServerHook.ts` - `/thumbnail` endpoint: one search-result thumbnail at a time, token-gated, with an in-process LRU in front of the upstream host
 - `server/internalApiEndpointServerHook.ts` - `/inference` proxy to self-hosted API
 - `server/validateAccessKeyServerHook.ts` - Access key validation endpoint
 - `server/statusEndpointServerHook.ts` - `/status` health check endpoint

--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -81,7 +81,8 @@ describe("ImageResultsList", () => {
   it("loads each tile from the /thumbnail endpoint once the src resolves", async () => {
     renderImageResultsList();
 
-    const img = await screen.findByRole("img");
+    // Both tiles resolve, so the query must allow a match on either.
+    const [img] = await screen.findAllByRole("img");
     expect(getThumbnailSrc).toHaveBeenCalledWith(
       "https://example.com/first.jpg",
     );
@@ -112,7 +113,7 @@ describe("ImageResultsList", () => {
   it("shows the host name when a thumbnail fails to load", async () => {
     renderImageResultsList();
 
-    const img = await screen.findByRole("img");
+    const [img] = await screen.findAllByRole("img");
     img.dispatchEvent(new Event("error"));
 
     // The second tile still loads, so exactly one img survives the failure.
@@ -120,6 +121,25 @@ describe("ImageResultsList", () => {
     expect(
       screen.getByRole("button", { name: "Open image preview: First image" }),
     ).toHaveTextContent("example.com");
+  });
+
+  it("shows the host-name placeholder in the lightbox when the thumbnail failed", async () => {
+    const user = userEvent.setup();
+    renderImageResultsList();
+
+    const [img] = await screen.findAllByRole("img");
+    img.dispatchEvent(new Event("error"));
+    await waitFor(() => expect(screen.getAllByRole("img")).toHaveLength(1));
+
+    await user.click(
+      screen.getByRole("button", { name: "Open image preview: First image" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    const slideImage = dialog.querySelector(".yarl__slide_current img");
+    const src = slideImage?.getAttribute("src") ?? "";
+    expect(src).toContain("data:image/svg+xml");
+    expect(src).toContain("example.com");
   });
 
   it("opens the focused thumbnail in the lightbox from the keyboard", async () => {

--- a/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.test.tsx
@@ -1,13 +1,34 @@
 import { MantineProvider } from "@mantine/core";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getThumbnailSrc } from "@/modules/thumbnailUrls";
 import type { ImageSearchResult } from "@/modules/types";
 import { setReducedMotionPreference } from "../testUtils";
 import ImageResultsList from "./ImageResultsList";
 
+vi.mock("@/modules/thumbnailUrls", () => ({
+  getThumbnailSrc: vi.fn(),
+}));
+
+// Mirrors the real module's contract closely enough for the component: an
+// empty thumbnail yields null, everything else comes back as a /thumbnail URL.
+function thumbnailSrcFor(thumbnailUrl: string): string | null {
+  if (!thumbnailUrl) return null;
+  const url = new URL("/thumbnail", "http://localhost:3000");
+  url.searchParams.set("u", thumbnailUrl);
+  return url.toString();
+}
+
+beforeEach(() => {
+  vi.mocked(getThumbnailSrc).mockImplementation(async (thumbnailUrl) =>
+    thumbnailUrl ? thumbnailSrcFor(thumbnailUrl) : null,
+  );
+});
+
 afterEach(() => {
   setReducedMotionPreference(false);
+  vi.clearAllMocks();
 });
 
 const imageResults: ImageSearchResult[] = [
@@ -55,6 +76,50 @@ describe("ImageResultsList", () => {
         name: "Open image preview: First image",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("loads each tile from the /thumbnail endpoint once the src resolves", async () => {
+    renderImageResultsList();
+
+    const img = await screen.findByRole("img");
+    expect(getThumbnailSrc).toHaveBeenCalledWith(
+      "https://example.com/first.jpg",
+    );
+    expect(img.getAttribute("src")).toBe(
+      thumbnailSrcFor("https://example.com/first.jpg"),
+    );
+  });
+
+  it("shows the host name for a result without a thumbnail", async () => {
+    render(
+      <MantineProvider>
+        <ImageResultsList
+          imageResults={[
+            [
+              "No thumbnail",
+              "https://example.com/no-thumbnail",
+              "",
+              "https://source.example.com/no-thumbnail",
+            ],
+          ]}
+        />
+      </MantineProvider>,
+    );
+
+    await screen.findByText("example.com");
+  });
+
+  it("shows the host name when a thumbnail fails to load", async () => {
+    renderImageResultsList();
+
+    const img = await screen.findByRole("img");
+    img.dispatchEvent(new Event("error"));
+
+    // The second tile still loads, so exactly one img survives the failure.
+    await waitFor(() => expect(screen.getAllByRole("img")).toHaveLength(1));
+    expect(
+      screen.getByRole("button", { name: "Open image preview: First image" }),
+    ).toHaveTextContent("example.com");
   });
 
   it("opens the focused thumbnail in the lightbox from the keyboard", async () => {

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -52,7 +52,10 @@ const tileBoxStyle = {
  * grid's fallback tile; a `data:` URL in an `<img>` cannot execute anything.
  */
 function hostNamePlaceholder(hostName: string): string {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360"><text x="50%" y="50%" fill="#888888" font-family="sans-serif" font-size="24" text-anchor="middle" dominant-baseline="middle">${hostName}</text></svg>`;
+  // The host is interpolated into markup; escape the characters that could
+  // close the <text> node.
+  const safe = hostName.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360"><text x="50%" y="50%" fill="#888888" font-family="sans-serif" font-size="24" text-anchor="middle" dominant-baseline="middle">${safe}</text></svg>`;
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -45,6 +45,17 @@ const tileBoxStyle = {
   border: `${rem(2)} solid var(--mantine-color-default-border)`,
 } as const;
 
+/**
+ * A lightbox slide without a loaded thumbnail would render as a blank or
+ * broken image, and the result's source URL is not always an image (video
+ * results point at a page). An inert SVG carrying the host name matches the
+ * grid's fallback tile; a `data:` URL in an `<img>` cannot execute anything.
+ */
+function hostNamePlaceholder(hostName: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360"><text x="50%" y="50%" fill="#888888" font-family="sans-serif" font-size="24" text-anchor="middle" dominant-baseline="middle">${hostName}</text></svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
 export default function ImageResultsList({
   imageResults,
 }: {
@@ -191,11 +202,12 @@ export default function ImageResultsList({
         plugins={[Captions]}
         index={state.lightboxIndex}
         slides={imageResults.map(([title, url, , sourceUrl]) => ({
-          // The grid's thumbnail when it loaded; when it did not, the full
-          // image behind the result is the best stand-in the lightbox has.
-          src: failedThumbnails[url]
-            ? sourceUrl
-            : (thumbnailSrcs[url] ?? sourceUrl),
+          // The grid's thumbnail when it loaded; when it did not, the same
+          // host-name placeholder the tile shows.
+          src:
+            thumbnailSrcs[url] && !failedThumbnails[url]
+              ? thumbnailSrcs[url]
+              : hostNamePlaceholder(getHostname(url)),
           alt: title,
           description: (
             <Stack align="center" gap="md">

--- a/client/components/Search/Results/Graphical/ImageResultsList.tsx
+++ b/client/components/Search/Results/Graphical/ImageResultsList.tsx
@@ -1,8 +1,10 @@
 import { Carousel } from "@mantine/carousel";
 import {
+  Box,
   Button,
   Group,
   rem,
+  Skeleton,
   Stack,
   Text,
   Transition,
@@ -19,12 +21,29 @@ import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/captions.css";
 import { addLogEntry } from "@/modules/logEntries";
 import { getHostname } from "@/modules/stringFormatters";
+import { getThumbnailSrc } from "@/modules/thumbnailUrls";
 
 interface ImageResultsState {
   isLightboxOpen: boolean;
   lightboxIndex: number;
   canStartTransition: boolean;
 }
+
+const imageStyle = {
+  objectFit: "cover",
+  height: rem(180),
+  width: rem(240),
+  borderRadius: rem(4),
+  border: `${rem(2)} solid var(--mantine-color-default-border)`,
+} as const;
+
+/** Matches the image box, so a tile keeps its size from skeleton to image. */
+const tileBoxStyle = {
+  height: rem(180),
+  width: rem(240),
+  borderRadius: rem(4),
+  border: `${rem(2)} solid var(--mantine-color-default-border)`,
+} as const;
 
 export default function ImageResultsList({
   imageResults,
@@ -37,10 +56,45 @@ export default function ImageResultsList({
     lightboxIndex: 0,
     canStartTransition: false,
   });
+  const [thumbnailSrcs, setThumbnailSrcs] = useState<
+    Record<string, string | null>
+  >({});
+  const [failedThumbnails, setFailedThumbnails] = useState<
+    Record<string, boolean>
+  >({});
 
   useEffect(() => {
     setState((prev) => ({ ...prev, canStartTransition: true }));
   }, []);
+
+  // The search response carries thumbnail URLs, not bytes, so the grid can
+  // show as soon as the results arrive. Each tile then loads on its own from
+  // the server's /thumbnail endpoint, and a dead host costs one placeholder
+  // tile instead of delaying the whole response.
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const entries = await Promise.all(
+        imageResults.map(async ([, url, thumbnailUrl]) => {
+          try {
+            return [url, await getThumbnailSrc(thumbnailUrl)] as const;
+          } catch {
+            return [url, null] as const;
+          }
+        }),
+      );
+
+      if (!cancelled) {
+        setThumbnailSrcs(Object.fromEntries(entries));
+        setFailedThumbnails({});
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageResults]);
 
   const handleImageClick = (index: number) => {
     setState((prev) => ({
@@ -50,13 +104,51 @@ export default function ImageResultsList({
     }));
   };
 
-  const imageStyle = {
-    objectFit: "cover",
-    height: rem(180),
-    width: rem(240),
-    borderRadius: rem(4),
-    border: `${rem(2)} solid var(--mantine-color-default-border)`,
-  } as const;
+  const markThumbnailFailed = (url: string) => {
+    setFailedThumbnails((prev) => ({ ...prev, [url]: true }));
+  };
+
+  const renderTile = (title: string, url: string) => {
+    const tileSrc = failedThumbnails[url] ? null : thumbnailSrcs[url];
+
+    if (tileSrc) {
+      return (
+        <img
+          alt={title}
+          src={tileSrc}
+          loading="lazy"
+          style={imageStyle}
+          onError={() => markThumbnailFailed(url)}
+        />
+      );
+    }
+
+    // `null` means the result has no thumbnail, or the load failed: the host
+    // name is the most that can be shown. `undefined` means the src is still
+    // being resolved, so the tile keeps a skeleton in the meantime.
+    if (thumbnailSrcs[url] === undefined) {
+      return (
+        <Box style={tileBoxStyle}>
+          <Skeleton style={{ height: "100%", width: "100%" }} />
+        </Box>
+      );
+    }
+
+    return (
+      <Box
+        style={{
+          ...tileBoxStyle,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text size="xs" c="dimmed" truncate>
+          {getHostname(url)}
+        </Text>
+      </Box>
+    );
+  };
 
   return (
     <>
@@ -70,7 +162,7 @@ export default function ImageResultsList({
           loop: true,
         }}
       >
-        {imageResults.map(([title, url, thumbnail], index) => (
+        {imageResults.map(([title, url], index) => (
           <Transition
             key={url}
             mounted={state.canStartTransition}
@@ -86,12 +178,7 @@ export default function ImageResultsList({
                   className={classes.thumbnailButton}
                   onClick={() => handleImageClick(index)}
                 >
-                  <img
-                    alt={title}
-                    src={thumbnail}
-                    loading="lazy"
-                    style={imageStyle}
-                  />
+                  {renderTile(title, url)}
                 </UnstyledButton>
               </Carousel.Slide>
             )}
@@ -103,8 +190,12 @@ export default function ImageResultsList({
         close={() => setState((prev) => ({ ...prev, isLightboxOpen: false }))}
         plugins={[Captions]}
         index={state.lightboxIndex}
-        slides={imageResults.map(([title, url, thumbnail, sourceUrl]) => ({
-          src: thumbnail,
+        slides={imageResults.map(([title, url, , sourceUrl]) => ({
+          // The grid's thumbnail when it loaded; when it did not, the full
+          // image behind the result is the best stand-in the lightbox has.
+          src: failedThumbnails[url]
+            ? sourceUrl
+            : (thumbnailSrcs[url] ?? sourceUrl),
           alt: title,
           description: (
             <Stack align="center" gap="md">
@@ -119,20 +210,22 @@ export default function ImageResultsList({
                 </Text>
               )}
               <Group align="center" justify="center" gap="xs">
-                <Button
-                  variant="subtle"
-                  component="a"
-                  size="xs"
-                  href={sourceUrl}
-                  target="_blank"
-                  title="Click to see the image in full size"
-                  rel="noopener noreferrer"
-                  onClick={() => {
-                    addLogEntry("User visited an image result in full size");
-                  }}
-                >
-                  View in full resolution
-                </Button>
+                {sourceUrl && (
+                  <Button
+                    variant="subtle"
+                    component="a"
+                    size="xs"
+                    href={sourceUrl}
+                    target="_blank"
+                    title="Click to see the image in full size"
+                    rel="noopener noreferrer"
+                    onClick={() => {
+                      addLogEntry("User visited an image result in full size");
+                    }}
+                  >
+                    View in full resolution
+                  </Button>
+                )}
                 <Button
                   variant="subtle"
                   component="a"

--- a/client/modules/thumbnailUrls.test.ts
+++ b/client/modules/thumbnailUrls.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./searchTokenHash", () => ({
+  getSearchTokenHash: vi.fn(),
+}));
+
+import { getSearchTokenHash } from "./searchTokenHash";
+import { getThumbnailSrc } from "./thumbnailUrls";
+
+describe("getThumbnailSrc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSearchTokenHash).mockResolvedValue("token-hash");
+  });
+
+  it("returns null for a result without a thumbnail", async () => {
+    expect(await getThumbnailSrc("")).toBeNull();
+    expect(getSearchTokenHash).not.toHaveBeenCalled();
+  });
+
+  it("uses a cached data URL as is", async () => {
+    const dataUrl = "data:image/jpeg;base64,ASDTQW";
+
+    expect(await getThumbnailSrc(dataUrl)).toBe(dataUrl);
+    expect(getSearchTokenHash).not.toHaveBeenCalled();
+  });
+
+  it("wraps a thumbnail URL in the /thumbnail endpoint with the search token", async () => {
+    const src = await getThumbnailSrc("https://thumbs.example.com/a.jpg");
+
+    const url = new URL(src as string);
+    expect(url.pathname).toBe("/thumbnail");
+    expect(url.searchParams.get("u")).toBe("https://thumbs.example.com/a.jpg");
+    expect(url.searchParams.get("token")).toBe("token-hash");
+  });
+
+  it("computes the search token hash once and reuses it for the next thumbnail", async () => {
+    // A fresh module pair: the token promise is module state, and an earlier
+    // test in this file may already have filled it.
+    vi.resetModules();
+    const freshHash = vi.mocked(
+      (await import("./searchTokenHash")).getSearchTokenHash,
+    );
+    const freshGetThumbnailSrc = (await import("./thumbnailUrls"))
+      .getThumbnailSrc;
+    freshHash.mockResolvedValue("token-hash");
+
+    await Promise.all([
+      freshGetThumbnailSrc("https://thumbs.example.com/a.jpg"),
+      freshGetThumbnailSrc("https://thumbs.example.com/b.jpg"),
+    ]);
+
+    expect(freshHash).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the token hash after a rejection instead of caching the failure", async () => {
+    vi.resetModules();
+    const freshHash = vi.mocked(
+      (await import("./searchTokenHash")).getSearchTokenHash,
+    );
+    const freshGetThumbnailSrc = (await import("./thumbnailUrls"))
+      .getThumbnailSrc;
+    freshHash.mockRejectedValueOnce(new Error("hash wasm down"));
+    freshHash.mockResolvedValueOnce("token-hash");
+
+    await expect(
+      freshGetThumbnailSrc("https://thumbs.example.com/a.jpg"),
+    ).rejects.toThrow("hash wasm down");
+    await expect(
+      freshGetThumbnailSrc("https://thumbs.example.com/a.jpg"),
+    ).resolves.toContain("/thumbnail");
+
+    expect(freshHash).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/modules/thumbnailUrls.ts
+++ b/client/modules/thumbnailUrls.ts
@@ -1,0 +1,40 @@
+import { getSearchTokenHash } from "./searchTokenHash";
+
+/**
+ * The search token hash is stable for the server's lifetime, so the argon2
+ * work happens once per session and every thumbnail reuses the promise. A
+ * rejection clears the cache so the next thumbnail retries instead of
+ * inheriting a permanently dead promise.
+ */
+let searchTokenPromise: Promise<string> | null = null;
+
+function getSearchToken(): Promise<string> {
+  searchTokenPromise ??= getSearchTokenHash().catch((error) => {
+    searchTokenPromise = null;
+    throw error;
+  });
+  return searchTokenPromise;
+}
+
+/**
+ * Resolves the `src` of an image result's thumbnail.
+ *
+ * An empty string means the result carried no thumbnail and there is nothing
+ * to load. A `data:` URL is used as is: entries cached by an older build
+ * stored the thumbnail bytes in the result itself, and they would not pass
+ * the server's URL checks. Everything else goes through the server's
+ * `/thumbnail` endpoint, which applies the SSRF guard and caches the image,
+ * so the browser never fetches a search-result URL directly.
+ */
+export async function getThumbnailSrc(
+  thumbnailUrl: string,
+): Promise<string | null> {
+  if (!thumbnailUrl) return null;
+  if (thumbnailUrl.startsWith("data:")) return thumbnailUrl;
+
+  const endpointUrl = new URL("/thumbnail", self.location.origin);
+  endpointUrl.searchParams.set("u", thumbnailUrl);
+  endpointUrl.searchParams.set("token", await getSearchToken());
+
+  return endpointUrl.toString();
+}

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -23,10 +23,15 @@ needed.
 | SearXNG is down | `/search/text` and `/search/images` answer HTTP 502 with a JSON error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Reranker is not ready | Results served in SearXNG order, HTTP 200 | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Reranking throws mid-request | Results served in SearXNG order, HTTP 200 | `server/searchEndpointServerHook.test.ts` › graceful degradation |
-| Reranker is not ready on an image search | Images still served with thumbnails | `server/searchEndpointServerHook.test.ts` › graceful degradation |
-| Reranking throws on an image search | Images still served with thumbnails | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Reranker is not ready on an image search | Images still served, with the thumbnail URLs as SearXNG sent them | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Reranking throws on an image search | Images still served, with the thumbnail URLs as SearXNG sent them | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Reranker returns a URL absent from the result set | That image is dropped | `server/searchEndpointServerHook.test.ts` › graceful degradation |
-| Thumbnail host never answers | Request aborted after the timeout, image dropped | `server/searchEndpointServerHook.test.ts` › graceful degradation |
+| Thumbnail host never answers | Request aborted after the timeout, `/thumbnail` answers HTTP 502 and the tile shows the host name | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail URL resolves into a private range | Refused before any request, `/thumbnail` answers HTTP 403 | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail redirects into a private range | Redirect not followed, HTTP 403 | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail upstream answers with a non-image or an empty body | `/thumbnail` answers HTTP 502, the tile shows the host name | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail body exceeds the byte cap | Body truncated at the cap and served | `server/thumbnailEndpointServerHook.test.ts` |
+| A tile's `/thumbnail` request fails in the browser | That tile shows the host name, the rest of the grid is untouched | `client/components/Search/Results/Graphical/ImageResultsList.test.tsx` |
 | Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |
 | Keyword fallback also returns nothing | Text search state stays `completed` with the no-results alert | `client/modules/textGeneration.degradation.test.ts` |

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -27,10 +27,14 @@ needed.
 | Reranking throws on an image search | Images still served, with the thumbnail URLs as SearXNG sent them | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Reranker returns a URL absent from the result set | That image is dropped | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Thumbnail host never answers | Request aborted after the timeout, `/thumbnail` answers HTTP 502 and the tile shows the host name | `server/thumbnailEndpointServerHook.test.ts` |
+| DNS lookup for a thumbnail never settles | Bounded by the same deadline as the fetch, `/thumbnail` answers HTTP 502 | `server/thumbnailEndpointServerHook.test.ts` |
 | Thumbnail URL resolves into a private range | Refused before any request, `/thumbnail` answers HTTP 403 | `server/thumbnailEndpointServerHook.test.ts` |
 | Thumbnail redirects into a private range | Redirect not followed, HTTP 403 | `server/thumbnailEndpointServerHook.test.ts` |
-| Thumbnail upstream answers with a non-image or an empty body | `/thumbnail` answers HTTP 502, the tile shows the host name | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail redirect carries a malformed Location | Not followed, HTTP 502, no unhandled rejection | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail upstream answers with a non-raster or an empty body (SVG included) | `/thumbnail` answers HTTP 502, the tile shows the host name | `server/thumbnailEndpointServerHook.test.ts` |
 | Thumbnail body exceeds the byte cap | Body truncated at the cap and served | `server/thumbnailEndpointServerHook.test.ts` |
+| Thumbnail upstream refuses once, then recovers | The failure is not cached; the next tile load fetches again and serves | `server/thumbnailEndpointServerHook.test.ts` |
+| `/thumbnail` budget is spent | HTTP 429 for the tiles only; the search budget is a separate limiter | `server/verifyTokenAndRateLimit.test.ts` |
 | A tile's `/thumbnail` request fails in the browser | That tile shows the host name, the rest of the grid is untouched | `client/components/Search/Results/Graphical/ImageResultsList.test.tsx` |
 | Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |

--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -34,7 +34,7 @@ needed.
 | Thumbnail upstream answers with a non-raster or an empty body (SVG included) | `/thumbnail` answers HTTP 502, the tile shows the host name | `server/thumbnailEndpointServerHook.test.ts` |
 | Thumbnail body exceeds the byte cap | Body truncated at the cap and served | `server/thumbnailEndpointServerHook.test.ts` |
 | Thumbnail upstream refuses once, then recovers | The failure is not cached; the next tile load fetches again and serves | `server/thumbnailEndpointServerHook.test.ts` |
-| `/thumbnail` budget is spent | HTTP 429 for the tiles only; the search budget is a separate limiter | `server/verifyTokenAndRateLimit.test.ts` |
+| `/thumbnail` budget is spent | HTTP 429 for the tiles only; the search budget is a separate limiter | `server/handleTokenVerification.test.ts`, `server/thumbnailEndpointServerHook.test.ts` |
 | A tile's `/thumbnail` request fails in the browser | That tile shows the host name, the rest of the grid is untouched | `client/components/Search/Results/Graphical/ImageResultsList.test.tsx` |
 | Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -63,7 +63,7 @@ MiniSearch employs a dual-layer persistence approach:
 - **IndexedDB** - Local storage for search history, settings, cached results, and saved AI transcripts
 - **TTL-based caching** - 15-minute freshness cache for search results to minimize API calls, with a 24-hour stale retention as a fallback when the live search fails
 
-Search history is backed by a Dexie database that keeps three coordinated tables (search runs, LLM responses, chat turns) along with automatic retention/max-entry cleanup. See `docs/search-history.md` for the complete schema and invariants. The caching layer minimizes redundant API calls to SearXNG while maintaining fresh results. Search results cached in IndexedDB have a 15-minute freshness TTL, after which new searches bypass the cache; an expired entry is kept for 24 hours so a failed live search can serve it, flagged stale, instead of failing.
+Search history is backed by a Dexie database that keeps three coordinated tables (search runs, LLM responses, chat turns) along with automatic retention/max-entry cleanup. See `docs/search-history.md` for the complete schema and invariants. The caching layer minimizes redundant API calls to SearXNG while maintaining fresh results. Search results cached in IndexedDB have a 15-minute freshness TTL, after which new searches bypass the cache; an expired entry is kept for 24 hours so a failed live search can serve it, flagged stale, instead of failing. Cached image results store the thumbnail URLs rather than the bytes, so a thumbnail host whose URLs expire or are signed shorter than the retention window shows host-name tiles instead of images on a stale restore.
 
 Long-running chat sessions use an in-memory conversation summary that rolls excess turns into a structured digest before continuing generation. Details about the token budgeting and summary refresh flow live in `docs/conversation-memory.md`.
 
@@ -318,7 +318,7 @@ verification, the funnel `/search/text`, `/search/images`, `/page-content` and
 | `reasons.invalidToken` | number | A token that failed verification, which is what probing looks like |
 | `bySurface` | object | `authorized` and `rejected` per endpoint family: `search`, `pageContent`, `thumbnail`, `inference`, `other` |
 | `rejectedTokenCacheHits` | number | Rejections served from the rejected-token cache without a second argon2 verification |
-| `limiter` | object | The limiter's `points` and `durationSeconds`, without which a rejection count says nothing |
+| `limiter` | object | The shared limiter's `points` and `durationSeconds`, plus the separate `thumbnail` budget behind `/thumbnail`, without which a rejection count says nothing |
 
 `authorized` plus every entry of `reasons` sums to `requests`, and each half of
 `bySurface` sums to its side of that, on the same principle as `pageReads`.
@@ -396,7 +396,7 @@ way `pageReads` does:
 | `reranker.fallbackApplied` | number | `minPercentageFallback`: a large share means the deviation threshold is emptying batches the fallback then has to rescue |
 | `reranker.skippedUnhealthy` | number | Nothing; searches served in SearXNG's own order because the model was not loaded |
 | `reranker.failed` | number | Nothing; the same, because reranking threw |
-| `thumbnails.requested` | number | Nothing; the denominator for the two below; every verified `/thumbnail` request, cache hits included |
+| `thumbnails.requested` | number | Nothing; the denominator for the two below; every verified `/thumbnail` request, cache hits included. Before the endpoint existed this counted image results in a search response, so the served share cannot be trended across that deploy |
 | `thumbnails.dropped` | number | `THUMBNAIL_TIMEOUT_MS` and `MAX_THUMBNAIL_BYTES` in `thumbnailEndpointServerHook.ts`: every one of these is a tile the user saw as a placeholder |
 | `thumbnails.blocked` | number | The SSRF guard, as the share of thumbnails pointing outside public space |
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -97,7 +97,7 @@ The system executes two parallel flows when a user submits a query:
 4. Server verifies request token via `searchToken.ts` (CSRF protection)
 5. `webSearchService.ts` forwards query to SearXNG at `http://127.0.0.1:8888`
 6. Raw results are deduplicated, cleaned, and optionally reranked
-7. Thumbnails are proxied and converted to base64 Data URLs to avoid CORS issues
+7. Image results keep the thumbnail URLs SearXNG returned; the client loads each tile on its own from `/thumbnail`, so the response does not wait on any thumbnail host
 8. Results returned as structured JSON and cached in IndexedDB (15-minute freshness TTL)
 
 ### AI Generation Flow
@@ -119,7 +119,7 @@ The `textGeneration` module orchestrates the entire search-to-response flow, man
 - **Retry Logic**: Exponential backoff for HTTP 500 errors, up to 3 retries
 - **Fail-Fast on Suspending Engines**: An empty response in which every unresponsive engine is under a long suspension (CAPTCHA, rate limit, access denied; SearXNG suspends them for an hour to a day) throws on the first attempt instead of spending the retry budget, which it could not possibly outlast. Transient engine errors (timeouts, server API errors) keep the full retry budget.
 - **Content Processing**: Converts HTML results to plain text, strips emojis for cleaner output
-- **Thumbnail Proxying**: Server fetches external thumbnails and converts to base64 Data URLs, avoiding CORS issues and improving loading stability
+- **Lazy Thumbnail Loading**: The search response returns thumbnail URLs as SearXNG sent them; the client then loads each tile from `/thumbnail`, which applies the SSRF guard and serves from an in-process LRU, so a dead thumbnail host delays one tile instead of the whole grid
 
 ### Search Token Lifecycle
 
@@ -251,7 +251,7 @@ The `/status` endpoint returns a JSON object:
 | `inference` | object | AI answer counters since last restart, see below |
 | `searches` | object | Search timing, circuit state and grounding, see below |
 | `reranker` | object | Reranking cost and effect, see below |
-| `thumbnails` | object | Image thumbnail fetches, see below |
+| `thumbnails` | object | `/thumbnail` request outcomes, see below |
 | `build.timestamp` | string | ISO 8601 build time |
 | `build.gitCommit` | string | Short Git commit hash |
 
@@ -268,8 +268,9 @@ whether the case is being over-classified. It undercounts a sustained
 outage, where the circuit breaker short-circuits before `performSearch` is
 reached, and it does not count a search that recovered on a retry at all,
 which is the point of the retry. The discarded count covers text searches only,
-because an image result is never dropped at this stage: an unusable
-thumbnail is dropped later, when `searchEndpointServerHook` fetches it.
+because an image result is never dropped at this stage: a thumbnail that
+cannot be loaded is dropped later, when the client fetches it from
+`/thumbnail`.
 
 `pageReads` reports what happened to the pages read for AI answers. Each field
 is attached to a constant that someone will want to move, which is the reason it
@@ -315,7 +316,7 @@ verification, the funnel `/search/text`, `/search/images`, `/page-content` and
 | `reasons.rateLimited` | number | Refused by the limiter before anything else ran |
 | `reasons.missingToken` | number | No token on the request, which is what an outdated client looks like |
 | `reasons.invalidToken` | number | A token that failed verification, which is what probing looks like |
-| `bySurface` | object | `authorized` and `rejected` per endpoint family: `search`, `pageContent`, `inference`, `other` |
+| `bySurface` | object | `authorized` and `rejected` per endpoint family: `search`, `pageContent`, `thumbnail`, `inference`, `other` |
 | `rejectedTokenCacheHits` | number | Rejections served from the rejected-token cache without a second argon2 verification |
 | `limiter` | object | The limiter's `points` and `durationSeconds`, without which a rejection count says nothing |
 
@@ -327,10 +328,11 @@ than adding to that sum.
 The limiter keys on the client IP and none of that reaches these counters: no
 address, no token, no query, no per-request timestamp. The cut is by reason and
 by surface, both properties of the request rather than of whoever sent it.
-`bySurface` is the one worth watching: all four endpoints share one budget and
-a single user action fans out into a text search, an image search and a
-page-content read, so its `authorized` side says where the budget goes and its
-`rejected` side says who pays for it running out.
+`bySurface` is the one worth watching: all five endpoints share one budget and
+a single user action fans out into a text search, an image search, the
+thumbnail loads behind the image grid and a page-content read, so its
+`authorized` side says where the budget goes and its `rejected` side says who
+pays for it running out.
 
 `inference` reports what happened to the AI answers served through
 `/inference`. Nothing about the conversation is kept, so the questions it can
@@ -394,8 +396,8 @@ way `pageReads` does:
 | `reranker.fallbackApplied` | number | `minPercentageFallback`: a large share means the deviation threshold is emptying batches the fallback then has to rescue |
 | `reranker.skippedUnhealthy` | number | Nothing; searches served in SearXNG's own order because the model was not loaded |
 | `reranker.failed` | number | Nothing; the same, because reranking threw |
-| `thumbnails.requested` | number | Nothing; the denominator for the two below |
-| `thumbnails.dropped` | number | `THUMBNAIL_TIMEOUT_MS` and `MAX_THUMBNAIL_BYTES`: every one of these is an image result the user never saw |
+| `thumbnails.requested` | number | Nothing; the denominator for the two below; every verified `/thumbnail` request, cache hits included |
+| `thumbnails.dropped` | number | `THUMBNAIL_TIMEOUT_MS` and `MAX_THUMBNAIL_BYTES` in `thumbnailEndpointServerHook.ts`: every one of these is a tile the user saw as a placeholder |
 | `thumbnails.blocked` | number | The SSRF guard, as the share of thumbnails pointing outside public space |
 
 `thumbnails.dropped` includes the blocked ones, so `requested` minus `dropped`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -397,8 +397,8 @@ way `pageReads` does:
 | `reranker.skippedUnhealthy` | number | Nothing; searches served in SearXNG's own order because the model was not loaded |
 | `reranker.failed` | number | Nothing; the same, because reranking threw |
 | `thumbnails.requested` | number | Nothing; the denominator for the two below; every verified `/thumbnail` request, cache hits included. Before the endpoint existed this counted image results in a search response, so the served share cannot be trended across that deploy |
-| `thumbnails.dropped` | number | `THUMBNAIL_TIMEOUT_MS` and `MAX_THUMBNAIL_BYTES` in `thumbnailEndpointServerHook.ts`: every one of these is a tile the user saw as a placeholder |
-| `thumbnails.blocked` | number | The SSRF guard, as the share of thumbnails pointing outside public space |
+| `thumbnails.dropped` | number | Every request that did not serve a tile: timeout, a non-raster or empty answer, or an address the guard refused (`MAX_THUMBNAIL_BYTES` is not one of these, a capped body is truncated and served): each is a tile the user saw as a placeholder |
+| `thumbnails.blocked` | number | The SSRF guard, as the share of thumbnails whose host is in private space or does not resolve |
 
 `thumbnails.dropped` includes the blocked ones, so `requested` minus `dropped`
 is what reached the client.

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,25 +79,28 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 | `server/searchesSinceLastRestart.ts` | In-memory counters for aggregate search outcomes (text/image search totals, and how often searches came back empty or were fully discarded), reported on `/status` |
 | `server/pageReadsSinceLastRestart.ts` | In-memory aggregate counters for pages read for grounding (outcomes, durations, passage ratios), reported on `/status`; records no query, URL, host, or per-read timestamp |
 | `server/searchEndpointServerHook.ts` | Proxies text/image search to SearXNG after token verification (via `handleTokenVerification`) |
-| `server/verifyTokenAndRateLimit.ts` | Verifies the Argon2 token hash and enforces rate limiting (10 requests per 10 seconds) shared by the search, page-content and inference endpoints |
-| `server/handleTokenVerification.ts` | Middleware bridge that calls `verifyTokenAndRateLimit` and writes 400/401/429 error responses for the search, page-content and inference endpoints |
+| `server/verifyTokenAndRateLimit.ts` | Verifies the Argon2 token hash and enforces rate limiting (10 requests per 10 seconds) shared by the search, page-content, thumbnail and inference endpoints |
+| `server/handleTokenVerification.ts` | Middleware bridge that calls `verifyTokenAndRateLimit` and writes 400/401/429 error responses for the search, page-content, thumbnail and inference endpoints |
 | `server/configEndpointServerHook.ts` | Serves the non-secret runtime config at `/api/config`, including whether access keys are enabled |
 | `server/utils/publicUrl.ts` | Rejects non-HTTP schemes and hosts resolving into private, loopback, link-local or reserved ranges before the server fetches a client-supplied URL |
 | `server/pageContentEndpointServerHook.ts` | Reads result pages at `/page-content` after token verification, capped at 6 URLs per request |
+| `server/thumbnailEndpointServerHook.ts` | Serves one search-result thumbnail at a time at `/thumbnail` after token verification, with an in-process LRU in front of the upstream host |
 
 ### Server-Side Fetching of Client-Supplied URLs
 
 `/page-content` is the endpoint that fetches a URL the client chose, so it is
 the main place where SSRF matters. It is always available; the user's
 `enablePageContentFetch` toggle decides whether each browser actually uses it.
-It shares the 10-requests-per-10-seconds bucket with `/search/`, but each
-request can fan out to six pages, so it is the heavier of the two per point.
+It shares the 10-requests-per-10-seconds bucket with `/search/` and
+`/thumbnail`, but each request can fan out to six pages, so it is the
+heaviest of the three per point.
 
-`/search/images` also fetches on the server's behalf: the thumbnail URLs that
-come back from SearXNG are fetched and returned as data URLs. Thumbnails are
-harder for an attacker to steer than a client-chosen page URL, but a
-compromised or hostile engine result could still point the server at an
-internal address, so the same guard applies.
+`/thumbnail` is the second place the server fetches on a client's behalf: the
+client loads each search-result thumbnail from it, one tile at a time. The
+URLs come back from SearXNG rather than from the user, but a compromised or
+hostile engine result could still point the server at an internal address, so
+the same guard applies, and the endpoint is token-gated and rate-limited like
+the rest.
 
 Every hop - the original URL and each redirect - passes `resolvePublicUrl`
 before a request is made, which blocks loopback, link-local (including

--- a/docs/security.md
+++ b/docs/security.md
@@ -96,11 +96,14 @@ It shares the 10-requests-per-10-seconds bucket with `/search/` and
 heaviest of the three per point.
 
 `/thumbnail` is the second place the server fetches on a client's behalf: the
-client loads each search-result thumbnail from it, one tile at a time. The
-URLs come back from SearXNG rather than from the user, but a compromised or
-hostile engine result could still point the server at an internal address, so
-the same guard applies, and the endpoint is token-gated and rate-limited like
-the rest.
+client loads each search-result thumbnail from it, one tile at a time, and the
+`u` parameter is client-supplied. In practice it carries the URLs SearXNG
+returned, but the endpoint is a general token-gated fetch for any public
+raster image, so the guard must hold for arbitrary input: every hop passes
+`resolvePublicUrl` (the documented DNS-rebinding residual applies per
+request), only raster content types are served, and the response carries
+`nosniff` plus a sandbox CSP because it is same-origin. It draws from its own
+rate-limit budget, since one grid fans out into up to 30 tile loads.
 
 Every hop - the original URL and each redirect - passes `resolvePublicUrl`
 before a request is made, which blocks loopback, link-local (including

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,7 +79,7 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 | `server/searchesSinceLastRestart.ts` | In-memory counters for aggregate search outcomes (text/image search totals, and how often searches came back empty or were fully discarded), reported on `/status` |
 | `server/pageReadsSinceLastRestart.ts` | In-memory aggregate counters for pages read for grounding (outcomes, durations, passage ratios), reported on `/status`; records no query, URL, host, or per-read timestamp |
 | `server/searchEndpointServerHook.ts` | Proxies text/image search to SearXNG after token verification (via `handleTokenVerification`) |
-| `server/verifyTokenAndRateLimit.ts` | Verifies the Argon2 token hash and enforces rate limiting (10 requests per 10 seconds) shared by the search, page-content, thumbnail and inference endpoints |
+| `server/verifyTokenAndRateLimit.ts` | Verifies the Argon2 token hash and enforces rate limiting (10 requests per 10 seconds, shared by the search, page-content and inference endpoints; a separate 60-per-10-seconds budget for `/thumbnail`) |
 | `server/handleTokenVerification.ts` | Middleware bridge that calls `verifyTokenAndRateLimit` and writes 400/401/429 error responses for the search, page-content, thumbnail and inference endpoints |
 | `server/configEndpointServerHook.ts` | Serves the non-secret runtime config at `/api/config`, including whether access keys are enabled |
 | `server/utils/publicUrl.ts` | Rejects non-HTTP schemes and hosts resolving into private, loopback, link-local or reserved ranges before the server fetches a client-supplied URL |
@@ -92,8 +92,8 @@ Every HTTP request from client to backend carries a `token` query parameter for 
 the main place where SSRF matters. It is always available; the user's
 `enablePageContentFetch` toggle decides whether each browser actually uses it.
 It shares the 10-requests-per-10-seconds bucket with `/search/` and
-`/thumbnail`, but each request can fan out to six pages, so it is the
-heaviest of the three per point.
+`/inference` (`/thumbnail` keeps its own budget, below), but each request can
+fan out to six pages, so it is the heaviest per point.
 
 `/thumbnail` is the second place the server fetches on a client's behalf: the
 client loads each search-result thumbnail from it, one tile at a time, and the

--- a/server/authorizationSinceLastRestart.ts
+++ b/server/authorizationSinceLastRestart.ts
@@ -13,6 +13,8 @@ import {
   RATE_LIMIT_DURATION_SECONDS,
   RATE_LIMIT_POINTS,
   type RejectionReason,
+  THUMBNAIL_RATE_LIMIT_DURATION_SECONDS,
+  THUMBNAIL_RATE_LIMIT_POINTS,
 } from "./verifyTokenAndRateLimit.ts";
 
 /**
@@ -94,6 +96,10 @@ export function getAuthorizationStats() {
     limiter: {
       points: RATE_LIMIT_POINTS,
       durationSeconds: RATE_LIMIT_DURATION_SECONDS,
+      thumbnail: {
+        points: THUMBNAIL_RATE_LIMIT_POINTS,
+        durationSeconds: THUMBNAIL_RATE_LIMIT_DURATION_SECONDS,
+      },
     },
   };
 }

--- a/server/authorizationSinceLastRestart.ts
+++ b/server/authorizationSinceLastRestart.ts
@@ -23,6 +23,7 @@ import {
 export type AuthorizationSurface =
   | "search"
   | "pageContent"
+  | "thumbnail"
   | "inference"
   | "other";
 
@@ -42,6 +43,7 @@ const reasons: Record<RejectionReason, number> = {
 const bySurface: Record<AuthorizationSurface, SurfaceCounts> = {
   search: { authorized: 0, rejected: 0 },
   pageContent: { authorized: 0, rejected: 0 },
+  thumbnail: { authorized: 0, rejected: 0 },
   inference: { authorized: 0, rejected: 0 },
   other: { authorized: 0, rejected: 0 },
 };

--- a/server/handleTokenVerification.test.ts
+++ b/server/handleTokenVerification.test.ts
@@ -94,6 +94,7 @@ describe("handleTokenVerification", () => {
     ["/search/text", "search"],
     ["/search/images", "search"],
     ["/page-content", "pageContent"],
+    ["/thumbnail", "thumbnail"],
     ["/inference", "inference"],
     ["/something-else", "other"],
   ] as const)(
@@ -190,6 +191,7 @@ describe("handleTokenVerification", () => {
       "other",
       "pageContent",
       "search",
+      "thumbnail",
     ]);
     expect(Object.keys(stats.limiter).sort()).toEqual([
       "durationSeconds",

--- a/server/handleTokenVerification.test.ts
+++ b/server/handleTokenVerification.test.ts
@@ -164,6 +164,10 @@ describe("handleTokenVerification", () => {
     expect(getAuthorizationStats().limiter).toEqual({
       points: 10,
       durationSeconds: 10,
+      thumbnail: {
+        points: 60,
+        durationSeconds: 10,
+      },
     });
   });
 
@@ -196,6 +200,7 @@ describe("handleTokenVerification", () => {
     expect(Object.keys(stats.limiter).sort()).toEqual([
       "durationSeconds",
       "points",
+      "thumbnail",
     ]);
     expectNumbersAllTheWayDown(stats, "authorization");
     expect(JSON.stringify(stats)).not.toContain("borogoves");

--- a/server/handleTokenVerification.ts
+++ b/server/handleTokenVerification.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   type AuthorizationSurface,
   recordAuthorizedRequest,
@@ -28,8 +29,13 @@ export async function handleTokenVerification(
   token: string | null,
   response: ServerResponse,
   request?: IncomingMessage,
+  options?: { limiter?: RateLimiterMemory },
 ): Promise<{ shouldContinue: boolean }> {
-  const result = await verifyTokenAndRateLimit(token, request);
+  const result = await verifyTokenAndRateLimit(
+    token,
+    request,
+    options?.limiter,
+  );
   const surface = resolveSurface(request);
 
   if (!result.isAuthorized) {

--- a/server/handleTokenVerification.ts
+++ b/server/handleTokenVerification.ts
@@ -9,6 +9,7 @@ import { verifyTokenAndRateLimit } from "./verifyTokenAndRateLimit.ts";
 const SURFACES: [pathPrefix: string, surface: AuthorizationSurface][] = [
   ["/search", "search"],
   ["/page-content", "pageContent"],
+  ["/thumbnail", "thumbnail"],
   ["/inference", "inference"],
 ];
 

--- a/server/searchEndpointServerHook.test.ts
+++ b/server/searchEndpointServerHook.test.ts
@@ -1,13 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const lookupMock = vi.hoisted(() => vi.fn());
-
-vi.mock("node:dns/promises", () => ({
-  default: { lookup: lookupMock },
-  lookup: lookupMock,
-}));
-
 vi.mock("./handleTokenVerification", () => ({
   handleTokenVerification: vi.fn(),
 }));
@@ -24,9 +17,6 @@ vi.mock("./searchesSinceLastRestart", () => ({
   incrementTextualSearchesSinceLastRestart: vi.fn(),
   incrementGraphicalSearchesSinceLastRestart: vi.fn(),
   recordSearchDuration: vi.fn(),
-  recordThumbnailRequested: vi.fn(),
-  recordThumbnailDropped: vi.fn(),
-  recordThumbnailBlocked: vi.fn(),
 }));
 
 vi.mock("./webSearchService", () => ({
@@ -41,14 +31,8 @@ import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
   recordSearchDuration,
-  recordThumbnailBlocked,
-  recordThumbnailDropped,
-  recordThumbnailRequested,
 } from "./searchesSinceLastRestart";
 import { fetchSearXNG } from "./webSearchService";
-
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 function createRequest(url: string): IncomingMessage {
   return {
@@ -83,11 +67,6 @@ function getRegisteredHandler() {
 describe("searchEndpointServerHook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // clearAllMocks keeps implementations, and one degradation case installs a
-    // fetch that only settles on abort.
-    mockFetch.mockReset();
-    lookupMock.mockReset();
-    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     vi.mocked(handleTokenVerification).mockResolvedValue({
       shouldContinue: true,
     });
@@ -245,7 +224,10 @@ describe("searchEndpointServerHook", () => {
     );
   });
 
-  it("returns image results with thumbnails converted to data URLs and increments the graphical counter", async () => {
+  it("returns image results with the thumbnail URL untouched and increments the graphical counter", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      throw new Error("the search endpoint must not fetch thumbnails");
+    });
     vi.mocked(fetchSearXNG).mockResolvedValue([
       [
         "Cat picture",
@@ -254,12 +236,6 @@ describe("searchEndpointServerHook", () => {
         "https://example.com/cat",
       ],
     ]);
-    mockFetch.mockResolvedValue(
-      new Response(new Uint8Array([1, 2, 3]), {
-        status: 200,
-        headers: { "content-type": "image/jpeg" },
-      }),
-    );
 
     const handler = getRegisteredHandler();
     const response = createResponse();
@@ -271,39 +247,18 @@ describe("searchEndpointServerHook", () => {
     );
 
     expect(incrementGraphicalSearchesSinceLastRestart).toHaveBeenCalled();
-    const [body] = response.end.mock.calls[0];
-    expect(JSON.parse(body)).toEqual([
-      [
-        "Cat picture",
-        "https://example.com/cat.jpg",
-        `data:image/jpeg;base64,${Buffer.from([1, 2, 3]).toString("base64")}`,
-        "https://example.com/cat",
-      ],
-    ]);
-  });
-
-  it("drops image results whose thumbnail fails to download", async () => {
-    vi.mocked(fetchSearXNG).mockResolvedValue([
-      [
-        "Cat picture",
-        "https://example.com/cat.jpg",
-        "https://thumb.example.com/cat.jpg",
-        "https://example.com/cat",
-      ],
-    ]);
-    mockFetch.mockResolvedValue(new Response(null, { status: 404 }));
-
-    const handler = getRegisteredHandler();
-    const response = createResponse();
-
-    await handler(
-      createRequest("/search/images?q=cats&token=abc"),
-      response,
-      vi.fn(),
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify([
+        [
+          "Cat picture",
+          "https://example.com/cat.jpg",
+          "https://thumb.example.com/cat.jpg",
+          "https://example.com/cat",
+        ],
+      ]),
     );
-
-    const [body] = response.end.mock.calls[0];
-    expect(JSON.parse(body)).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
   });
 
   describe("graceful degradation", () => {
@@ -317,16 +272,6 @@ describe("searchEndpointServerHook", () => {
       "https://thumb.example.com/cat.jpg",
       "https://example.com/cat",
     ];
-    const thumbnailDataUrl = `data:image/jpeg;base64,${Buffer.from([1, 2, 3]).toString("base64")}`;
-
-    function respondWithThumbnail() {
-      mockFetch.mockResolvedValue(
-        new Response(new Uint8Array([1, 2, 3]), {
-          status: 200,
-          headers: { "content-type": "image/jpeg" },
-        }),
-      );
-    }
 
     beforeEach(() => {
       // The degradation paths log on purpose; keep the test output readable.
@@ -379,7 +324,6 @@ describe("searchEndpointServerHook", () => {
     it("still serves image results when the reranker is down", async () => {
       vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
       vi.mocked(getRerankerStatus).mockResolvedValue(false);
-      respondWithThumbnail();
 
       const handler = getRegisteredHandler();
       const response = createResponse();
@@ -393,9 +337,7 @@ describe("searchEndpointServerHook", () => {
       expect(rankSearchResults).not.toHaveBeenCalled();
       expect(response.statusCode).toBe(200);
       const [body] = response.end.mock.calls[0];
-      expect(JSON.parse(body)).toEqual([
-        [imageResult[0], imageResult[1], thumbnailDataUrl, imageResult[3]],
-      ]);
+      expect(JSON.parse(body)).toEqual([imageResult]);
     });
 
     it("still serves image results when reranking throws mid-request", async () => {
@@ -404,7 +346,6 @@ describe("searchEndpointServerHook", () => {
       vi.mocked(rankSearchResults).mockRejectedValue(
         new Error("Reranker model is not loaded"),
       );
-      respondWithThumbnail();
 
       const handler = getRegisteredHandler();
       const response = createResponse();
@@ -417,9 +358,7 @@ describe("searchEndpointServerHook", () => {
 
       expect(response.statusCode).toBe(200);
       const [body] = response.end.mock.calls[0];
-      expect(JSON.parse(body)).toEqual([
-        [imageResult[0], imageResult[1], thumbnailDataUrl, imageResult[3]],
-      ]);
+      expect(JSON.parse(body)).toEqual([imageResult]);
     });
 
     it("drops an image the reranker returns under an unknown URL", async () => {
@@ -445,40 +384,6 @@ describe("searchEndpointServerHook", () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.end).toHaveBeenCalledWith("[]");
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it("drops an image whose thumbnail host never answers", async () => {
-      // Matches THUMBNAIL_TIMEOUT_MS in searchEndpointServerHook.ts.
-      const thumbnailTimeoutMs = 1000;
-      vi.useFakeTimers();
-      try {
-        vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
-        vi.mocked(getRerankerStatus).mockResolvedValue(false);
-        mockFetch.mockImplementation(
-          (_url: string, init?: RequestInit) =>
-            new Promise((_resolve, reject) => {
-              init?.signal?.addEventListener("abort", () =>
-                reject(new Error("The operation was aborted")),
-              );
-            }),
-        );
-
-        const handler = getRegisteredHandler();
-        const response = createResponse();
-        const handled = handler(
-          createRequest("/search/images?q=cats&token=abc"),
-          response,
-          vi.fn(),
-        );
-        await vi.advanceTimersByTimeAsync(thumbnailTimeoutMs);
-        await handled;
-
-        expect(response.statusCode).toBe(200);
-        expect(response.end).toHaveBeenCalledWith("[]");
-      } finally {
-        vi.useRealTimers();
-      }
     });
 
     it("answers 502 when SearXNG is down", async () => {
@@ -518,105 +423,6 @@ describe("searchEndpointServerHook", () => {
         JSON.stringify({ error: "Search service unavailable" }),
       );
     });
-
-    it("drops an image whose thumbnail resolves to a private address", async () => {
-      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
-      vi.mocked(getRerankerStatus).mockResolvedValue(false);
-      lookupMock.mockResolvedValue([{ address: "192.168.1.5", family: 4 }]);
-
-      const handler = getRegisteredHandler();
-      const response = createResponse();
-
-      await handler(
-        createRequest("/search/images?q=cats&token=abc"),
-        response,
-        vi.fn(),
-      );
-
-      expect(response.statusCode).toBe(200);
-      expect(response.end).toHaveBeenCalledWith("[]");
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it("drops an image whose thumbnail URL uses a non-HTTP scheme", async () => {
-      vi.mocked(fetchSearXNG).mockResolvedValue([
-        [
-          "Cat picture",
-          "https://example.com/cat.jpg",
-          "file:///etc/passwd",
-          "https://example.com/cat",
-        ],
-      ]);
-      vi.mocked(getRerankerStatus).mockResolvedValue(false);
-
-      const handler = getRegisteredHandler();
-      const response = createResponse();
-
-      await handler(
-        createRequest("/search/images?q=cats&token=abc"),
-        response,
-        vi.fn(),
-      );
-
-      expect(response.statusCode).toBe(200);
-      expect(response.end).toHaveBeenCalledWith("[]");
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it("does not follow a thumbnail redirect into a private address", async () => {
-      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
-      vi.mocked(getRerankerStatus).mockResolvedValue(false);
-      lookupMock
-        .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
-        .mockResolvedValue([{ address: "10.0.0.7", family: 4 }]);
-      mockFetch.mockResolvedValueOnce(
-        new Response(null, {
-          status: 302,
-          headers: { location: "http://10.0.0.7/thumb.jpg" },
-        }),
-      );
-
-      const handler = getRegisteredHandler();
-      const response = createResponse();
-
-      await handler(
-        createRequest("/search/images?q=cats&token=abc"),
-        response,
-        vi.fn(),
-      );
-
-      expect(response.statusCode).toBe(200);
-      expect(response.end).toHaveBeenCalledWith("[]");
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-    });
-
-    it("truncates an oversized thumbnail body", async () => {
-      vi.mocked(fetchSearXNG).mockResolvedValue([imageResult]);
-      vi.mocked(getRerankerStatus).mockResolvedValue(false);
-      const bigBody = new Uint8Array(600_000).fill(7);
-      mockFetch.mockResolvedValue(
-        new Response(bigBody, {
-          status: 200,
-          headers: { "content-type": "image/jpeg" },
-        }),
-      );
-
-      const handler = getRegisteredHandler();
-      const response = createResponse();
-
-      await handler(
-        createRequest("/search/images?q=cats&token=abc"),
-        response,
-        vi.fn(),
-      );
-
-      const [body] = response.end.mock.calls[0];
-      const [thumbnailDataUrl] = JSON.parse(body);
-      expect(thumbnailDataUrl[2]).toContain("data:image/jpeg;base64,");
-      // The cap is 500_000 bytes; a 600_000-byte body must be truncated.
-      const decoded = Buffer.from(thumbnailDataUrl[2].split(",")[1], "base64");
-      expect(decoded.length).toBe(500_000);
-    });
   });
 
   it("responds 500 when an unexpected error is thrown", async () => {
@@ -639,6 +445,7 @@ describe("searchEndpointServerHook", () => {
       JSON.stringify({ error: "Internal server error" }),
     );
   });
+
   describe("search path counters", () => {
     it("records how long SearXNG took on a text search", async () => {
       vi.mocked(fetchSearXNG).mockResolvedValue([
@@ -669,52 +476,6 @@ describe("searchEndpointServerHook", () => {
       );
 
       expect(recordSearchDuration).not.toHaveBeenCalled();
-    });
-
-    it("counts a thumbnail that was fetched and one that was dropped", async () => {
-      vi.mocked(fetchSearXNG).mockResolvedValue([
-        [
-          "picture",
-          "https://example.com/page",
-          "https://example.com/thumb.jpg",
-          "https://example.com/full.jpg",
-        ],
-      ]);
-      mockFetch.mockRejectedValue(new Error("thumbnail host down"));
-      const handler = getRegisteredHandler();
-
-      await handler(
-        createRequest("/search/images?q=test&token=abc"),
-        createResponse(),
-        vi.fn(),
-      );
-
-      expect(recordThumbnailRequested).toHaveBeenCalledTimes(1);
-      expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
-      expect(recordThumbnailBlocked).not.toHaveBeenCalled();
-    });
-
-    it("counts a thumbnail refused for resolving outside public space", async () => {
-      vi.mocked(fetchSearXNG).mockResolvedValue([
-        [
-          "picture",
-          "https://example.com/page",
-          "https://169.254.169.254/thumb.jpg",
-          "https://example.com/full.jpg",
-        ],
-      ]);
-      lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
-      const handler = getRegisteredHandler();
-
-      await handler(
-        createRequest("/search/images?q=test&token=abc"),
-        createResponse(),
-        vi.fn(),
-      );
-
-      expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
-      // Blocked thumbnails are dropped too, so the requested total stays closed.
-      expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
     });
 
     it("counts the searches served without the reranker", async () => {

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -11,17 +11,9 @@ import {
   incrementGraphicalSearchesSinceLastRestart,
   incrementTextualSearchesSinceLastRestart,
   recordSearchDuration,
-  recordThumbnailBlocked,
-  recordThumbnailDropped,
-  recordThumbnailRequested,
 } from "./searchesSinceLastRestart.ts";
-import { resolvePublicUrl } from "./utils/publicUrl.ts";
-import { readCappedBytes } from "./utils/streamUtils.ts";
 import { fetchSearXNG } from "./webSearchService.ts";
 
-const THUMBNAIL_TIMEOUT_MS = 1000;
-const MAX_THUMBNAIL_REDIRECTS = 3;
-const MAX_THUMBNAIL_BYTES = 500_000;
 const DEFAULT_SEARCH_LIMIT = 30;
 const MAX_SEARCH_LIMIT = 30;
 const MAX_QUERY_LENGTH = 2000;
@@ -51,64 +43,6 @@ type ImageResult = [
   sourceUrl: string,
 ];
 
-async function fetchThumbnailAsDataUrl(thumbnailSource: string) {
-  recordThumbnailRequested();
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), THUMBNAIL_TIMEOUT_MS);
-  try {
-    let target = thumbnailSource;
-
-    for (let hop = 0; hop <= MAX_THUMBNAIL_REDIRECTS; hop++) {
-      let url: URL;
-      try {
-        url = await resolvePublicUrl(target);
-      } catch {
-        // Malformed, non-HTTP, or a private/link-local/reserved address:
-        // do not fetch it on the server's behalf. Throwing lets the caller's
-        // catch drop the whole image result, matching the other failure paths.
-        recordThumbnailBlocked();
-        throw new Error(
-          "Refusing to fetch thumbnail from a non-public address",
-        );
-      }
-
-      const response = await fetch(url, {
-        redirect: "manual",
-        signal: controller.signal,
-      });
-
-      const location = response.headers.get("location");
-      if (isRedirect(response.status) && location) {
-        await response.body?.cancel().catch(() => {});
-        target = new URL(location, url).toString();
-        continue;
-      }
-
-      if (!response.ok) {
-        await response.body?.cancel().catch(() => {});
-        throw new Error(
-          `Thumbnail request failed with status ${response.status}`,
-        );
-      }
-
-      const contentType =
-        response.headers.get("content-type") ?? "application/octet-stream";
-      const { bytes } = await readCappedBytes(response, MAX_THUMBNAIL_BYTES);
-      const base64 = Buffer.from(bytes).toString("base64");
-
-      return `data:${contentType};base64,${base64}`;
-    }
-
-    throw new Error("Thumbnail redirected too many times");
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function isRedirect(status: number): boolean {
-  return status >= 300 && status < 400 && status !== 304;
-}
-
 async function handleRanking(
   query: string,
   results: [title: string, content: string, url: string][],
@@ -137,7 +71,9 @@ async function handleRanking(
 
 /**
  * Serves `/search/text` and `/search/images`: verified requests go through
- * SearXNG, with reranking, score filtering, and thumbnail data-URLs.
+ * SearXNG, with reranking and score filtering. Image results carry the
+ * thumbnail URL as SearXNG returned it; the client loads each one from
+ * `/thumbnail`, so the response does not wait on any thumbnail host.
  */
 export function searchEndpointServerHook<
   T extends ViteDevServer | PreviewServer,
@@ -208,26 +144,16 @@ export function searchEndpointServerHook<
         );
         const rankedResults = await handleRanking(query, resultsText);
 
-        const processedResults = (
-          await Promise.all(
-            rankedResults.map(async ([title, , rankedResultUrl]) => {
-              const result = results.find(
-                ([, resultUrl]) => resultUrl === rankedResultUrl,
-              );
-              if (!result) return null;
-              const [_, url, thumbnailSource, sourceUrl] = result;
-              try {
-                const thumbnail =
-                  await fetchThumbnailAsDataUrl(thumbnailSource);
-
-                return [title, url, thumbnail, sourceUrl] as ImageResult;
-              } catch {
-                recordThumbnailDropped();
-                return null;
-              }
-            }),
-          )
-        ).filter((result): result is ImageResult => result !== null);
+        const processedResults = rankedResults
+          .map(([title, , rankedResultUrl]) => {
+            const result = results.find(
+              ([, resultUrl]) => resultUrl === rankedResultUrl,
+            );
+            if (!result) return null;
+            const [, url, thumbnailSource, sourceUrl] = result;
+            return [title, url, thumbnailSource, sourceUrl] as ImageResult;
+          })
+          .filter((result): result is ImageResult => result !== null);
 
         incrementGraphicalSearchesSinceLastRestart();
 

--- a/server/thumbnailEndpointServerHook.test.ts
+++ b/server/thumbnailEndpointServerHook.test.ts
@@ -24,7 +24,11 @@ import {
   recordThumbnailDropped,
   recordThumbnailRequested,
 } from "./searchesSinceLastRestart";
-import { thumbnailEndpointServerHook } from "./thumbnailEndpointServerHook";
+import {
+  getThumbnailCacheLimits,
+  resetThumbnailCache,
+  thumbnailEndpointServerHook,
+} from "./thumbnailEndpointServerHook";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -154,6 +158,16 @@ describe("thumbnailEndpointServerHook", () => {
       "Content-Type",
       "image/jpeg",
     );
+    // The response is same-origin, so the browser must be barred from
+    // interpreting the bytes as anything but the declared image type.
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "X-Content-Type-Options",
+      "nosniff",
+    );
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Security-Policy",
+      "default-src 'none'; sandbox",
+    );
     expect(response.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "private, max-age=3600",
@@ -208,6 +222,19 @@ describe("thumbnailEndpointServerHook", () => {
     expect(response.statusCode).toBe(403);
     expect(mockFetch).not.toHaveBeenCalled();
     expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a URL longer than the cap", async () => {
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+    const longUrl = `https://thumbs.example.com/${"a".repeat(2050)}`;
+
+    await handler(createRequest(requestUrlFor(longUrl)), response, vi.fn());
+
+    expect(response.statusCode).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(recordThumbnailRequested).not.toHaveBeenCalled();
   });
 
   it("does not follow a redirect into a private address", async () => {
@@ -234,7 +261,7 @@ describe("thumbnailEndpointServerHook", () => {
     expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
   });
 
-  it("answers 502 when the upstream returns an error status", async () => {
+  it("answers 502 with no-store when the upstream returns an error status", async () => {
     mockFetch.mockResolvedValue(new Response(null, { status: 404 }));
     const handler = getRegisteredHandler();
     const response = createResponse();
@@ -246,13 +273,17 @@ describe("thumbnailEndpointServerHook", () => {
     );
 
     expect(response.statusCode).toBe(502);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "no-store",
+    );
     expect(response.end).toHaveBeenCalledWith(
       JSON.stringify({ error: "Thumbnail could not be fetched" }),
     );
     expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
   });
 
-  it("answers 502 when the upstream answer is not an image", async () => {
+  it("answers 502 when the upstream answer is not an accepted image type", async () => {
     mockFetch.mockResolvedValue(
       new Response("<html></html>", {
         status: 200,
@@ -270,6 +301,65 @@ describe("thumbnailEndpointServerHook", () => {
 
     expect(response.statusCode).toBe(502);
     expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 502 when the upstream answer is an SVG", async () => {
+    // An SVG is a document: served same-origin it would run its scripts.
+    mockFetch.mockResolvedValue(
+      new Response("<svg><script>alert(1)</script></svg>", {
+        status: 200,
+        headers: { "content-type": "image/svg+xml" },
+      }),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(502);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not follow a redirect with a malformed Location", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://[" },
+      }),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(502);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a failure, so the next load retries the upstream", async () => {
+    const url = publicThumbnailUrl();
+    mockFetch
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(imageResponse());
+    const handler = getRegisteredHandler();
+
+    const first = createResponse();
+    await handler(createRequest(requestUrlFor(url)), first, vi.fn());
+    expect(first.statusCode).toBe(502);
+
+    const second = createResponse();
+    await handler(createRequest(requestUrlFor(url)), second, vi.fn());
+    expect(second.statusCode).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("answers 502 when the upstream body is empty", async () => {
@@ -290,6 +380,31 @@ describe("thumbnailEndpointServerHook", () => {
 
     expect(response.statusCode).toBe(502);
     expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a hanging DNS lookup with the same deadline", async () => {
+    // A resolver that never settles must not add its own timeout on top of
+    // the documented one. Matches THUMBNAIL_TIMEOUT_MS.
+    const thumbnailTimeoutMs = 3000;
+    lookupMock.mockImplementation(() => new Promise(() => {}));
+    vi.useFakeTimers();
+    try {
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+      const handled = handler(
+        createRequest(requestUrlFor(publicThumbnailUrl())),
+        response,
+        vi.fn(),
+      );
+      await vi.advanceTimersByTimeAsync(thumbnailTimeoutMs);
+      await handled;
+
+      expect(response.statusCode).toBe(502);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("answers 502 when the host never answers within the timeout", async () => {
@@ -366,14 +481,17 @@ describe("thumbnailEndpointServerHook", () => {
     // A fresh Response per call: a body can only be read once.
     mockFetch.mockImplementation(async () => imageResponse());
     const handler = getRegisteredHandler();
+    // A clean slate, so the eviction side is exactly where this test puts it.
+    resetThumbnailCache();
     const firstUrl = publicThumbnailUrl();
+    const maxEntries = getThumbnailCacheLimits().entries;
 
     await handler(
       createRequest(requestUrlFor(firstUrl)),
       createResponse(),
       vi.fn(),
     );
-    for (let i = 0; i < 100; i += 1) {
+    for (let i = 0; i < maxEntries; i += 1) {
       await handler(
         createRequest(requestUrlFor(publicThumbnailUrl())),
         createResponse(),
@@ -381,13 +499,14 @@ describe("thumbnailEndpointServerHook", () => {
       );
     }
 
-    // 101 entries pushed the cache past its cap, so the first entry is gone.
+    // maxEntries + 1 entries pushed the cache past its cap, so the first
+    // entry is gone and the repeat fetches again.
     await handler(
       createRequest(requestUrlFor(firstUrl)),
       createResponse(),
       vi.fn(),
     );
 
-    expect(mockFetch).toHaveBeenCalledTimes(102);
+    expect(mockFetch).toHaveBeenCalledTimes(maxEntries + 2);
   });
 });

--- a/server/thumbnailEndpointServerHook.test.ts
+++ b/server/thumbnailEndpointServerHook.test.ts
@@ -178,6 +178,28 @@ describe("thumbnailEndpointServerHook", () => {
     expect(recordThumbnailBlocked).not.toHaveBeenCalled();
   });
 
+  it("verifies through the thumbnail's own rate-limit budget", async () => {
+    mockFetch.mockResolvedValue(imageResponse());
+    const { thumbnailRateLimiter } = await import("./verifyTokenAndRateLimit");
+    const handler = getRegisteredHandler();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      createResponse(),
+      vi.fn(),
+    );
+
+    // The whole separate-budget design rests on this wiring: delete the
+    // options argument and the grid's 30 tile loads draw from the search
+    // budget again.
+    expect(vi.mocked(handleTokenVerification)).toHaveBeenCalledWith(
+      "abc",
+      expect.anything(),
+      expect.anything(),
+      { limiter: thumbnailRateLimiter },
+    );
+  });
+
   it("serves a repeat request from the cache without fetching again", async () => {
     const url = publicThumbnailUrl();
     // A fresh Response per call: a body can only be read once.
@@ -477,36 +499,39 @@ describe("thumbnailEndpointServerHook", () => {
     expect(body.length).toBe(500_000);
   });
 
-  it("evicts the least recently used entry once the cache is full", async () => {
+  it("evicts the least recently used entry, not the least recently loaded one", async () => {
     // A fresh Response per call: a body can only be read once.
     mockFetch.mockImplementation(async () => imageResponse());
     const handler = getRegisteredHandler();
     // A clean slate, so the eviction side is exactly where this test puts it.
     resetThumbnailCache();
     const firstUrl = publicThumbnailUrl();
+    const secondUrl = publicThumbnailUrl();
     const maxEntries = getThumbnailCacheLimits().entries;
+    const load = (url: string) =>
+      handler(createRequest(requestUrlFor(url)), createResponse(), vi.fn());
+    const fetched = (url: string) =>
+      mockFetch.mock.calls.filter((call) => String(call[0]) === url).length;
 
-    await handler(
-      createRequest(requestUrlFor(firstUrl)),
-      createResponse(),
-      vi.fn(),
-    );
-    for (let i = 0; i < maxEntries; i += 1) {
-      await handler(
-        createRequest(requestUrlFor(publicThumbnailUrl())),
-        createResponse(),
-        vi.fn(),
-      );
+    await load(firstUrl);
+    await load(secondUrl);
+
+    // Re-reading firstUrl promotes it, so secondUrl is the eviction candidate.
+    await load(firstUrl);
+
+    for (let i = 0; i < maxEntries - 2; i += 1) {
+      await load(publicThumbnailUrl());
     }
+    // This insert pushes the cache past the cap: exactly one entry is evicted.
+    await load(publicThumbnailUrl());
 
-    // maxEntries + 1 entries pushed the cache past its cap, so the first
-    // entry is gone and the repeat fetches again.
-    await handler(
-      createRequest(requestUrlFor(firstUrl)),
-      createResponse(),
-      vi.fn(),
-    );
-
-    expect(mockFetch).toHaveBeenCalledTimes(maxEntries + 2);
+    // firstUrl (promoted by the re-read) survived and serves from the cache.
+    // A cache without promote-on-hit would have evicted it, being the oldest
+    // load.
+    await load(firstUrl);
+    expect(fetched(firstUrl)).toBe(1);
+    // secondUrl (least recently used) was evicted and fetches again.
+    await load(secondUrl);
+    expect(fetched(secondUrl)).toBe(2);
   });
 });

--- a/server/thumbnailEndpointServerHook.test.ts
+++ b/server/thumbnailEndpointServerHook.test.ts
@@ -1,0 +1,393 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const lookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns/promises", () => ({
+  default: { lookup: lookupMock },
+  lookup: lookupMock,
+}));
+
+vi.mock("./handleTokenVerification", () => ({
+  handleTokenVerification: vi.fn(),
+}));
+
+vi.mock("./searchesSinceLastRestart", () => ({
+  recordThumbnailRequested: vi.fn(),
+  recordThumbnailDropped: vi.fn(),
+  recordThumbnailBlocked: vi.fn(),
+}));
+
+import { handleTokenVerification } from "./handleTokenVerification";
+import {
+  recordThumbnailBlocked,
+  recordThumbnailDropped,
+  recordThumbnailRequested,
+} from "./searchesSinceLastRestart";
+import { thumbnailEndpointServerHook } from "./thumbnailEndpointServerHook";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function createRequest(url: string): IncomingMessage {
+  return {
+    url,
+    headers: { host: "localhost:3000" },
+  } as unknown as IncomingMessage;
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as ServerResponse & {
+    setHeader: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+}
+
+function getRegisteredHandler() {
+  const use = vi.fn();
+  thumbnailEndpointServerHook({
+    middlewares: { use },
+  } as unknown as Parameters<typeof thumbnailEndpointServerHook>[0]);
+  return use.mock.calls[0][0] as (
+    request: IncomingMessage,
+    response: ServerResponse,
+    next: () => void,
+  ) => Promise<void>;
+}
+
+// The in-process cache is module state, so each test aims at its own URL and
+// a hit can only come from the request the test itself made.
+let urlCounter = 0;
+function publicThumbnailUrl(): string {
+  urlCounter += 1;
+  return `https://thumbs.example.com/${urlCounter}/image.jpg`;
+}
+
+function requestUrlFor(thumbnailUrl: string): string {
+  return `/thumbnail?u=${encodeURIComponent(thumbnailUrl)}&token=abc`;
+}
+
+function imageResponse(
+  bytes: Uint8Array<ArrayBuffer> = new Uint8Array([1, 2, 3]),
+  contentType = "image/jpeg",
+): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+}
+
+describe("thumbnailEndpointServerHook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    vi.mocked(handleTokenVerification).mockResolvedValue({
+      shouldContinue: true,
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes through requests that aren't under /thumbnail", async () => {
+    const handler = getRegisteredHandler();
+    const next = vi.fn();
+
+    await handler(createRequest("/status"), createResponse(), next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("stops processing when token verification fails", async () => {
+    vi.mocked(handleTokenVerification).mockResolvedValue({
+      shouldContinue: false,
+    });
+    const handler = getRegisteredHandler();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      createResponse(),
+      vi.fn(),
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(recordThumbnailRequested).not.toHaveBeenCalled();
+  });
+
+  it("responds 400 when the thumbnail URL is missing", async () => {
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(createRequest("/thumbnail?token=abc"), response, vi.fn());
+
+    expect(response.statusCode).toBe(400);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ error: "Missing thumbnail URL" }),
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(recordThumbnailRequested).not.toHaveBeenCalled();
+  });
+
+  it("serves a fetched image with its normalized content type and a private cache", async () => {
+    mockFetch.mockResolvedValue(
+      imageResponse(new Uint8Array([1, 2, 3]), "IMAGE/JPEG; charset=binary"),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "image/jpeg",
+    );
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "private, max-age=3600",
+    );
+    expect(response.end).toHaveBeenCalledWith(Buffer.from([1, 2, 3]));
+    expect(recordThumbnailRequested).toHaveBeenCalledTimes(1);
+    expect(recordThumbnailDropped).not.toHaveBeenCalled();
+    expect(recordThumbnailBlocked).not.toHaveBeenCalled();
+  });
+
+  it("serves a repeat request from the cache without fetching again", async () => {
+    const url = publicThumbnailUrl();
+    // A fresh Response per call: a body can only be read once.
+    mockFetch.mockImplementation(async () => imageResponse());
+    const handler = getRegisteredHandler();
+
+    await handler(createRequest(requestUrlFor(url)), createResponse(), vi.fn());
+    await handler(createRequest(requestUrlFor(url)), createResponse(), vi.fn());
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Both requests are demand, so both count even though only one fetched.
+    expect(recordThumbnailRequested).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a URL that resolves into a private address", async () => {
+    lookupMock.mockResolvedValue([{ address: "192.168.1.5", family: 4 }]);
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a URL with a non-HTTP scheme", async () => {
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor("file:///etc/passwd")),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not follow a redirect into a private address", async () => {
+    lookupMock
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValue([{ address: "10.0.0.7", family: 4 }]);
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://10.0.0.7/thumb.jpg" },
+      }),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(recordThumbnailBlocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 502 when the upstream returns an error status", async () => {
+    mockFetch.mockResolvedValue(new Response(null, { status: 404 }));
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(502);
+    expect(response.end).toHaveBeenCalledWith(
+      JSON.stringify({ error: "Thumbnail could not be fetched" }),
+    );
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 502 when the upstream answer is not an image", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("<html></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(502);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 502 when the upstream body is empty", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(new Uint8Array(), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(502);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 502 when the host never answers within the timeout", async () => {
+    // Matches THUMBNAIL_TIMEOUT_MS in thumbnailEndpointServerHook.ts.
+    const thumbnailTimeoutMs = 3000;
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockImplementation(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new Error("The operation was aborted")),
+            );
+          }),
+      );
+      const handler = getRegisteredHandler();
+      const response = createResponse();
+      const handled = handler(
+        createRequest(requestUrlFor(publicThumbnailUrl())),
+        response,
+        vi.fn(),
+      );
+      await vi.advanceTimersByTimeAsync(thumbnailTimeoutMs);
+      await handled;
+
+      expect(response.statusCode).toBe(502);
+      expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("answers 502 after the redirect budget is spent", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://thumbs.example.com/loop.jpg" },
+      }),
+    );
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(502);
+    // One request per hop, four hops for three redirects.
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(recordThumbnailDropped).toHaveBeenCalledTimes(1);
+  });
+
+  it("truncates an oversized body to the byte cap", async () => {
+    const bigBody = new Uint8Array(600_000).fill(7);
+    mockFetch.mockResolvedValue(imageResponse(bigBody));
+    const handler = getRegisteredHandler();
+    const response = createResponse();
+
+    await handler(
+      createRequest(requestUrlFor(publicThumbnailUrl())),
+      response,
+      vi.fn(),
+    );
+
+    expect(response.statusCode).toBe(200);
+    const body = response.end.mock.calls[0][0] as Buffer;
+    // The cap is 500_000 bytes; a 600_000-byte body must be truncated.
+    expect(body.length).toBe(500_000);
+  });
+
+  it("evicts the least recently used entry once the cache is full", async () => {
+    // A fresh Response per call: a body can only be read once.
+    mockFetch.mockImplementation(async () => imageResponse());
+    const handler = getRegisteredHandler();
+    const firstUrl = publicThumbnailUrl();
+
+    await handler(
+      createRequest(requestUrlFor(firstUrl)),
+      createResponse(),
+      vi.fn(),
+    );
+    for (let i = 0; i < 100; i += 1) {
+      await handler(
+        createRequest(requestUrlFor(publicThumbnailUrl())),
+        createResponse(),
+        vi.fn(),
+      );
+    }
+
+    // 101 entries pushed the cache past its cap, so the first entry is gone.
+    await handler(
+      createRequest(requestUrlFor(firstUrl)),
+      createResponse(),
+      vi.fn(),
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(102);
+  });
+});

--- a/server/thumbnailEndpointServerHook.ts
+++ b/server/thumbnailEndpointServerHook.ts
@@ -1,0 +1,246 @@
+import type { ServerResponse } from "node:http";
+import type { PreviewServer, ViteDevServer } from "vite";
+import { handleTokenVerification } from "./handleTokenVerification.ts";
+import {
+  recordThumbnailBlocked,
+  recordThumbnailDropped,
+  recordThumbnailRequested,
+} from "./searchesSinceLastRestart.ts";
+import { resolvePublicUrl } from "./utils/publicUrl.ts";
+import { readCappedBytes } from "./utils/streamUtils.ts";
+
+/**
+ * Off the critical path: the search response no longer waits on a thumbnail,
+ * so the budget is set against how long a user tolerates a placeholder tile,
+ * not against the whole grid.
+ */
+const THUMBNAIL_TIMEOUT_MS = 3000;
+const MAX_THUMBNAIL_REDIRECTS = 3;
+const MAX_THUMBNAIL_BYTES = 500_000;
+
+/**
+ * In-process LRU in front of the upstream hosts: re-running a search,
+ * restoring history and the browser's own cache all miss at the same time
+ * after a restart, and a thumbnail host should not be asked for the same
+ * bytes twice while they are still held.
+ */
+const MAX_CACHE_ENTRIES = 100;
+const MAX_CACHE_BYTES = 50 * 1024 * 1024;
+
+interface CachedThumbnail {
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+const thumbnailCache = new Map<string, CachedThumbnail>();
+let thumbnailCacheBytes = 0;
+
+function getCachedThumbnail(key: string): CachedThumbnail | undefined {
+  const entry = thumbnailCache.get(key);
+  if (!entry) return undefined;
+  // A Map iterates in insertion order, so re-inserting the key moves it to
+  // the end, away from the eviction side.
+  thumbnailCache.delete(key);
+  thumbnailCache.set(key, entry);
+  return entry;
+}
+
+function setCachedThumbnail(key: string, entry: CachedThumbnail): void {
+  const previous = thumbnailCache.get(key);
+  if (previous) thumbnailCacheBytes -= previous.bytes.byteLength;
+  thumbnailCache.set(key, entry);
+  thumbnailCacheBytes += entry.bytes.byteLength;
+
+  while (
+    thumbnailCache.size > MAX_CACHE_ENTRIES ||
+    thumbnailCacheBytes > MAX_CACHE_BYTES
+  ) {
+    const oldestKey = thumbnailCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    const evicted = thumbnailCache.get(oldestKey);
+    thumbnailCache.delete(oldestKey);
+    if (evicted) thumbnailCacheBytes -= evicted.bytes.byteLength;
+  }
+}
+
+type ThumbnailOutcome =
+  | { kind: "image"; bytes: Uint8Array; contentType: string }
+  | { kind: "blocked" }
+  | { kind: "failed"; reason: string };
+
+function isRedirect(status: number): boolean {
+  return status >= 300 && status < 400 && status !== 304;
+}
+
+/**
+ * Follows redirects by hand so that every hop is validated, the way
+ * `pageContentService` does: `redirect: "follow"` would let a public host
+ * bounce the server into a private address. The chain shares one deadline, so
+ * a redirector cannot buy extra time per hop.
+ *
+ * The URL is client-supplied (it arrives as a query parameter), so on failure
+ * it is not logged, matching `/page-content`; the outcome is counted instead.
+ */
+async function fetchThumbnail(rawUrl: string): Promise<ThumbnailOutcome> {
+  let target = rawUrl;
+  const deadline = AbortSignal.timeout(THUMBNAIL_TIMEOUT_MS);
+
+  for (let hop = 0; hop <= MAX_THUMBNAIL_REDIRECTS; hop++) {
+    let url: URL;
+    try {
+      url = await resolvePublicUrl(target);
+    } catch {
+      return { kind: "blocked" };
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        redirect: "manual",
+        signal: deadline,
+      });
+    } catch (error) {
+      return {
+        kind: "failed",
+        reason: error instanceof Error ? error.name : String(error),
+      };
+    }
+
+    const location = response.headers.get("location");
+    if (isRedirect(response.status) && location) {
+      await response.body?.cancel().catch(() => {});
+      target = new URL(location, url).toString();
+      continue;
+    }
+
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => {});
+      return { kind: "failed", reason: `HTTP ${response.status}` };
+    }
+
+    const contentType = (response.headers.get("content-type") ?? "")
+      .split(";")[0]
+      .trim()
+      .toLowerCase();
+    if (!contentType.startsWith("image/")) {
+      await response.body?.cancel().catch(() => {});
+      return {
+        kind: "failed",
+        reason: contentType
+          ? `not an image (${contentType})`
+          : "no content type",
+      };
+    }
+
+    let bytes: Uint8Array;
+    try {
+      ({ bytes } = await readCappedBytes(response, MAX_THUMBNAIL_BYTES));
+    } catch (error) {
+      return {
+        kind: "failed",
+        reason: error instanceof Error ? error.name : String(error),
+      };
+    }
+
+    if (bytes.byteLength === 0) {
+      return { kind: "failed", reason: "empty body" };
+    }
+
+    return { kind: "image", bytes, contentType };
+  }
+
+  return { kind: "failed", reason: "redirected too many times" };
+}
+
+function serveThumbnail(
+  response: ServerResponse,
+  entry: CachedThumbnail,
+): void {
+  response.statusCode = 200;
+  response.setHeader("Content-Type", entry.contentType);
+  // Private: the endpoint is token-gated, so one browser's fetched thumbnails
+  // must not be shared with another user of the same browser.
+  response.setHeader("Cache-Control", "private, max-age=3600");
+  response.end(Buffer.from(entry.bytes));
+}
+
+function serveError(
+  response: ServerResponse,
+  statusCode: number,
+  error: string,
+): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json");
+  // A refusal or an upstream failure is not a stable property of the URL, so
+  // the browser must not hold on to it.
+  response.setHeader("Cache-Control", "no-store");
+  response.end(JSON.stringify({ error }));
+}
+
+/**
+ * Serves `/thumbnail?u=<url>`: one search-result thumbnail at a time, behind
+ * the same token verification as `/search`, with an in-process LRU in front
+ * of the upstream host. The search endpoint returns thumbnail URLs as they
+ * came back from SearXNG; the client loads each tile from here, so a dead
+ * thumbnail host delays one tile instead of the whole grid.
+ */
+export function thumbnailEndpointServerHook<
+  T extends ViteDevServer | PreviewServer,
+>(server: T) {
+  server.middlewares.use(async (request, response, next) => {
+    if (!request.url?.startsWith("/thumbnail")) return next();
+
+    const url = new URL(request.url, `http://${request.headers.host}`);
+
+    const { shouldContinue } = await handleTokenVerification(
+      url.searchParams.get("token"),
+      response,
+      request,
+    );
+
+    if (!shouldContinue) return;
+
+    const rawTarget = url.searchParams.get("u");
+    if (!rawTarget) {
+      serveError(response, 400, "Missing thumbnail URL");
+      return;
+    }
+
+    recordThumbnailRequested();
+
+    const cached = getCachedThumbnail(rawTarget);
+    if (cached) {
+      serveThumbnail(response, cached);
+      return;
+    }
+
+    const outcome = await fetchThumbnail(rawTarget);
+
+    if (outcome.kind === "blocked") {
+      recordThumbnailBlocked();
+      // `dropped` is the total of what never reached the client, blocked
+      // included, so `requested` minus `dropped` stays the served count.
+      recordThumbnailDropped();
+      serveError(
+        response,
+        403,
+        "Refusing to fetch thumbnail from a non-public address",
+      );
+      return;
+    }
+
+    if (outcome.kind === "failed") {
+      recordThumbnailDropped();
+      console.warn(`Thumbnail fetch failed: ${outcome.reason}`);
+      serveError(response, 502, "Thumbnail could not be fetched");
+      return;
+    }
+
+    const entry: CachedThumbnail = {
+      bytes: outcome.bytes,
+      contentType: outcome.contentType,
+    };
+    setCachedThumbnail(rawTarget, entry);
+    serveThumbnail(response, entry);
+  });
+}

--- a/server/thumbnailEndpointServerHook.ts
+++ b/server/thumbnailEndpointServerHook.ts
@@ -7,16 +7,36 @@ import {
   recordThumbnailRequested,
 } from "./searchesSinceLastRestart.ts";
 import { resolvePublicUrl } from "./utils/publicUrl.ts";
-import { readCappedBytes } from "./utils/streamUtils.ts";
+import { readCappedBytes, safeEndResponse } from "./utils/streamUtils.ts";
+import { thumbnailRateLimiter } from "./verifyTokenAndRateLimit.ts";
 
 /**
  * Off the critical path: the search response no longer waits on a thumbnail,
  * so the budget is set against how long a user tolerates a placeholder tile,
- * not against the whole grid.
+ * not against the whole grid. It bounds the redirect hops too, DNS included.
  */
 const THUMBNAIL_TIMEOUT_MS = 3000;
 const MAX_THUMBNAIL_REDIRECTS = 3;
 const MAX_THUMBNAIL_BYTES = 500_000;
+/** Matches the cap `/page-content` puts on its client-supplied URLs. */
+const MAX_THUMBNAIL_URL_LENGTH = 2048;
+
+/**
+ * Raster types only, by name: the response is served same-origin, and an SVG
+ * loaded by direct navigation is a document whose scripts would run on this
+ * origin. A data URL in an `<img>` (what the old search path produced) stays
+ * inert; this endpoint must not open that door.
+ */
+const ACCEPTED_CONTENT_TYPES = [
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/vnd.microsoft.icon",
+  "image/webp",
+  "image/x-icon",
+];
 
 /**
  * In-process LRU in front of the upstream hosts: re-running a search,
@@ -34,6 +54,13 @@ interface CachedThumbnail {
 
 const thumbnailCache = new Map<string, CachedThumbnail>();
 let thumbnailCacheBytes = 0;
+
+export function getThumbnailCacheLimits(): {
+  entries: number;
+  bytes: number;
+} {
+  return { entries: MAX_CACHE_ENTRIES, bytes: MAX_CACHE_BYTES };
+}
 
 function getCachedThumbnail(key: string): CachedThumbnail | undefined {
   const entry = thumbnailCache.get(key);
@@ -63,6 +90,15 @@ function setCachedThumbnail(key: string, entry: CachedThumbnail): void {
   }
 }
 
+/**
+ * Drops the in-process cache. The cache is module state, so tests that care
+ * about exact entry counts need a clean slate.
+ */
+export function resetThumbnailCache(): void {
+  thumbnailCache.clear();
+  thumbnailCacheBytes = 0;
+}
+
 type ThumbnailOutcome =
   | { kind: "image"; bytes: Uint8Array; contentType: string }
   | { kind: "blocked" }
@@ -70,6 +106,38 @@ type ThumbnailOutcome =
 
 function isRedirect(status: number): boolean {
   return status >= 300 && status < 400 && status !== 304;
+}
+
+/**
+ * `resolvePublicUrl`'s DNS lookup does not take a signal, so it is raced
+ * against the hop deadline: a hanging resolver would otherwise add its own
+ * timeout on top of the one that is documented to bound the whole chain.
+ */
+function timeoutError(): Error {
+  const error = new Error("The operation was aborted");
+  error.name = "TimeoutError";
+  return error;
+}
+
+function resolveWithinDeadline(
+  deadline: AbortSignal,
+  work: Promise<URL>,
+): Promise<URL> {
+  if (deadline.aborted) return Promise.reject(timeoutError());
+  return new Promise<URL>((resolve, reject) => {
+    const onAbort = () => reject(timeoutError());
+    deadline.addEventListener("abort", onAbort, { once: true });
+    work.then(
+      (url) => {
+        deadline.removeEventListener("abort", onAbort);
+        resolve(url);
+      },
+      (error) => {
+        deadline.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 /**
@@ -88,8 +156,11 @@ async function fetchThumbnail(rawUrl: string): Promise<ThumbnailOutcome> {
   for (let hop = 0; hop <= MAX_THUMBNAIL_REDIRECTS; hop++) {
     let url: URL;
     try {
-      url = await resolvePublicUrl(target);
-    } catch {
+      url = await resolveWithinDeadline(deadline, resolvePublicUrl(target));
+    } catch (error) {
+      if (error instanceof Error && error.name === "TimeoutError") {
+        return { kind: "failed", reason: "TimeoutError" };
+      }
       return { kind: "blocked" };
     }
 
@@ -109,7 +180,11 @@ async function fetchThumbnail(rawUrl: string): Promise<ThumbnailOutcome> {
     const location = response.headers.get("location");
     if (isRedirect(response.status) && location) {
       await response.body?.cancel().catch(() => {});
-      target = new URL(location, url).toString();
+      try {
+        target = new URL(location, url).toString();
+      } catch {
+        return { kind: "failed", reason: "malformed redirect location" };
+      }
       continue;
     }
 
@@ -118,16 +193,16 @@ async function fetchThumbnail(rawUrl: string): Promise<ThumbnailOutcome> {
       return { kind: "failed", reason: `HTTP ${response.status}` };
     }
 
-    const contentType = (response.headers.get("content-type") ?? "")
+    const normalizedType = (response.headers.get("content-type") ?? "")
       .split(";")[0]
       .trim()
       .toLowerCase();
-    if (!contentType.startsWith("image/")) {
+    if (!ACCEPTED_CONTENT_TYPES.includes(normalizedType)) {
       await response.body?.cancel().catch(() => {});
       return {
         kind: "failed",
-        reason: contentType
-          ? `not an image (${contentType})`
+        reason: normalizedType
+          ? `not an accepted image type (${normalizedType})`
           : "no content type",
       };
     }
@@ -146,7 +221,7 @@ async function fetchThumbnail(rawUrl: string): Promise<ThumbnailOutcome> {
       return { kind: "failed", reason: "empty body" };
     }
 
-    return { kind: "image", bytes, contentType };
+    return { kind: "image", bytes, contentType: normalizedType };
   }
 
   return { kind: "failed", reason: "redirected too many times" };
@@ -158,8 +233,13 @@ function serveThumbnail(
 ): void {
   response.statusCode = 200;
   response.setHeader("Content-Type", entry.contentType);
-  // Private: the endpoint is token-gated, so one browser's fetched thumbnails
-  // must not be shared with another user of the same browser.
+  // Defense in depth on top of the raster allowlist: even if a type ever
+  // slips through, the browser must not interpret it as anything else.
+  response.setHeader("X-Content-Type-Options", "nosniff");
+  response.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
+  // Private: the endpoint is token-gated and one browser must not hand
+  // another user's fetched tiles to it. (The in-process LRU is shared across
+  // sessions, but it only serves bytes the upstream already published.)
   response.setHeader("Cache-Control", "private, max-age=3600");
   response.end(Buffer.from(entry.bytes));
 }
@@ -179,10 +259,11 @@ function serveError(
 
 /**
  * Serves `/thumbnail?u=<url>`: one search-result thumbnail at a time, behind
- * the same token verification as `/search`, with an in-process LRU in front
- * of the upstream host. The search endpoint returns thumbnail URLs as they
- * came back from SearXNG; the client loads each tile from here, so a dead
- * thumbnail host delays one tile instead of the whole grid.
+ * the same token verification as `/search` (on its own rate-limit budget,
+ * since one grid fans out into up to 30 of these), with an in-process LRU in
+ * front of the upstream host. The search endpoint returns thumbnail URLs as
+ * they came back from SearXNG; the client loads each tile from here, so a
+ * dead thumbnail host delays one tile instead of the whole grid.
  */
 export function thumbnailEndpointServerHook<
   T extends ViteDevServer | PreviewServer,
@@ -190,57 +271,75 @@ export function thumbnailEndpointServerHook<
   server.middlewares.use(async (request, response, next) => {
     if (!request.url?.startsWith("/thumbnail")) return next();
 
-    const url = new URL(request.url, `http://${request.headers.host}`);
+    try {
+      const url = new URL(request.url, `http://${request.headers.host}`);
 
-    const { shouldContinue } = await handleTokenVerification(
-      url.searchParams.get("token"),
-      response,
-      request,
-    );
-
-    if (!shouldContinue) return;
-
-    const rawTarget = url.searchParams.get("u");
-    if (!rawTarget) {
-      serveError(response, 400, "Missing thumbnail URL");
-      return;
-    }
-
-    recordThumbnailRequested();
-
-    const cached = getCachedThumbnail(rawTarget);
-    if (cached) {
-      serveThumbnail(response, cached);
-      return;
-    }
-
-    const outcome = await fetchThumbnail(rawTarget);
-
-    if (outcome.kind === "blocked") {
-      recordThumbnailBlocked();
-      // `dropped` is the total of what never reached the client, blocked
-      // included, so `requested` minus `dropped` stays the served count.
-      recordThumbnailDropped();
-      serveError(
+      const { shouldContinue } = await handleTokenVerification(
+        url.searchParams.get("token"),
         response,
-        403,
-        "Refusing to fetch thumbnail from a non-public address",
+        request,
+        { limiter: thumbnailRateLimiter },
       );
-      return;
-    }
 
-    if (outcome.kind === "failed") {
-      recordThumbnailDropped();
-      console.warn(`Thumbnail fetch failed: ${outcome.reason}`);
-      serveError(response, 502, "Thumbnail could not be fetched");
-      return;
-    }
+      if (!shouldContinue) return;
 
-    const entry: CachedThumbnail = {
-      bytes: outcome.bytes,
-      contentType: outcome.contentType,
-    };
-    setCachedThumbnail(rawTarget, entry);
-    serveThumbnail(response, entry);
+      const rawTarget = url.searchParams.get("u");
+      if (!rawTarget) {
+        serveError(response, 400, "Missing thumbnail URL");
+        return;
+      }
+
+      if (rawTarget.length > MAX_THUMBNAIL_URL_LENGTH) {
+        serveError(response, 400, "Thumbnail URL too long");
+        return;
+      }
+
+      recordThumbnailRequested();
+
+      const cached = getCachedThumbnail(rawTarget);
+      if (cached) {
+        serveThumbnail(response, cached);
+        return;
+      }
+
+      const outcome = await fetchThumbnail(rawTarget);
+
+      if (outcome.kind === "blocked") {
+        recordThumbnailBlocked();
+        // `dropped` is the total of what never reached the client, blocked
+        // included, so `requested` minus `dropped` stays the served count.
+        recordThumbnailDropped();
+        serveError(
+          response,
+          403,
+          "Refusing to fetch thumbnail from a non-public address",
+        );
+        return;
+      }
+
+      if (outcome.kind === "failed") {
+        recordThumbnailDropped();
+        console.warn(`Thumbnail fetch failed: ${outcome.reason}`);
+        serveError(response, 502, "Thumbnail could not be fetched");
+        return;
+      }
+
+      // Failures are never cached: a transient upstream refusal must be able
+      // to recover on the next tile load.
+      const entry: CachedThumbnail = {
+        bytes: outcome.bytes,
+        contentType: outcome.contentType,
+      };
+      setCachedThumbnail(rawTarget, entry);
+      serveThumbnail(response, entry);
+    } catch {
+      // Vite's connect stack does not await async middleware, so a throw here
+      // would be an unhandled rejection that takes the process down.
+      response.statusCode = 500;
+      safeEndResponse(
+        response,
+        JSON.stringify({ error: "Internal server error" }),
+      );
+    }
   });
 }

--- a/server/thumbnailEndpointServerHook.ts
+++ b/server/thumbnailEndpointServerHook.ts
@@ -309,10 +309,12 @@ export function thumbnailEndpointServerHook<
         // `dropped` is the total of what never reached the client, blocked
         // included, so `requested` minus `dropped` stays the served count.
         recordThumbnailDropped();
+        // Covers both refusals resolvePublicUrl reports the same way: a host
+        // in private space and a host that does not resolve.
         serveError(
           response,
           403,
-          "Refusing to fetch thumbnail from a non-public address",
+          "Refusing to fetch a thumbnail from a non-public or unresolvable address",
         );
         return;
       }

--- a/server/verifyTokenAndRateLimit.test.ts
+++ b/server/verifyTokenAndRateLimit.test.ts
@@ -360,6 +360,34 @@ describe("verifyTokenAndRateLimit", () => {
     expect(mockConsume).toHaveBeenCalledWith("127.0.0.1");
   });
 
+  it("draws /thumbnail requests from a separate limiter, so one grid cannot exhaust the search budget", async () => {
+    vi.resetModules();
+    const {
+      verifyTokenAndRateLimit,
+      thumbnailRateLimiter,
+      RATE_LIMIT_POINTS,
+      THUMBNAIL_RATE_LIMIT_POINTS,
+    } = await import("./verifyTokenAndRateLimit");
+    consumeInstances.clear();
+    mockIsVerifiedToken = true;
+    const mockReq = makeMockRequest("192.168.1.100");
+
+    await verifyTokenAndRateLimit("token", mockReq);
+    const searchInstances = [...consumeInstances];
+
+    await verifyTokenAndRateLimit("token", mockReq, thumbnailRateLimiter);
+    const thumbnailInstances = [...consumeInstances].filter(
+      (instance) => !searchInstances.includes(instance),
+    );
+
+    // The tile load drew from a different limiter than the search, so the
+    // up-to-30-tile fan-out of one image search cannot eat the user's
+    // text-search and page-read budget.
+    expect(searchInstances).toHaveLength(1);
+    expect(thumbnailInstances).toHaveLength(1);
+    expect(THUMBNAIL_RATE_LIMIT_POINTS).toBeGreaterThan(RATE_LIMIT_POINTS);
+  });
+
   it("should key rate limiter on the forwarded client IP when TRUST_PROXY is enabled", async () => {
     mockRateLimiterShouldFail = false;
     vi.stubEnv("TRUST_PROXY", "true");

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -102,10 +102,13 @@ export function getClientIp(request: IncomingMessage): string {
  * client IP. Returns `true` when the request is within budget, `false` when the
  * limiter refuses it.
  *
- * It reuses the same limiter instance the search path consumes from, so a
- * caller cannot get a second, independent budget by hitting a different
- * endpoint. Endpoints that pay for expensive work without a token (access-key
- * validation) must consume here before doing that work.
+ * It reuses the same limiter instance the token-verified endpoints consume
+ * from, so a tokenless caller cannot get a second, independent budget by
+ * hitting a different endpoint. (The one deliberate exception is /thumbnail,
+ * which verifies a token like the rest and carries its own budget because a
+ * grid fans out into up to 30 tile loads.) Endpoints that pay for expensive
+ * work without a token (access-key validation) must consume here before doing
+ * that work.
  */
 export async function consumeRateLimitPoint(
   request: IncomingMessage,

--- a/server/verifyTokenAndRateLimit.ts
+++ b/server/verifyTokenAndRateLimit.ts
@@ -25,6 +25,21 @@ const rateLimiter = new RateLimiterMemory({
   duration: RATE_LIMIT_DURATION_SECONDS,
 });
 
+/**
+ * A single image search fans out into up to 30 tile loads, so `/thumbnail`
+ * draws from its own budget: sharing the search bucket would let one grid
+ * exhaust the user's text-search and page-read budget, and the 429s would
+ * land on tiles the browser's `<img>` cannot retry. The token gate stays
+ * shared, so a hostile caller still pays one verification per tile.
+ */
+export const THUMBNAIL_RATE_LIMIT_POINTS = 60;
+export const THUMBNAIL_RATE_LIMIT_DURATION_SECONDS = 10;
+
+export const thumbnailRateLimiter = new RateLimiterMemory({
+  points: THUMBNAIL_RATE_LIMIT_POINTS,
+  duration: THUMBNAIL_RATE_LIMIT_DURATION_SECONDS,
+});
+
 /** Why a request was turned away, named by the check that turned it away. */
 export type RejectionReason = "rateLimited" | "missingToken" | "invalidToken";
 
@@ -124,6 +139,7 @@ function reportTokenFileChangeOnce() {
 export async function verifyTokenAndRateLimit(
   token: string | null,
   request?: IncomingMessage,
+  limiter: RateLimiterMemory = rateLimiter,
 ): Promise<TokenVerificationResult> {
   // Rate-limit before anything else. An invalid or missing token used to skip
   // the limiter entirely, and every rejected request still pays for a full
@@ -132,7 +148,7 @@ export async function verifyTokenAndRateLimit(
   // bogus tokens and pin the server's CPU without ever hitting the limiter.
   const rateLimitKey = request ? getClientIp(request) : (token ?? "anonymous");
   try {
-    await rateLimiter.consume(rateLimitKey);
+    await limiter.consume(rateLimitKey);
   } catch {
     return {
       isAuthorized: false,

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -303,13 +303,17 @@ export async function fetchSearXNG(
 
 async function processGraphicalResult(result: SearxngSearchResult) {
   const thumbnailSource =
-    result.category === "videos" ? result.thumbnail : result.thumbnail_src;
+    (result.category === "videos" ? result.thumbnail : result.thumbnail_src) ??
+    "";
 
   const sourceUrl =
-    result.category === "videos"
+    (result.category === "videos"
       ? result.iframe_src || result.url
-      : result.img_src;
+      : result.img_src) ?? "";
 
+  // Empty strings, not undefined: the client reads the tuple positionally and
+  // treats an empty thumbnail as "no thumbnail" and an empty source as
+  // "no link to the full image".
   try {
     return [result.title, result.url, thumbnailSource, sourceUrl] as [
       title: string,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ import { rerankerServiceHook } from "./server/rerankerServiceHook.ts";
 import { searchEndpointServerHook } from "./server/searchEndpointServerHook.ts";
 import { regenerateSearchToken } from "./server/searchToken.ts";
 import { statusEndpointServerHook } from "./server/statusEndpointServerHook.ts";
+import { thumbnailEndpointServerHook } from "./server/thumbnailEndpointServerHook.ts";
 import { validateAccessKeyServerHook } from "./server/validateAccessKeyServerHook.ts";
 
 dotenv.config({ path: [".env", ".env.example"], quiet: true });
@@ -96,6 +97,11 @@ export default defineConfig(({ command }) => {
         name: "configure-server-page-content-endpoint",
         configureServer: pageContentEndpointServerHook,
         configurePreviewServer: pageContentEndpointServerHook,
+      },
+      {
+        name: "configure-server-thumbnail-endpoint",
+        configureServer: thumbnailEndpointServerHook,
+        configurePreviewServer: thumbnailEndpointServerHook,
       },
       {
         name: "configure-server-status-endpoint",


### PR DESCRIPTION
Currently, an image search waits on every thumbnail before answering: the server pre-fetches each `thumbnail_src` into a data URL, and the response awaits the slowest of up to 30. On the deployed Space that shows up as `averageGraphicalMs` at 3822ms against 910ms for text, while 200 of the last 496 thumbnails end up as placeholders anyway (105 dropped, 95 blocked).

This PR returns the ranked grid without waiting on the thumbnails. The search response carries the URLs as-is, and the client loads each tile from a new `/thumbnail` endpoint.

| Where | What |
| --- | --- |
| `server/thumbnailEndpointServerHook.ts` | New token-gated `/thumbnail?u=...` endpoint: SSRF guard on every redirect hop, 3s deadline (DNS included), 500KB byte cap (truncated and served), raster content types only, in-process LRU (100 entries, 50MB), and its own rate-limit budget (60 points per 10s) since one grid fans out into up to 30 tile loads |
| `server/searchEndpointServerHook.ts` | The image path no longer fetches thumbnails; results carry `thumbnailSource` URLs |
| `client/modules/thumbnailUrls.ts` | New: wraps each thumbnail URL in a `/thumbnail` request, with the token resolved once per page load |
| `client/components/Search/Results/Graphical/ImageResultsList.tsx` | Skeleton tiles until the src resolves, `loading="lazy"`, host-name fallback on error, and the same host-name placeholder in the lightbox when a thumbnail is missing |
| `server/authorizationSinceLastRestart.ts` | `thumbnail` added to `bySurface`; `/status` reports both rate-limit budgets |
| docs | `overview.md`, `security.md`, `failure-injection.md`, `agents.md` |

## Verification

- `npx vitest run`: 727 passed (21 in the new hook test file).
- `npm run lint`: 0 errors (6 pre-existing stale-doc warnings, also on `main`).
- Live smoke against `npm run dev`: 200 responses carry `nosniff` plus a sandbox CSP, an `image/svg+xml` upstream is refused with 502, 61 rapid requests yield 60 served plus 3 x 429, and the `/status` sums close.

## How to test

1. `npm run dev`, run an image search. The grid should appear without waiting, and tiles fill in as they load (one `/thumbnail?u=...` request per tile in the network tab).
2. Pick a result whose host is slow or dead: the grid still renders, the tile shows the host name, and the lightbox shows the placeholder instead of a blank or a page.
3. Check `/status`: `authorization.bySurface.thumbnail` and the `thumbnails.*` counters.

## Known limitations

- The IndexedDB result cache stores thumbnail URLs now instead of bytes, so a host that signs short-lived URLs will show host-name tiles on a stale restore (15min to 24h).
- `thumbnails.requested` counted image results in the search response before this change, so the served share cannot be trended across this deploy.
