### PR TITLE
Fix the stale header comment in searxng-settings.yml

### DIFF
--- a/searxng-settings.yml
+++ b/searxng-settings.yml
@@ -2,8 +2,8 @@
 #
 # Built on top of SearXNG's upstream defaults via `use_default_settings`, so this
 # file only declares what MiniSearch overrides:
+#   - a placeholder secret_key
 #   - JSON output format (consumed by server/webSearchService.ts)
-#   - an explicit, resilient set of general-web engines
 #
 # Docs: https://docs.searxng.org/admin/settings/settings_use_default_settings.html
 use_default_settings: true


### PR DESCRIPTION
Currently, the header comment in `searxng-settings.yml` says the file declares "an explicit, resilient set of general-web engines". That set was removed in `ac8a983` (the engines did not bring useful results), and the file no longer declares any engines, so the comment describes an override that does not exist.

This PR updates the header to list the two things the file actually declares.

| Where | What |
| --- | --- |
| `searxng-settings.yml` | Header comment: the stale engines bullet is replaced by the `secret_key` placeholder (the other real declaration), and the bullets now follow the file's order |

## Verification

- Checked against the file body and `Dockerfile:49` (`sed` replacing the placeholder with `openssl rand -hex 32` at image build time).
- Grep confirms nothing else in the repo (docs, README) makes the same stale engines claim.
