### PR TITLE
Report the server start time on /status

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -234,7 +234,8 @@ The `/status` endpoint returns a JSON object:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `uptime` | string | Human-readable server uptime |
+| `uptime` | string | Human-readable server uptime, measured from `startedAt` |
+| `startedAt` | string | ISO timestamp of the server start; all the "since last restart" counters below are measured from this moment |
 | `sessions` | number | Distinct verified sessions since last restart, which the two per-session averages below divide by |
 | `activeSessions` | number | Sessions still in the cache, dropped after 30 idle minutes |
 | `textualSearches` | number | Text search count since last restart |

--- a/server/statusEndpointServerHook.test.ts
+++ b/server/statusEndpointServerHook.test.ts
@@ -1,0 +1,76 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { statusEndpointServerHook } from "./statusEndpointServerHook.ts";
+
+// The health getters probe live services; this test is about the payload,
+// so they answer healthy without a network.
+vi.mock("./biEncoderService.ts", () => ({
+  getBiEncoderStatus: async () => true,
+}));
+vi.mock("./rerankerService.ts", () => ({
+  getRerankerStatus: async () => true,
+}));
+vi.mock("./webSearchService.ts", () => ({
+  getWebSearchStatus: async () => true,
+  getSearchCircuitStats: () => ({
+    circuitState: "closed",
+    circuitOpens: 0,
+  }),
+}));
+
+type Handler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+  next: () => void,
+) => Promise<void>;
+
+type RecordedResponse = ServerResponse & {
+  setHeader: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+};
+
+function callStatus(): Promise<Record<string, unknown>> {
+  const use = vi.fn();
+  // Vite sets VITE_BUILD_DATE_TIME for every serve (see vite.config.ts).
+  statusEndpointServerHook({
+    middlewares: { use },
+    config: { define: { VITE_BUILD_DATE_TIME: new Date().toISOString() } },
+  } as unknown as Parameters<typeof statusEndpointServerHook>[0]);
+
+  const response = {
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as RecordedResponse;
+  const request = {
+    url: "/status",
+    headers: {},
+  } as unknown as IncomingMessage;
+
+  return (use.mock.calls[0][0] as Handler)(
+    request,
+    response,
+    () => undefined,
+  ).then(() => JSON.parse(response.end.mock.calls[0][0]));
+}
+
+describe("statusEndpointServerHook", () => {
+  it("keeps startedAt fixed at the restart while uptime advances", async () => {
+    const first = await callStatus();
+    expect(typeof first.startedAt).toBe("string");
+    const startedAt = Date.parse(first.startedAt as string);
+    expect(Number.isNaN(startedAt)).toBe(false);
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(startedAt + 600_000);
+      const later = await callStatus();
+      // The module captured its start once, on import: startedAt is the same
+      // instant on every call while uptime advances. Replacing the capture
+      // with a per-call Date.now() fails this.
+      expect(later.startedAt).toBe(first.startedAt);
+      expect(later.uptime).toBe("10 minutes");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/statusEndpointServerHook.ts
+++ b/server/statusEndpointServerHook.ts
@@ -68,6 +68,10 @@ export function statusEndpointServerHook<
       uptime: prettyMilliseconds(Date.now() - serverStartTime, {
         verbose: true,
       }),
+      // The counters below read "since last restart"; this is that start,
+      // as an absolute timestamp, so a reader can tell which deploys a
+      // window of counters spans.
+      startedAt: new Date(serverStartTime).toISOString(),
       sessions,
       textualSearches,
       graphicalSearches,


### PR DESCRIPTION
Currently, every counter on `/status` reads "since last restart" (the Space restarts on each deploy), but nothing says when that restart was, so a reader cannot tell which deploys a window of counters spans. The `uptime` string only gives the window in relative terms.

This PR exposes the start instant as an ISO timestamp. The hook already captured `serverStartTime` at module load for the human-readable `uptime` string; `startedAt` is that same instant.

| Where | What |
| --- | --- |
| `server/statusEndpointServerHook.ts` | `startedAt` (ISO) next to `uptime` |
| `docs/overview.md` | The new field in the `/status` table, and the `uptime` row now points at it |
| `server/statusEndpointServerHook.test.ts` | New (first test file for the hook): with the clock advanced 10 minutes, `startedAt` is the same string on both calls while `uptime` reads "10 minutes"; verified by mutation (a per-call `Date.now()` fails it) |

## Verification

- `npx vitest run`: 704 passed, including the new file.
- `npm run lint`: 0 errors (6 pre-existing stale-doc warnings, also on `main`).
