### PR TITLE
Drop image results that come back without a thumbnail URL

### DIFF
--- a/docs/failure-injection.md
+++ b/docs/failure-injection.md
@@ -36,6 +36,7 @@ needed.
 | Thumbnail upstream refuses once, then recovers | The failure is not cached; the next tile load fetches again and serves | `server/thumbnailEndpointServerHook.test.ts` |
 | `/thumbnail` budget is spent | HTTP 429 for the tiles only; the search budget is a separate limiter | `server/handleTokenVerification.test.ts`, `server/thumbnailEndpointServerHook.test.ts` |
 | A tile's `/thumbnail` request fails in the browser | That tile shows the host name, the rest of the grid is untouched | `client/components/Search/Results/Graphical/ImageResultsList.test.tsx` |
+| SearXNG returns an image result with no thumbnail URL | The result is dropped, so the grid never shows a host-name tile for it | `server/webSearchService.test.ts` › graceful degradation |
 | Search returns nothing to the endpoint | HTTP 200 with `[]`, not an error | `server/searchEndpointServerHook.test.ts` › graceful degradation |
 | Text search returns nothing to the client | Keyword-only query retried as a fallback | `client/modules/textGeneration.degradation.test.ts` |
 | Keyword fallback also returns nothing | Text search state stays `completed` with the no-results alert | `client/modules/textGeneration.degradation.test.ts` |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -97,7 +97,7 @@ The system executes two parallel flows when a user submits a query:
 4. Server verifies request token via `searchToken.ts` (CSRF protection)
 5. `webSearchService.ts` forwards query to SearXNG at `http://127.0.0.1:8888`
 6. Raw results are deduplicated, cleaned, and optionally reranked
-7. Image results keep the thumbnail URLs SearXNG returned; the client loads each tile on its own from `/thumbnail`, so the response does not wait on any thumbnail host
+7. Image results keep the thumbnail URLs SearXNG returned, and results that came back without one are dropped; the client loads each tile on its own from `/thumbnail`, so the response does not wait on any thumbnail host
 8. Results returned as structured JSON and cached in IndexedDB (15-minute freshness TTL)
 
 ### AI Generation Flow
@@ -268,9 +268,10 @@ after the retries are spent or immediately for an all-suspended set
 whether the case is being over-classified. It undercounts a sustained
 outage, where the circuit breaker short-circuits before `performSearch` is
 reached, and it does not count a search that recovered on a retry at all,
-which is the point of the retry. The discarded count covers text searches only,
-because an image result is never dropped at this stage: a thumbnail that
-cannot be loaded is dropped later, when the client fetches it from
+which is the point of the retry. The discarded count covers image searches too:
+a result SearXNG returned without a thumbnail URL is dropped here, since the
+grid has nothing to show for it. A thumbnail whose URL is there but cannot be
+loaded is a later, per-tile failure, handled when the client fetches it from
 `/thumbnail`.
 
 `pageReads` reports what happened to the pages read for AI answers. Each field

--- a/server/webSearchService.test.ts
+++ b/server/webSearchService.test.ts
@@ -526,6 +526,52 @@ describe("graceful degradation", () => {
 
     expect(results).toEqual([]);
   });
+
+  it("drops image results that carry no thumbnail URL", async () => {
+    fetchMock.mockResolvedValue(
+      createMockResponse(
+        JSON.stringify({
+          results: [
+            {
+              title: "with thumbnail",
+              url: "https://example.com/picture",
+              category: "images",
+              img_src: "https://example.com/picture.jpg",
+              thumbnail_src: "https://example.com/thumbnail.jpg",
+            },
+            {
+              title: "video without thumbnail",
+              url: "https://example.com/watch",
+              category: "videos",
+              iframe_src: "https://example.com/embed",
+            },
+            {
+              title: "image without thumbnail",
+              url: "https://other.com/picture",
+              category: "images",
+              img_src: "https://other.com/picture.jpg",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const results = await fetchSearXNG(
+      "failure injection",
+      "images",
+      30,
+      new CircuitBreaker(breakerOptions),
+    );
+
+    expect(results).toEqual([
+      [
+        "with thumbnail",
+        "https://example.com/picture",
+        "https://example.com/thumbnail.jpg",
+        "https://example.com/picture.jpg",
+      ],
+    ]);
+  });
 });
 
 describe("query privacy", () => {

--- a/server/webSearchService.ts
+++ b/server/webSearchService.ts
@@ -303,31 +303,26 @@ export async function fetchSearXNG(
 
 async function processGraphicalResult(result: SearxngSearchResult) {
   const thumbnailSource =
-    (result.category === "videos" ? result.thumbnail : result.thumbnail_src) ??
-    "";
+    result.category === "videos" ? result.thumbnail : result.thumbnail_src;
 
+  // A grid tile is the thumbnail: without one there is nothing to show but the
+  // host name, and SearXNG leaves the field out often enough (video engines
+  // especially) that keeping these fills the carousel with text placeholders.
+  if (!thumbnailSource) return null;
+
+  // Empty string, not undefined: the client reads the tuple positionally and
+  // treats an empty source as "no link to the full image".
   const sourceUrl =
     (result.category === "videos"
       ? result.iframe_src || result.url
       : result.img_src) ?? "";
 
-  // Empty strings, not undefined: the client reads the tuple positionally and
-  // treats an empty thumbnail as "no thumbnail" and an empty source as
-  // "no link to the full image".
-  try {
-    return [result.title, result.url, thumbnailSource, sourceUrl] as [
-      title: string,
-      url: string,
-      thumbnailSource: string,
-      sourceUrl: string,
-    ];
-  } catch (error) {
-    console.warn(
-      `Failed to process ${result.category} result: ${result.url}`,
-      error instanceof Error ? error.message : error,
-    );
-    return null;
-  }
+  return [result.title, result.url, thumbnailSource, sourceUrl] as [
+    title: string,
+    url: string,
+    thumbnailSource: string,
+    sourceUrl: string,
+  ];
 }
 
 function processSnippet(snippet: string): string {


### PR DESCRIPTION
## Description

Currently, the image grid shows host-name text tiles instead of pictures, for a large share of the results. SearXNG often returns image and video results with no `thumbnail_src` (or no `thumbnail`, for the videos category), and until #2489 those results were dropped as a side effect: the server fetched every thumbnail itself, the fetch of an empty URL threw, and the result was filtered out. Now the browser loads each tile from `/thumbnail`, so nothing drops them anymore and they reach the carousel with an empty thumbnail, where the client renders the host name as a fallback.

Sampled on the dev container, before the fix: `guitar tutorial` 6 of 15, `cat` 6 of 20, `cooking pasta` 5 of 20, `mountain landscape` 4 of 18, `javascript tutorial` 3 of 16. After the fix, all five queries return zero results without a thumbnail. (On `golden retriever puppies` the grid went from a `youtube.com` placeholder in the second tile to 17 results that are all images.)

`processGraphicalResult` now returns `null` for those, so `filterNullResults` drops them the same way it drops a text result without a snippet. The now-unreachable `try`/`catch` around the tuple went away with it (it was there for the thumbnail fetch that moved to `/thumbnail`).

The client's host-name fallback tile stays as it is. It still covers the case it was written for: a thumbnail URL that is there but fails to load (a dead host, a 403, a non-raster type), plus cached history entries from before this change.

## How to test

1. `docker compose up`
2. `docker compose exec development-server npm run test` (new case in `server/webSearchService.test.ts`: "drops image results that carry no thumbnail URL")
3. Open `http://localhost:7860/?q=guitar%20tutorial` and check the image carousel. Every tile is a picture, with no gray boxes reading `youtube.com` or similar.
4. `docker compose exec development-server npm run lint`