### PR TITLE
ci: fix biome.json schema version mismatch warning (#2529)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
﻿## Summary

Fixes #2529 — updates the `$schema` in `biome.json` from version `2.5.8` to `2.5.11` via `biome migrate`.

## Problem

Running `npm run lint` or `biome check biome.json` produced the following schema mismatch warning:
```
The configuration schema version does not match the CLI version 2.5.11
Expected: 2.5.11
Found: 2.5.8
```

## Changes

- Updated `$schema` in `biome.json` to `"https://biomejs.dev/schemas/2.5.11/schema.json"`.

## Verification

- Ran `npx @biomejs/biome check biome.json` and verified:
  ```
  Checked 1 file in 1874µs. No fixes applied.
  ```
- Confirmed zero warnings or errors emitted on `biome.json`.
- Staged as Draft PR for maintainer review.
