### PR TITLE
fix: add missing jscpd-windows-arm64-msvc to lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4511,7 +4511,7 @@
         "jscpd-linux-arm64-gnu": "5.0.16",
         "jscpd-linux-x64-gnu": "5.0.16",
         "jscpd-linux-x64-musl": "5.0.16",
-        "jscpd-windows-arm64-msvc": "5.0.16",
+        "jscpd-windows-arm64-msvc": "5.1.0",
         "jscpd-windows-x64-msvc": "5.0.16"
       }
     },
@@ -8451,6 +8451,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/jscpd-windows-arm64-msvc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jscpd-windows-arm64-msvc/-/jscpd-windows-arm64-msvc-5.1.0.tgz",
+      "integrity": "sha512-+tCR9mz65S1c1283rsziv+012HBW2DqzCWzZi58InOxidnik/zkO/CYcrtbVsmLT2ZgPpCBsLYXFsKS9fxt/xA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

CI is failing on main after the jscpd 5.1.0 update (#2509). The npm ci step in the Docker build fails with:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: jscpd-windows-arm64-msvc@ from lock file
```

## Root cause

The Renovate PR that updated jscpd to 5.1.0 added jscpd-windows-arm64-msvc to jscpd's optionalDependencies in the lock file, but the actual package entry for node_modules/jscpd-windows-arm64-msvc was never added. The npm ci command requires all packages (including optional platform-specific ones) to have entries in the lock file.

## Fix

Add the missing jscpd-windows-arm64-msvc@5.1.0 package entry to package-lock.json.

## Verification

- npm ci --dry-run passes locally
- Lock file now contains the package entry with correct integrity hash