### PR TITLE
dx: use local biome binary in pre-commit hook (#2522)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
-npm install --no-save @biomejs/biome
 if git diff --cached --name-only | grep -qE '\.(ts|tsx|js|jsx|mjs|cjs)$'; then
-  npx @biomejs/biome check --write --staged --no-errors-on-unmatched
+  biome="$(git rev-parse --show-toplevel)/node_modules/.bin/biome"
+  if [ ! -x "$biome" ]; then
+    echo "pre-commit: @biomejs/biome not found in node_modules. Run 'npm ci' and try again." >&2
+    exit 1
+  fi
+  "$biome" check --write --staged --no-errors-on-unmatched
 fi
 git diff --cached --name-only --diff-filter=d | while read -r file; do [ -f "$file" ] && git add "$file"; done


### PR DESCRIPTION
I'd drop the npm install --no-save line from .husky/pre-commit and call ./node_modules/.bin/biome directly, since it's already a devDependency. 

I'd add a guard that fails with a clear "run npm ci" message if the binary is missing, and verify commits still format staged files correctly while offline.
