### PR TITLE
docs: add project support guidance

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,36 @@
+# Support
+
+## Getting help
+
+If you need help with MiniSearch, these are the best support channels.
+
+### GitHub Discussions
+
+For questions, feature requests, and general discussion, use [GitHub Discussions](https://github.com/felladrin/MiniSearch/discussions). This is the best place to:
+
+- Ask how to configure MiniSearch for your use case
+- Request new features
+- Share ideas and feedback
+- Discuss best practices
+
+### Bug reports
+
+Report bugs through [GitHub Issues](https://github.com/felladrin/MiniSearch/issues/new?template=bug_report.yml). Before opening an issue, check whether the problem has already been reported and include enough detail to reproduce it.
+
+### Security vulnerabilities
+
+Do not report security vulnerabilities in a public issue. Use [GitHub's Private Vulnerability Reporting](https://github.com/felladrin/MiniSearch/security/advisories/new) instead.
+
+### Live demo
+
+Try MiniSearch in your browser at [felladrin-minisearch.hf.space](https://felladrin-minisearch.hf.space) before deploying your own instance.
+
+## Community
+
+- Follow [@felladrin](https://github.com/felladrin) for project updates
+- Star the repository to show your support
+- Contribute by opening pull requests after reading the [contribution guidelines](CONTRIBUTING.md)
+
+## Response times
+
+This is a community-maintained project. While the maintainer tries to respond to issues and discussions promptly, response times may vary.


### PR DESCRIPTION
## Description

I added a project-specific support page that directs users to the right channel for questions, feature requests, bug reports, and private security reports. It also links to the live demo and contribution guidelines and sets expectations for response times.

Fixes #2528

## How to test

1. Run `npm ci`.
2. Run `npm run lint`.
3. Run `npm run test`.
4. Run `npm run format:check`.
5. Verify that every link in `.github/SUPPORT.md` resolves.

I ran all of the commands above. The complete test suite passed with 729 tests, the full lint pipeline and formatting check passed, and each external support URL returned HTTP 200.
