### PR TITLE
test: cover server model configuration and reranker lifecycle hook

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,24 @@ Configure default models for different inference types:
 |----------|---------|-------------|
 | `WLLAMA_DEFAULT_MODEL_ID` | `littlelamb-290m` | Default Wllama model ID (used for both WebGPU-accelerated and CPU inference) |
 
+### Server Model Request Configuration
+
+The server-side model request defaults can be adjusted at runtime with these
+optional environment variables. Integer values are parsed as decimal numbers,
+and temperature and top-p values are parsed as floating-point numbers. An empty
+value uses the corresponding default.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL_MAX_RETRIES` | `5` | Maximum number of retries for a model request |
+| `MODEL_BASE_BACKOFF_MS` | `100` | Initial retry backoff in milliseconds |
+| `MODEL_MAX_BACKOFF_MS` | `5000` | Maximum retry backoff in milliseconds |
+| `MODEL_REQUEST_TIMEOUT_MS` | `30000` | Model request timeout in milliseconds |
+| `MODEL_MAX_CONCURRENT_REQUESTS` | `10` | Maximum number of simultaneous model requests |
+| `MODEL_DEFAULT_MAX_TOKENS` | `2048` | Default maximum number of generated tokens |
+| `MODEL_TEMPERATURE` | `0.7` | Model sampling temperature |
+| `MODEL_TOP_P` | `0.9` | Model nucleus-sampling probability |
+
 ### Internal API Configuration
 
 For self-hosted OpenAI-compatible APIs:

--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -139,7 +139,7 @@ The `O4` (fp16) export loads without complaint but is slower than fp32 on CPU, s
 
 ## Testing
 
-`server/rerankerService.test.ts` runs in the default suite and covers Unicode sanitization, token truncation, and that every document is sent as its own unpadded row, with the ONNX Runtime session, the tokenizer, and the model download all mocked.
+`server/rerankerService.test.ts` runs in the default suite and covers Unicode sanitization, token truncation, and that every document is sent as its own unpadded row, with the ONNX Runtime session, the tokenizer, and the model download all mocked. `server/rerankerServiceHook.test.ts` covers startup error handling and shutdown cleanup with the service dependencies mocked.
 
 `server/rerankerService.integration.test.ts` loads the real model and asserts ranking quality against English and Portuguese fixtures. It downloads ~136MB, the model plus a 17MB sentencepiece tokenizer, so it is excluded from the default suite:
 

--- a/server/config/modelConfig.test.ts
+++ b/server/config/modelConfig.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getModelConfig } from "./modelConfig.ts";
+
+const modelEnvironmentVariables = [
+  "MODEL_MAX_RETRIES",
+  "MODEL_BASE_BACKOFF_MS",
+  "MODEL_MAX_BACKOFF_MS",
+  "MODEL_REQUEST_TIMEOUT_MS",
+  "MODEL_MAX_CONCURRENT_REQUESTS",
+  "MODEL_DEFAULT_MAX_TOKENS",
+  "MODEL_TEMPERATURE",
+  "MODEL_TOP_P",
+] as const;
+
+const originalModelEnvironment = new Map(
+  modelEnvironmentVariables.map((variable) => [
+    variable,
+    process.env[variable],
+  ]),
+);
+
+function clearModelEnvironment() {
+  for (const variable of modelEnvironmentVariables) {
+    delete process.env[variable];
+  }
+}
+
+function restoreModelEnvironment() {
+  for (const variable of modelEnvironmentVariables) {
+    const originalValue = originalModelEnvironment.get(variable);
+    if (originalValue === undefined) delete process.env[variable];
+    else process.env[variable] = originalValue;
+  }
+}
+
+describe("getModelConfig", () => {
+  beforeEach(clearModelEnvironment);
+
+  afterEach(restoreModelEnvironment);
+
+  it("returns the default model configuration", () => {
+    expect(getModelConfig()).toEqual({
+      maxRetries: 5,
+      baseBackoffMs: 100,
+      maxBackoffMs: 5000,
+      requestTimeoutMs: 30000,
+      maxConcurrentRequests: 10,
+      defaultMaxTokens: 2048,
+      temperature: 0.7,
+      topP: 0.9,
+    });
+  });
+
+  it("keeps the defaults within the supported request ranges", () => {
+    const config = getModelConfig();
+
+    expect(config.maxRetries).toBeGreaterThanOrEqual(0);
+    expect(config.baseBackoffMs).toBeGreaterThan(0);
+    expect(config.maxBackoffMs).toBeGreaterThanOrEqual(config.baseBackoffMs);
+    expect(config.requestTimeoutMs).toBeGreaterThan(0);
+    expect(config.maxConcurrentRequests).toBeGreaterThan(0);
+    expect(config.defaultMaxTokens).toBeGreaterThan(0);
+    expect(config.temperature).toBeGreaterThanOrEqual(0);
+    expect(config.temperature).toBeLessThanOrEqual(2);
+    expect(config.topP).toBeGreaterThan(0);
+    expect(config.topP).toBeLessThanOrEqual(1);
+  });
+
+  it("parses every supported environment override", () => {
+    process.env.MODEL_MAX_RETRIES = "2";
+    process.env.MODEL_BASE_BACKOFF_MS = "250";
+    process.env.MODEL_MAX_BACKOFF_MS = "10000";
+    process.env.MODEL_REQUEST_TIMEOUT_MS = "45000";
+    process.env.MODEL_MAX_CONCURRENT_REQUESTS = "4";
+    process.env.MODEL_DEFAULT_MAX_TOKENS = "4096";
+    process.env.MODEL_TEMPERATURE = "0.2";
+    process.env.MODEL_TOP_P = "0.95";
+
+    expect(getModelConfig()).toEqual({
+      maxRetries: 2,
+      baseBackoffMs: 250,
+      maxBackoffMs: 10000,
+      requestTimeoutMs: 45000,
+      maxConcurrentRequests: 4,
+      defaultMaxTokens: 4096,
+      temperature: 0.2,
+      topP: 0.95,
+    });
+  });
+
+  it("uses the default for an empty environment variable", () => {
+    process.env.MODEL_MAX_RETRIES = "";
+    process.env.MODEL_TEMPERATURE = "";
+
+    expect(getModelConfig()).toMatchObject({
+      maxRetries: 5,
+      temperature: 0.7,
+    });
+  });
+});

--- a/server/rerankerServiceHook.test.ts
+++ b/server/rerankerServiceHook.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  startRerankerService,
+  stopRerankerService,
+} from "./rerankerService.ts";
+import { rerankerServiceHook } from "./rerankerServiceHook.ts";
+import { startWebSearchService } from "./webSearchService.ts";
+
+vi.mock("./rerankerService.ts", () => ({
+  startRerankerService: vi.fn(),
+  stopRerankerService: vi.fn(),
+}));
+
+vi.mock("./webSearchService.ts", () => ({
+  startWebSearchService: vi.fn(),
+}));
+
+type ServerWithCloseHandler = {
+  httpServer?: {
+    on: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createServer(withHttpServer = true): ServerWithCloseHandler {
+  return withHttpServer ? { httpServer: { on: vi.fn() } } : {};
+}
+
+describe("rerankerServiceHook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(startRerankerService).mockResolvedValue(undefined);
+    vi.mocked(startWebSearchService).mockResolvedValue(undefined);
+    vi.mocked(stopRerankerService).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts both services and stops the reranker when the server closes", async () => {
+    const server = createServer();
+
+    await rerankerServiceHook(
+      server as unknown as Parameters<typeof rerankerServiceHook>[0],
+    );
+
+    expect(startRerankerService).toHaveBeenCalledOnce();
+    expect(startWebSearchService).toHaveBeenCalledOnce();
+    expect(server.httpServer?.on).toHaveBeenCalledWith(
+      "close",
+      expect.any(Function),
+    );
+
+    const closeHandler = server.httpServer?.on.mock.calls[0][1] as () => void;
+    closeHandler();
+    await Promise.resolve();
+    expect(stopRerankerService).toHaveBeenCalledOnce();
+  });
+
+  it("continues startup and logs when the reranker fails", async () => {
+    const error = new Error("reranker unavailable");
+    vi.mocked(startRerankerService).mockRejectedValue(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const server = createServer();
+
+    await rerankerServiceHook(
+      server as unknown as Parameters<typeof rerankerServiceHook>[0],
+    );
+
+    expect(startWebSearchService).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to start reranker service:",
+      error,
+    );
+  });
+
+  it("continues startup and logs when the web search service fails", async () => {
+    const error = new Error("search service unavailable");
+    vi.mocked(startWebSearchService).mockRejectedValue(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const server = createServer();
+
+    await rerankerServiceHook(
+      server as unknown as Parameters<typeof rerankerServiceHook>[0],
+    );
+
+    expect(startRerankerService).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to start web search service:",
+      error,
+    );
+  });
+
+  it("logs a shutdown failure without rejecting the close callback", async () => {
+    const error = new Error("release failed");
+    vi.mocked(stopRerankerService).mockRejectedValue(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const server = createServer();
+
+    await rerankerServiceHook(
+      server as unknown as Parameters<typeof rerankerServiceHook>[0],
+    );
+    const closeHandler = server.httpServer?.on.mock.calls[0][1] as () => void;
+
+    expect(() => closeHandler()).not.toThrow();
+    await Promise.resolve();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to stop reranker service:",
+      error,
+    );
+  });
+
+  it("does not register a close handler when no HTTP server exists", async () => {
+    await rerankerServiceHook(
+      createServer(false) as unknown as Parameters<
+        typeof rerankerServiceHook
+      >[0],
+    );
+
+    expect(startRerankerService).toHaveBeenCalledOnce();
+    expect(startWebSearchService).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `getModelConfig` defaults, bounds, overrides, and empty-value fallback
- add reranker hook tests for startup, error logging, shutdown cleanup, and missing HTTP servers
- document server model request environment variables and hook test coverage

## Validation
- Focused Vitest coverage reports 100% lines for both target files.

Validation observed for this change:
- `docker run --rm -v /workspace/repository:/workspace/repository -v minisearch-node-deps:/workspace/repository/node_modules -w /workspace/repository node:22.21.1-bookworm-slim@sha256:25b3eb23a00590b7499f2a2ce939322727fcce1b15fdd69754fcd09536a3ae2c bash -lc 'npm ci --ignore-scripts && npm exec vitest -- run server/config/modelConfig.test.ts server/rerankerServiceHook.test.ts --coverage --coverage.include=server/config/modelConfig.ts --coverage.include=server/rerankerServiceHook.ts --coverage.reporter=text --coverage.thresholds.lines=80 --coverage.thresholds.functions=80'`
- `docker run --rm -e VITEST_MAX_WORKERS=1 -v /workspace/repository:/workspace/repository -v minisearch-node-deps:/workspace/repository/node_modules -w /workspace/repository node:22.21.1-bookworm@sha256:b84d52cd45bfe261096ccbf886955d431b8b9ed01b72eaef588e8886bda09e78 npm test`
- `docker run --rm -v /workspace/repository:/workspace/repository -v minisearch-node-deps:/workspace/repository/node_modules -w /workspace/repository node:22.21.1-bookworm@sha256:b84d52cd45bfe261096ccbf886955d431b8b9ed01b72eaef588e8886bda09e78 npm run lint`

Fixes #2527

<!-- repo-agent-case:38cc5349-2827-403a-8ec5-532970b2e518 -->