### PR TITLE
docs: clarify main application port vs HMR in quick-start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -20,7 +20,7 @@ cd MiniSearch
 docker compose up
 ```
 
-Access the application at `http://localhost:7861` (HMR) or `http://localhost:7860` (main)
+Access the application at `http://localhost:7860` (main). During development, HMR is available on `http://localhost:7861` for instant code changes.
 
 The development server includes:
 - Hot Module Replacement (HMR) on port 7861 for instant code changes


### PR DESCRIPTION
## Description
Lists port 7860 first as the main application access URL in `docs/quick-start.md` and clarifies that port 7861 is the development HMR server.

Closes #2526

## How to test
Inspect `docs/quick-start.md` line 23 to verify port 7860 is presented as the primary application URL.
