### PR TITLE
fix: prevent biome schema drift and restore jest-dom types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/client/setupTests.ts
+++ b/client/setupTests.ts
@@ -2,7 +2,7 @@
 // etc.) so that Dexie-based cache tests exercise the real cache code paths
 // instead of silently erroring into catch blocks.
 import "fake-indexeddb/auto";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
 Object.defineProperty(window, "matchMedia", {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
       "@shared/*": ["./shared/*"],
       "@root/*": ["./*"]
     },
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals"]
   },
   "include": ["client", "shared", "test"]
 }


### PR DESCRIPTION
## What changed

| File | Change |
|---|---|
| biome.json | Changed $schema from a versioned URL to a relative path pointing at the schema shipped inside the installed package |
| client/setupTests.ts | Switched import from @testing-library/jest-dom to @testing-library/jest-dom/vitest |
| tsconfig.json | Removed "@testing-library/jest-dom" from the types array |

## Root cause 1: biome schema drift (the original issue)

The versioned schema URL in biome.json (e.g. https://biomejs.dev/schemas/2.5.11/schema.json) drifts from the installed CLI version whenever Renovate bumps @biomejs/biome. CI uses npm ci, which installs the exact version from package-lock.json. When the lockfile is at 2.5.12 but the schema URL says 2.5.11, biome exits with a deserialize error and npm run lint fails.

This has already required four manual catch-up commits: 064c4db, 44761ac, a7ebc05, and aad970d.

Fix: point $schema at configuration_schema.json shipped inside node_modules/@biomejs/biome. That file is part of the package's published files, so it always matches the installed CLI.

## Root cause 2: jest-dom types missing (uncovered by the biome fix)

Once biome stopped failing, tsc started failing with:

error TS2339: Property 'toBeInTheDocument' does not exist on type 'Assertion<void, HTMLElement>'.

@testing-library/jest-dom v7.0.1 ships its vitest matchers in a separate entry point. The main index.d.ts only references jest.d.ts, so listing "@testing-library/jest-dom" in tsconfig's types array pulls in jest globals but not the vitest matchers.

Fix: import @testing-library/jest-dom/vitest in setupTests.ts, which both extends expect at runtime via an explicit import and applies the type augmentation. Remove the stale types entry from tsconfig.json.

## How it was verified

- npm run lint passes (biome check, tsc, all three tsconfigs, knip, jscpd, architectural linter, doc gardening, doc validator)
- vitest run: 738 tests pass across 63 files
- The schema file exists at node_modules/@biomejs/biome/configuration_schema.json after npm ci

## Trade-offs

- Editor autocomplete for biome.json requires node_modules to be present (npm ci first). This matches the existing pre-commit hook, which already resolves biome from node_modules.
- The target biome version is no longer visible in biome.json; package-lock.json is the source of truth.
- jest-dom's runtime extension now uses an explicit import instead of relying on vitest's globals: true, which is more robust if globals is ever disabled.