### PR TITLE
test: raise coverage thresholds to match actual coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,8 +29,10 @@ export default defineConfig({
       include: ["client/**/*.{tsx,ts,jsx,js}", "server/**/*.{ts,js}"],
       exclude: ["client/dist/**", "server/**/*.test.ts"],
       thresholds: {
-        lines: 31,
-        functions: 24,
+        lines: 60,
+        functions: 50,
+        statements: 60,
+        branches: 50,
       },
     },
   },


### PR DESCRIPTION
## Description

Raises the vitest coverage thresholds so the gate actually enforces something. Before this, `lines`/`functions` were set to 31%/24% against ~64%/~57% actual, and `statements`/`branches` had no threshold at all, so a PR dropping coverage by 20+ points would still pass CI.

New values are the ones proposed in #2515, a few points under current coverage to leave room for normal fluctuation:

| Metric | Before | After | Actual (main) |
|--------|--------|-------|---------------|
| Lines | 31 | 60 | 64.46% |
| Functions | 24 | 50 | 56.59% |
| Statements | none | 60 | 64.04% |
| Branches | none | 50 | 55.76% |

Only `vitest.config.ts` changes. The optional "fail if coverage drops >2% vs previous run" CI step from the issue is left out; it needs a persisted baseline and is a separate change if wanted.

Fixes #2515

## How to test

1. `npm run test:coverage` on this branch: 738 tests pass, summary reports ~64/56/64/56 (statements/branches/functions/lines), exit 0.
2. To confirm the gate is live: `npx vitest run --coverage --coverage.thresholds.branches=99` exits 1 with `ERROR: Coverage for branches (55.76%) does not meet global threshold (99%)`.
3. `npx biome check vitest.config.ts` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
