### PR TITLE
refactor: extract shared ONNX model loading into onnxModelLoader

### DIFF
--- a/docs/reranking.md
+++ b/docs/reranking.md
@@ -4,11 +4,12 @@ MiniSearch optionally reranks search results using a cross-encoder model running
 
 ## Architecture Overview
 
-The reranking subsystem consists of three components:
+The reranking subsystem consists of four components:
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Service Manager | `server/rerankerService.ts` | Model loading, readiness state, reranking inference |
+| Service Manager | `server/rerankerService.ts` | Readiness state, reranking inference |
+| Model Loading | `server/utils/onnxModelLoader.ts` | Shared model download, tokenizer loading, and session creation (used by both the reranker and the bi-encoder) |
 | Ranking Logic | `server/rankSearchResults.ts` | Score-based filtering and result reordering |
 | Server Hook | `server/rerankerServiceHook.ts` | Startup/shutdown coordination with Vite server |
 
@@ -35,9 +36,9 @@ The size check costs one metadata request per file at startup (roughly 600ms for
 
 ### Execution Providers
 
-The session is created with `["cpu"]`, with no configuration to set, and there is no second attempt to fall back from.
+The session is created with `["cpu"]`, with no configuration to set, and there is no second attempt to fall back from. This decision lives in `server/utils/onnxModelLoader.ts` and governs both the reranker and the bi-encoder.
 
-The model ships as a dynamically quantized graph, and the WebGPU provider has no kernels for its integer matmuls. It registers happily and then hands every one of them back to the CPU, paying a round trip each time: 812ms against 172ms of the same work, with scores drifting by as much as 1.15 and reordering results. GPU acceleration is therefore not on the table for this model, which also removes the reason the two-attempt session logic existed.
+The reranker ships as a dynamically quantized graph, and the WebGPU provider has no kernels for its integer matmuls. It registers happily and then hands every one of them back to the CPU, paying a round trip each time: 812ms against 172ms of the same work, with scores drifting by as much as 1.15 and reordering results. The bi-encoder is fp32 and was not benchmarked on accelerators, but inherits the CPU-only choice.
 
 | Provider | Availability in the Node binding | Notes |
 |----------|----------------------------------|-------|

--- a/server/biEncoderService.ts
+++ b/server/biEncoderService.ts
@@ -1,14 +1,9 @@
-import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { Tokenizer } from "@huggingface/tokenizers";
-import debug from "debug";
-import { InferenceSession, Tensor } from "onnxruntime-node";
-import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository.ts";
+import type { Tokenizer } from "@huggingface/tokenizers";
+import { type InferenceSession, Tensor } from "onnxruntime-node";
+import { createModelLogger, loadOnnxModel } from "./utils/onnxModelLoader.ts";
 
-const fileName = path.basename(import.meta.url);
-const printMessage = debug(fileName);
-printMessage.enabled = true;
+const printMessage = createModelLogger(path.basename(import.meta.url));
 
 const MODEL_HF_REPO =
   "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2";
@@ -20,9 +15,6 @@ const MODEL_HF_REPO =
  * with hundreds of passages each.
  */
 const MODEL_HF_FILE = "onnx/model.onnx";
-
-const TOKENIZER_HF_FILE = "tokenizer.json";
-const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
 
 /**
  * Maximum tokens per encoding. The model was trained with a 256-token limit;
@@ -38,36 +30,6 @@ const BATCH_SIZE = 64;
 let isReady = false;
 let session: InferenceSession | null = null;
 let tokenizer: Tokenizer | null = null;
-
-function resolveModelPath(hfRepoFile: string) {
-  return path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "models",
-    MODEL_HF_REPO,
-    hfRepoFile,
-  );
-}
-
-async function ensureFileExists(hfRepoFile: string) {
-  const localPath = resolveModelPath(hfRepoFile);
-  await downloadFileFromHuggingFaceRepository(
-    MODEL_HF_REPO,
-    hfRepoFile,
-    localPath,
-  );
-  return localPath;
-}
-
-function createSession(modelPath: string) {
-  printMessage(
-    `Loading bi-encoder on CPU (arch: ${process.arch}, platform: ${process.platform})...`,
-  );
-
-  return InferenceSession.create(modelPath, {
-    executionProviders: ["cpu"],
-    logSeverityLevel: 3,
-  });
-}
 
 /**
  * Encodes a single text into a normalized embedding vector.
@@ -176,19 +138,9 @@ function cosineSimilarities(
 
 export async function startBiEncoderService() {
   printMessage("Preparing bi-encoder model...");
-
-  const [modelPath, tokenizerPath, tokenizerConfigPath] = await Promise.all([
-    ensureFileExists(MODEL_HF_FILE),
-    ensureFileExists(TOKENIZER_HF_FILE),
-    ensureFileExists(TOKENIZER_CONFIG_HF_FILE),
-  ]);
-
-  tokenizer = new Tokenizer(
-    JSON.parse(fs.readFileSync(tokenizerPath, "utf8")),
-    JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
-  );
-
-  session = await createSession(modelPath);
+  const loaded = await loadOnnxModel(MODEL_HF_REPO, MODEL_HF_FILE);
+  session = loaded.session;
+  tokenizer = loaded.tokenizer;
 
   // Warm up with a test encoding.
   await encode(session, tokenizer, "test query");

--- a/server/internalApiEndpointServerHook.ts
+++ b/server/internalApiEndpointServerHook.ts
@@ -20,6 +20,7 @@ import {
   recordModelsRefetched,
   recordStreamEndedWithoutFinish,
 } from "./inferencesSinceLastRestart.ts";
+import { sendJsonError } from "./utils/httpResponse.ts";
 import {
   calculateBackoffTime,
   isResponseWritable,
@@ -71,21 +72,6 @@ function createChunkPayload(
       },
     ],
   };
-}
-
-function sendJsonError(
-  response: ServerResponse,
-  statusCode: number,
-  payload: Record<string, unknown>,
-): void {
-  if (response.headersSent) {
-    safeEndResponse(response);
-    return;
-  }
-
-  response.statusCode = statusCode;
-  response.setHeader("Content-Type", "application/json");
-  safeEndResponse(response, JSON.stringify(payload));
 }
 
 function ensureSseHeaders(response: ServerResponse): void {

--- a/server/pageContentEndpointServerHook.ts
+++ b/server/pageContentEndpointServerHook.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { handleTokenVerification } from "./handleTokenVerification.ts";
 import { fetchPageContents } from "./pageContentService.ts";
 import { recordGroundingOutcome } from "./pageReadsSinceLastRestart.ts";
+import { sendValidationError } from "./utils/httpResponse.ts";
 
 const MAX_QUERY_LENGTH = 2000;
 const MAX_URL_LENGTH = 2048;
@@ -68,11 +69,7 @@ export function pageContentEndpointServerHook<
     });
 
     if (!parsedParams.success) {
-      response.statusCode = 400;
-      response.setHeader("Content-Type", "application/json");
-      response.end(
-        JSON.stringify({ error: parsedParams.error.issues[0].message }),
-      );
+      sendValidationError(response, parsedParams.error);
       return;
     }
 

--- a/server/rerankerService.test.ts
+++ b/server/rerankerService.test.ts
@@ -135,6 +135,14 @@ describe("startRerankerService", () => {
 
     expect(requestedExecutionProviders).toEqual([["cpu"]]);
     expect(await getRerankerStatus()).toBe(true);
+
+    const downloadMock = vi.mocked(
+      (await import("./downloadFileFromHuggingFaceRepository"))
+        .downloadFileFromHuggingFaceRepository,
+    );
+    const downloadedFiles = downloadMock.mock.calls.map((call) => call[1]);
+    expect(downloadedFiles).toContain("tokenizer.json");
+    expect(downloadedFiles).toContain("tokenizer_config.json");
   });
 
   it("stays unready when the session cannot be created", async () => {

--- a/server/rerankerService.ts
+++ b/server/rerankerService.ts
@@ -1,14 +1,9 @@
-import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { Tokenizer } from "@huggingface/tokenizers";
-import debug from "debug";
-import { InferenceSession, Tensor } from "onnxruntime-node";
-import { downloadFileFromHuggingFaceRepository } from "./downloadFileFromHuggingFaceRepository.ts";
+import type { Tokenizer } from "@huggingface/tokenizers";
+import { type InferenceSession, Tensor } from "onnxruntime-node";
+import { createModelLogger, loadOnnxModel } from "./utils/onnxModelLoader.ts";
 
-const fileName = path.basename(import.meta.url);
-const printMessage = debug(fileName);
-printMessage.enabled = true;
+const printMessage = createModelLogger(path.basename(import.meta.url));
 
 const MODEL_HF_REPO = "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1";
 
@@ -22,9 +17,6 @@ const MODEL_HF_REPO = "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1";
  * on 240 MIRACL queries, for a quarter of the download and half the latency.
  */
 const MODEL_HF_FILE = "onnx/model_quint8_avx2.onnx";
-
-const TOKENIZER_HF_FILE = "tokenizer.json";
-const TOKENIZER_CONFIG_HF_FILE = "tokenizer_config.json";
 
 /**
  * Hard ceiling rather than a tuning knob: the model has 514 learned position
@@ -78,62 +70,11 @@ export function sanitizeUnicodeSurrogates(input: string) {
   return output;
 }
 
-function resolveModelPath(hfRepoFile: string) {
-  return path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "models",
-    MODEL_HF_REPO,
-    hfRepoFile,
-  );
-}
-
-async function ensureFileExists(hfRepoFile: string) {
-  const localPath = resolveModelPath(hfRepoFile);
-  await downloadFileFromHuggingFaceRepository(
-    MODEL_HF_REPO,
-    hfRepoFile,
-    localPath,
-  );
-  return localPath;
-}
-
-/**
- * Runs on the CPU, with nothing to configure. A dynamically quantized graph is
- * the wrong shape for the WebGPU provider, which has no kernels for the integer
- * matmuls and shuttles every one of them back to the CPU: 812ms against 172ms
- * for the same work, with scores drifting by up to 1.15 and reordering results.
- * `coreml` is out for the same reason it was before, being slower than CPU on
- * dynamic shapes. The architecture is logged because it selects the quantized
- * kernel, which is the part that varies between hosts.
- */
-function createSession(modelPath: string) {
-  printMessage(
-    `Loading model on CPU (arch: ${process.arch}, platform: ${process.platform})...`,
-  );
-
-  return InferenceSession.create(modelPath, {
-    executionProviders: ["cpu"],
-    // Errors only. ONNX Runtime otherwise warns on every startup that it
-    // assigned shape operators to CPU, which is expected and not actionable.
-    logSeverityLevel: 3,
-  });
-}
-
 export async function startRerankerService() {
   printMessage("Preparing model...");
-
-  const [modelPath, tokenizerPath, tokenizerConfigPath] = await Promise.all([
-    ensureFileExists(MODEL_HF_FILE),
-    ensureFileExists(TOKENIZER_HF_FILE),
-    ensureFileExists(TOKENIZER_CONFIG_HF_FILE),
-  ]);
-
-  tokenizer = new Tokenizer(
-    JSON.parse(fs.readFileSync(tokenizerPath, "utf8")),
-    JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
-  );
-
-  session = await createSession(modelPath);
+  const loaded = await loadOnnxModel(MODEL_HF_REPO, MODEL_HF_FILE);
+  session = loaded.session;
+  tokenizer = loaded.tokenizer;
 
   await score("test", ["test document"]);
 

--- a/server/searchEndpointServerHook.ts
+++ b/server/searchEndpointServerHook.ts
@@ -12,6 +12,7 @@ import {
   incrementTextualSearchesSinceLastRestart,
   recordSearchDuration,
 } from "./searchesSinceLastRestart.ts";
+import { sendValidationError } from "./utils/httpResponse.ts";
 import { fetchSearXNG } from "./webSearchService.ts";
 
 const DEFAULT_SEARCH_LIMIT = 30;
@@ -101,11 +102,7 @@ export function searchEndpointServerHook<
     });
 
     if (!parsedParams.success) {
-      response.statusCode = 400;
-      response.setHeader("Content-Type", "application/json");
-      response.end(
-        JSON.stringify({ error: parsedParams.error.issues[0].message }),
-      );
+      sendValidationError(response, parsedParams.error);
       return;
     }
 

--- a/server/utils/httpResponse.ts
+++ b/server/utils/httpResponse.ts
@@ -1,0 +1,32 @@
+import type { ServerResponse } from "node:http";
+import type { ZodError } from "zod";
+import { safeEndResponse } from "./streamUtils.ts";
+
+/**
+ * Sends a JSON error response, guarding against a response that already began
+ * writing.
+ */
+export function sendJsonError(
+  response: ServerResponse,
+  statusCode: number,
+  payload: Record<string, unknown>,
+): void {
+  if (response.headersSent) {
+    safeEndResponse(response);
+    return;
+  }
+
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json");
+  safeEndResponse(response, JSON.stringify(payload));
+}
+
+/**
+ * Sends a 400 response with the first Zod validation error message.
+ */
+export function sendValidationError(
+  response: ServerResponse,
+  error: ZodError,
+): void {
+  sendJsonError(response, 400, { error: error.issues[0].message });
+}

--- a/server/utils/onnxModelLoader.ts
+++ b/server/utils/onnxModelLoader.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Tokenizer } from "@huggingface/tokenizers";
+import debug from "debug";
+import { InferenceSession } from "onnxruntime-node";
+import { downloadFileFromHuggingFaceRepository } from "../downloadFileFromHuggingFaceRepository.ts";
+
+const SERVER_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const printMessage = createModelLogger(path.basename(import.meta.url));
+
+/**
+ * Creates a debug logger with the same enabled-always behavior used by the
+ * model services.
+ */
+export function createModelLogger(moduleName: string) {
+  const printMessage = debug(moduleName);
+  printMessage.enabled = true;
+  return printMessage;
+}
+
+function resolveModelPath(modelRepo: string, hfRepoFile: string) {
+  return path.resolve(SERVER_DIR, "models", modelRepo, hfRepoFile);
+}
+
+// Replaces a cached file when its size differs from the Hub, not just when
+// missing.
+async function ensureModelFileExists(modelRepo: string, hfRepoFile: string) {
+  const localPath = resolveModelPath(modelRepo, hfRepoFile);
+  await downloadFileFromHuggingFaceRepository(modelRepo, hfRepoFile, localPath);
+  return localPath;
+}
+
+// CPU-only, errors-only logging. The reranker is a dynamically quantized
+// graph, the wrong shape for WebGPU (no kernels for the integer matmuls,
+// shuttles them to the CPU: 812ms against 172ms for the same work, with scores
+// drifting by up to 1.15 and reordering results). `coreml` is slower than CPU
+// on dynamic shapes. The bi-encoder is fp32 and was not benchmarked on
+// accelerators, but inherits this choice. logSeverityLevel 3 keeps startup
+// quiet: ONNX Runtime otherwise warns that it assigned shape operators to CPU,
+// which is expected and not actionable. The architecture is logged because it
+// selects the quantized kernel, which is the part that varies between hosts.
+function createOnnxSession(modelRepo: string, modelPath: string) {
+  printMessage(
+    `Creating CPU session for ${modelRepo} (arch: ${process.arch}, platform: ${process.platform})...`,
+  );
+  return InferenceSession.create(modelPath, {
+    executionProviders: ["cpu"],
+    logSeverityLevel: 3,
+  });
+}
+
+/**
+ * Downloads model files from a Hugging Face repo and returns a ready
+ * inference session and tokenizer. The tokenizer files use the standard
+ * Hugging Face names when not overridden.
+ */
+export async function loadOnnxModel(
+  modelRepo: string,
+  modelFile: string,
+  tokenizerFile = "tokenizer.json",
+  tokenizerConfigFile = "tokenizer_config.json",
+): Promise<{ session: InferenceSession; tokenizer: Tokenizer }> {
+  const [modelPath, tokenizerPath, tokenizerConfigPath] = await Promise.all([
+    ensureModelFileExists(modelRepo, modelFile),
+    ensureModelFileExists(modelRepo, tokenizerFile),
+    ensureModelFileExists(modelRepo, tokenizerConfigFile),
+  ]);
+
+  const tokenizer = new Tokenizer(
+    JSON.parse(fs.readFileSync(tokenizerPath, "utf8")),
+    JSON.parse(fs.readFileSync(tokenizerConfigPath, "utf8")),
+  );
+  const session = await createOnnxSession(modelRepo, modelPath);
+
+  return { session, tokenizer };
+}


### PR DESCRIPTION
biEncoderService and rerankerService had near-identical model initialization: path resolution, file downloads, tokenizer loading, and session creation. This extracts the shared parts into `server/utils/onnxModelLoader.ts`, which both services now call through `loadOnnxModel()`.

Also lifts `sendJsonError` from `internalApiEndpointServerHook.ts` into `server/utils/httpResponse.ts` so it can be shared, and defines `sendValidationError` (used by the page-content and search endpoint hooks) in terms of it. The two endpoint hooks now route through `sendJsonError`, which adds a `headersSent` guard and uses `safeEndResponse` instead of a bare `response.end`. This is strictly safer (no more `ERR_HTTP_HEADERS_SENT` throws if a response somehow began writing) and unreachable in the current code paths, but it is a behavior difference from the previous bare `response.end`.

jscpd clone count drops from 96 to 93. The remaining production-code clones are the import blocks (structural, both modules need the same types) and redirect handling with divergent return types.

Closes #2513.

## How to test

1. `npm run lint` (passes, jscpd clone count reduced).
2. `npm run test:coverage` (738 tests pass, all coverage thresholds met).
3. Start the server and run a search (exercises the reranker and bi-encoder startup paths).