### PR TITLE
docs: make private vulnerability reporting the only security channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -10,11 +10,8 @@ body:
       value: |
         # ⚠️ IMPORTANT: SECURITY VULNERABILITIES SHOULD NOT BE REPORTED PUBLICLY ⚠️
         
-        This template will create a public issue, but for security vulnerabilities, please use one of these private reporting methods:
-        
-        1. **Preferred**: Use GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
-        2. **Alternative**: Email the maintainer privately
-        
+        This template will create a public issue, but security vulnerabilities must be reported privately through GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
+
         If you accidentally created a public issue, please close it and report privately instead.
 
   - type: checkboxes
@@ -23,7 +20,7 @@ body:
       label: Confirmation
       description: Please confirm you understand the security reporting process
       options:
-        - label: I understand this should be reported privately and will use the methods above
+        - label: I understand this should be reported privately and will use the method above
           required: true
 
   - type: dropdown

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -13,14 +13,11 @@ Only the latest version of MiniSearch receives security updates.
 
 ### Private Vulnerability Reporting
 
-We strongly encourage using GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) feature to report security vulnerabilities.
+Report security vulnerabilities through GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) feature. It is the only reporting channel, so every report stays private and tracked in one place.
 
 **Do not report security vulnerabilities through public issues.**
 
-### How to Report
-
-1. **Preferred**: Use GitHub's Private Vulnerability Reporting
-2. **Alternative**: Email the maintainer privately at: (contact can be provided upon request)
+### What to Include
 
 When reporting a vulnerability, please include:
 - A clear description of the vulnerability


### PR DESCRIPTION
## Description

`.github/SECURITY.md` listed a second reporting option that goes nowhere:

> 2. **Alternative**: Email the maintainer privately at: (contact can be provided upon request)

Following the recommended option from #2512, the email path is removed and GitHub's Private Vulnerability Reporting becomes the sole channel.

The same dead alternative was duplicated in `.github/ISSUE_TEMPLATE/security_vulnerability.yml` ("2. **Alternative**: Email the maintainer privately"), so it is removed there too — otherwise the reporting path stays ambiguous for anyone who arrives via the issue form rather than the policy file. The template's confirmation checkbox is adjusted from "the methods above" to "the method above" to match.

With the numbered list gone, `### How to Report` held nothing but the "please include" list, so it is renamed to `### What to Include`; the sentence introducing Private Vulnerability Reporting now states it plainly instead of "strongly encouraging" it, since there is no longer anything to choose between.

Out of scope, but noticed nearby: `.github/CODE_OF_CONDUCT.md` line 42 has the same placeholder (`- Email: (private contact can be provided upon request)`). That one is the conduct reporting path and has no GitHub-native equivalent to fall back on, so it needs your decision on a real contact rather than a removal. Happy to follow up if you open an issue for it.

## How to test

1. Read the rendered `.github/SECURITY.md` — the reporting section names one channel and no placeholder remains.
2. `node scripts/documentation-validator.cjs` — passes, 8/8 files, 0 issues.
3. Open the "Security Vulnerability" issue form (or parse the YAML) — the intro block renders as valid markdown with the single reporting method.

I could not run `docker compose exec development-server npm run lint` locally, but this change touches only a markdown file and an issue-form YAML; the documentation validator portion of that pipeline is verified above.

Fixes #2512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
