### PR TITLE
Fix TransactionInactiveError in history cleanup

### DIFF
--- a/client/modules/history.test.ts
+++ b/client/modules/history.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Pin auto-cleanup off and avoid pubSub's module-level localStorage reads.
 vi.mock("./pubSub", () => ({
-  getSettings: () => ({
+  getSettings: vi.fn(() => ({
     historyAutoCleanup: false,
     historyRetentionDays: 30,
     historyMaxEntries: 500,
-  }),
+  })),
 }));
 
 const createTestEntry = (overrides: Record<string, unknown> = {}) => ({
@@ -461,6 +461,62 @@ describe("History Module - Dexie CRUD", () => {
       const { getChatMessagesForQuery } = await import("./history");
       const messages = await getChatMessagesForQuery("nonexistent-run-id");
       expect(messages).toEqual([]);
+    });
+  });
+
+  describe("cleanup after add", () => {
+    it("should not throw TransactionInactiveError when auto-cleanup is enabled", async () => {
+      const { getSettings } = await import("./pubSub");
+      const { defaultSettings } = await import("./settings");
+      vi.mocked(getSettings).mockReturnValue({
+        ...defaultSettings,
+        historyAutoCleanup: true,
+        historyRetentionDays: 0,
+        historyMaxEntries: 5,
+      });
+
+      const { addSearchToHistory, historyDatabase } = await import("./history");
+      const results = {
+        type: "text" as const,
+        items: [{ title: "T", url: "https://t.com", snippet: "S" }],
+      };
+
+      // Add entries; each triggers cleanup after the transaction completes.
+      // Before the fix, the creating hook ran cleanup inside the add transaction,
+      // and the async import caused a TransactionInactiveError.
+      for (let i = 0; i < 8; i++) {
+        const id = await addSearchToHistory(`query ${i}`, results);
+        expect(id).toBeDefined();
+      }
+
+      // Settle any in-flight cleanup, then run one final cleanup to ensure
+      // the count reflects the steady state.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await historyDatabase.runCleanup();
+
+      // Cleanup should have trimmed to maxEntries (pinned entries exempt, none here)
+      const count = await historyDatabase.searches.count();
+      expect(count).toBeLessThanOrEqual(5);
+    });
+
+    it("should deduplicate concurrent cleanup calls", async () => {
+      const { getSettings } = await import("./pubSub");
+      const { defaultSettings } = await import("./settings");
+      vi.mocked(getSettings).mockReturnValue({
+        ...defaultSettings,
+        historyAutoCleanup: true,
+        historyRetentionDays: 0,
+        historyMaxEntries: 1000,
+      });
+
+      const { historyDatabase } = await import("./history");
+
+      // Two overlapping calls should share the same in-flight promise
+      const p1 = historyDatabase.runCleanup();
+      const p2 = historyDatabase.runCleanup();
+      expect(p1).toBe(p2);
+
+      await p1;
     });
   });
 

--- a/client/modules/history.ts
+++ b/client/modules/history.ts
@@ -118,12 +118,15 @@ class HistoryDatabase extends Dexie {
       chatHistory:
         "++id, conversationId, timestamp, [conversationId+timestamp]",
     });
+  }
 
-    this.searches.hook("creating", () => {
-      this.performCleanup().catch((error) => {
-        addLogEntry(`Cleanup hook error: ${error}`);
-      });
+  private cleanupInFlight: Promise<void> | null = null;
+
+  runCleanup(): Promise<void> {
+    this.cleanupInFlight ??= this.performCleanup().finally(() => {
+      this.cleanupInFlight = null;
     });
+    return this.cleanupInFlight;
   }
 
   async performCleanup(): Promise<void> {
@@ -237,22 +240,26 @@ export async function addSearchToHistory(
   results: TextResults | ImageResults,
   source: "user" | "followup" | "suggestion" = "user",
 ): Promise<number | undefined> {
-  return measurePerformance("Add search to history", async () => {
-    return await historyDatabase.searches.add({
-      searchRunId: getCurrentSearchRunId(),
-      query,
-      results,
-      ...(results.type === "text"
-        ? { textResults: results }
-        : { imageResults: results }),
-      timestamp: Date.now(),
-      source,
-      pinned: false,
+  try {
+    const id = await measurePerformance("Add search to history", async () => {
+      return await historyDatabase.searches.add({
+        searchRunId: getCurrentSearchRunId(),
+        query,
+        results,
+        ...(results.type === "text"
+          ? { textResults: results }
+          : { imageResults: results }),
+        timestamp: Date.now(),
+        source,
+        pinned: false,
+      });
     });
-  }).catch((error) => {
+    historyDatabase.runCleanup();
+    return id;
+  } catch (error) {
     addLogEntry(`Error adding search to history: ${error}`);
     return undefined;
-  });
+  }
 }
 
 export async function getRecentSearches(


### PR DESCRIPTION
Every search logged a cleanup error: the creating hook ran performCleanup() inside the add transaction, and the async settings import let the transaction close first.

Cleanup now runs after addSearchToHistory completes, in a fresh implicit transaction. An in-flight guard deduplicates concurrent cleanup passes.

Two new tests: cleanup with auto-cleanup enabled, and concurrent-call deduplication. All 740 tests pass.