### PR TITLE
chore: add stale issue and pull request automation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Mark and Close Stale Items
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Mark and close stale issues and pull requests
+        uses: actions/stale@v11
+        with:
+          days-before-stale: 60
+          # Counted from the moment an item is marked stale, so an issue is
+          # closed once it reaches 90 days of inactivity.
+          days-before-close: 30
+          # Pull requests are labelled and commented on, but never closed
+          # automatically: a stale branch is still worth rebasing.
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been inactive for 60 days. It will be closed in 30 days if there is no
+            further activity. Comment to keep it open.
+          stale-pr-message: >
+            This pull request has been inactive for 60 days. It will not be closed automatically,
+            but please rebase it on `main` and comment if it is still relevant.
+          close-issue-message: >
+            This issue was closed due to inactivity. Comment if it is still relevant and it will be
+            reopened.
+          exempt-issue-labels: good first issue,security,pinned
+          exempt-pr-labels: good first issue,security,pinned


### PR DESCRIPTION
## Description

Adds `.github/workflows/stale.yml`, a daily `actions/stale` run implementing the behaviour described in #2518: issues and pull requests are labelled `stale` after 60 days of inactivity and commented on, stale issues are closed at 90 days of inactivity, pull requests are never closed automatically, and `good first issue` / `security` / `pinned` items are exempt.

Two deliberate deviations from the snippet in the issue, both to match the acceptance criteria:

- **`days-before-close: 30`, not `90`.** In `actions/stale`, `days-before-close` is *"the number of days to wait to close an issue or a pull request **after it being marked stale**"*, not days of total inactivity. With `days-before-stale: 60`, a value of `90` would close issues at 150 days and contradict the stale comment's own "closed in 30 days". `30` gives the specified 90 days of inactivity.
- **`days-before-pr-close: -1`, not `days-before-pr-stale: -1`.** `days-before-pr-stale: -1` disables PR staling entirely, so PRs would never be labelled or commented on — but the issue asks for PRs to be labelled and commented on and only never *closed*. `days-before-pr-close: -1` is the input that means "never close pull requests". `stale-pr-message` is set for the same reason: without it the action skips PRs.

Also on `actions/stale@v11` rather than `v9`. v10/v11 changed only the action runtime (Node 24, ESM); no input behaviour changed, and this matches the repo's other official actions being on their current majors, so Renovate has nothing to bump on day one.

The `stale` label doesn't need to be created by hand — the labels API creates it on first use, and `exempt-issue-labels` tolerates `pinned` not existing yet.

## How to test

1. `actionlint .github/workflows/stale.yml` passes.
2. After merge, run the workflow manually from the Actions tab ("Stale" -> Run workflow) and check the run log. With the current backlog nothing is 60 days idle yet, so a first run should report no items — the useful signal is that the action starts and the token permissions are sufficient.

To watch it act on something without waiting, temporarily dispatch a copy with `days-before-stale: 0` on a fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
