### PR TITLE
Skip the onnxruntime-node CUDA postinstall download

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,8 @@
 legacy-peer-deps = true
 min-release-age = 3
+
+# onnxruntime-node's postinstall downloads a CUDA 12 nupkg on linux/x64 and
+# unpacks it with adm-zip, which follows symlinks at the extraction destination
+# (GHSA-vwc7-r8mq-g2x9, unfixed upstream). Both inference services pin
+# `executionProviders: ["cpu"]`, so those binaries are never loaded.
+onnxruntime-node-install = skip


### PR DESCRIPTION
## Description

Skips the `onnxruntime-node` postinstall download, which is what pulls the vulnerable `adm-zip` code path into our install ([GHSA-vwc7-r8mq-g2x9](https://github.com/advisories/GHSA-vwc7-r8mq-g2x9), [Dependabot alert 37](https://github.com/felladrin/MiniSearch/security/dependabot/37)).

On `linux/x64` (our Docker target), `install-metadata.js` requires `cuda12`, so `npm ci` downloads a NuGet package and unpacks it with `zip.extractEntryTo(entry, extractDir, false, true)` into `os.tmpdir()/onnxruntime-node-pkgs_${Date.now()}/extracted`. A predictable path in a shared `/tmp`, plus overwrite enabled, is exactly the precondition in the advisory. We never use what it downloads: `biEncoderService` and `rerankerService` both pin `executionProviders: ["cpu"]`.

There is nothing to upgrade to. The [upstream fix](https://github.com/cthackers/adm-zip/pull/575) is still open and `first_patched_version` is `null`. An `overrides` entry pointing at `0.5.8` (the last unaffected release) would trade this moderate advisory for a high-severity one, GHSA-xcpc-8h2w-3j85, which affects `< 0.6.0`. So the fix here is to not call the vulnerable code.

The download was dead weight anyway: `libonnxruntime_providers_cuda.so` alone is 219 MiB, and the `onnxruntime-node` binary folder goes from 263 MiB to 43 MiB without it.

### Known limitations

The alert won't close on its own. `adm-zip@0.6.0` stays in `package-lock.json`, and Dependabot reads the lockfile, not the execution path. I'm dismissing it as "vulnerable code is not actually used", which this change makes true.

## How to test

1. Run the install the way the Docker build does, on `linux/x64`:

```
docker run --rm --platform linux/amd64 -v "$PWD":/src:ro node:lts-slim sh -c '
  mkdir -p /t && cd /t && cp /src/package.json /src/package-lock.json /src/.npmrc /t/ &&
  npm ci --foreground-scripts 2>&1 | grep -Ei "downloading|extracting" || echo "no download"'
```

2. Check that it prints `no download` (on `main` it prints the `Downloading .../microsoft.ml.onnxruntime.gpu.linux.1.29.0.nupkg` line and three `Extracting` lines).
3. In the same container, confirm CPU inference still works: `InferenceSession.create(model, { executionProviders: ["cpu"] })` and run it. I checked this with a two-element `Add` model and got the right result back.

Note: `npx vitest run` fails on my machine with a missing `rolldown` native binding, on this branch and on `main` alike. It's a stale `node_modules` on my side, not something this PR touches.
