### PR TITLE
feat: keep the screen awake while a response is generating

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -155,6 +155,7 @@ Need to:
 - `client/hooks/useSearchHistory.ts` - Search history management from IndexedDB
 - `client/hooks/useHistoryRestore.ts` - Restores full search state from history
 - `client/hooks/useDrawerState.ts` - Drawer open/close state with logging
+- `client/hooks/useScreenWakeLock.ts` - Keeps the screen awake while a response is generating
 
 ## Common Tasks Quick Reference
 

--- a/client/components/AiResponse/AiResponseSection.tsx
+++ b/client/components/AiResponse/AiResponseSection.tsx
@@ -1,6 +1,7 @@
 import { CodeHighlightAdapterProvider } from "@mantine/code-highlight";
 import { usePubSub } from "create-pubsub/react";
 import { useMemo } from "react";
+import { useScreenWakeLock } from "@/hooks/useScreenWakeLock";
 import {
   chatMessagesPubSub,
   isRestoringFromHistoryPubSub,
@@ -12,12 +13,20 @@ import {
   textGenerationStatePubSub,
 } from "@/modules/pubSub";
 import { shikiAdapter } from "@/modules/shiki";
+import type { TextGenerationState } from "@/modules/types";
 import "@mantine/code-highlight/styles.css";
 import AiModelDownloadAllowanceContent from "./AiModelDownloadAllowanceContent";
 import AiResponseContent from "./AiResponseContent";
 import ChatInterface from "./ChatInterface";
 import LoadingModelContent from "./LoadingModelContent";
 import PreparingContent from "./PreparingContent";
+
+const statesKeepingTheScreenAwake: TextGenerationState[] = [
+  "loadingModel",
+  "awaitingSearchResults",
+  "preparingToGenerate",
+  "generating",
+];
 
 export default function AiResponseSection() {
   const [query] = usePubSub(queryPubSub);
@@ -30,6 +39,8 @@ export default function AiResponseSection() {
   const [modelSizeInMegabytes] = usePubSub(modelSizeInMegabytesPubSub);
   const [chatMessages] = usePubSub(chatMessagesPubSub);
   const [isRestoringFromHistory] = usePubSub(isRestoringFromHistoryPubSub);
+
+  useScreenWakeLock(statesKeepingTheScreenAwake.includes(textGenerationState));
 
   return useMemo(() => {
     if (!settings.enableAiResponse || textGenerationState === "idle") {

--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import throttle from "throttleit";
+import { useScreenWakeLock } from "@/hooks/useScreenWakeLock";
 import { persistChatMessages, runFollowUpSearch } from "@/modules/chatHelpers";
 import { generateFollowUpQuestion } from "@/modules/followUpQuestions";
 import { handleEnterKeyDown } from "@/modules/keyboard";
@@ -77,6 +78,8 @@ export default function ChatInterface({
     }, 1000 / 12),
     [],
   );
+
+  useScreenWakeLock(generationState.isGeneratingResponse);
 
   const regenerateFollowUpQuestion = useCallback(
     async (currentQuery: string, currentResponse: string) => {

--- a/client/hooks/useScreenWakeLock.test.ts
+++ b/client/hooks/useScreenWakeLock.test.ts
@@ -1,0 +1,250 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { addLogEntry } from "@/modules/logEntries";
+import { useScreenWakeLock } from "./useScreenWakeLock";
+
+vi.mock("@/modules/logEntries", () => ({ addLogEntry: vi.fn() }));
+
+class FakeSentinel extends EventTarget {
+  released = false;
+
+  release() {
+    this.released = true;
+    this.dispatchEvent(new Event("release"));
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Replaces the platform API with a fake. With `deferred`, requests stay pending
+ * until `resolveAll` runs, which is how the in-flight cases are reproduced.
+ */
+function stubWakeLockApi({ deferred = false } = {}) {
+  const sentinels: FakeSentinel[] = [];
+  const pendingResolvers: Array<() => void> = [];
+
+  const request = vi.fn(() => {
+    const sentinel = new FakeSentinel();
+    sentinels.push(sentinel);
+
+    if (!deferred) return Promise.resolve(sentinel);
+
+    return new Promise<FakeSentinel>((resolve) => {
+      pendingResolvers.push(() => resolve(sentinel));
+    });
+  });
+
+  Object.defineProperty(navigator, "wakeLock", {
+    value: { request },
+    configurable: true,
+  });
+
+  return {
+    request,
+    sentinels,
+    resolveAll: () => {
+      for (const resolve of pendingResolvers.splice(0)) resolve();
+    },
+  };
+}
+
+function stubVisibilityState(visibilityState: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    value: visibilityState,
+    configurable: true,
+  });
+}
+
+afterEach(async () => {
+  // Unmount before clearing the spies: the cleanup's release log resolves in a
+  // microtask, and React Testing Library's own cleanup runs after this hook.
+  cleanup();
+  await act(async () => {});
+
+  Reflect.deleteProperty(navigator, "wakeLock");
+  stubVisibilityState("visible");
+  vi.clearAllMocks();
+});
+
+describe("useScreenWakeLock", () => {
+  it("holds the lock while active and releases it once inactive", async () => {
+    const { request, sentinels } = stubWakeLockApi();
+
+    const { rerender } = renderHook(
+      ({ isActive }) => useScreenWakeLock(isActive),
+      { initialProps: { isActive: true } },
+    );
+
+    await waitFor(() => expect(request).toHaveBeenCalledWith("screen"));
+
+    expect(addLogEntry).toHaveBeenCalledWith("Screen wake lock acquired");
+
+    rerender({ isActive: false });
+
+    await waitFor(() => expect(sentinels[0].released).toBe(true));
+    await waitFor(() =>
+      expect(addLogEntry).toHaveBeenCalledWith("Screen wake lock released"),
+    );
+  });
+
+  it("does not request a lock while inactive", () => {
+    const { request } = stubWakeLockApi();
+
+    renderHook(() => useScreenWakeLock(false));
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("requests a fresh lock only after the platform released the previous one", async () => {
+    const { request, sentinels } = stubWakeLockApi();
+
+    renderHook(() => useScreenWakeLock(true));
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await sentinels[0].release();
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+  });
+
+  it("keeps a single lock when visibility changes while a request is in flight", async () => {
+    const { request, resolveAll } = stubWakeLockApi({ deferred: true });
+
+    renderHook(() => useScreenWakeLock(true));
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      resolveAll();
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a lock that arrives after the hook stopped needing it", async () => {
+    const { sentinels, resolveAll } = stubWakeLockApi({ deferred: true });
+
+    const { unmount } = renderHook(() => useScreenWakeLock(true));
+
+    unmount();
+
+    await act(async () => {
+      resolveAll();
+    });
+
+    await waitFor(() => expect(sentinels[0].released).toBe(true));
+  });
+
+  it("does not request a lock while the document is hidden", async () => {
+    const { request } = stubWakeLockApi();
+    stubVisibilityState("hidden");
+
+    renderHook(() => useScreenWakeLock(true));
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("retries instead of keeping a lock that arrives already released", async () => {
+    const { request, sentinels, resolveAll } = stubWakeLockApi({
+      deferred: true,
+    });
+
+    renderHook(() => useScreenWakeLock(true));
+
+    sentinels[0].released = true;
+
+    await act(async () => {
+      resolveAll();
+    });
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+  });
+
+  it("stops listening for visibility changes after cleanup", async () => {
+    const { request } = stubWakeLockApi();
+
+    const { unmount } = renderHook(() => useScreenWakeLock(true));
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a failed request and can still acquire a lock afterwards", async () => {
+    const request = vi
+      .fn<() => Promise<FakeSentinel>>()
+      .mockRejectedValueOnce(new Error("denied"))
+      .mockResolvedValueOnce(new FakeSentinel());
+
+    Object.defineProperty(navigator, "wakeLock", {
+      value: { request },
+      configurable: true,
+    });
+
+    renderHook(() => useScreenWakeLock(true));
+
+    await waitFor(() =>
+      expect(addLogEntry).toHaveBeenCalledWith(
+        "Screen wake lock unavailable: denied",
+      ),
+    );
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+  });
+
+  it("logs a release that fails during cleanup", async () => {
+    const sentinel = new FakeSentinel();
+    sentinel.release = () => Promise.reject("boom");
+
+    Object.defineProperty(navigator, "wakeLock", {
+      value: { request: vi.fn(() => Promise.resolve(sentinel)) },
+      configurable: true,
+    });
+
+    const { unmount } = renderHook(() => useScreenWakeLock(true));
+
+    await waitFor(() =>
+      expect(addLogEntry).toHaveBeenCalledWith("Screen wake lock acquired"),
+    );
+
+    unmount();
+
+    await waitFor(() =>
+      expect(addLogEntry).toHaveBeenCalledWith(
+        "Failed to release screen wake lock: unknown error",
+      ),
+    );
+  });
+
+  it("stays inert when the browser has no Screen Wake Lock API", () => {
+    expect(() => renderHook(() => useScreenWakeLock(true))).not.toThrow();
+    expect(addLogEntry).not.toHaveBeenCalled();
+  });
+});

--- a/client/hooks/useScreenWakeLock.ts
+++ b/client/hooks/useScreenWakeLock.ts
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+import { addLogEntry } from "@/modules/logEntries";
+
+const describeError = (error: unknown) =>
+  error instanceof Error ? error.message : "unknown error";
+
+/**
+ * Holds the platform screen wake lock while `isActive` is true, so a phone left
+ * untouched during a long answer does not lock while the text streams in.
+ *
+ * The platform releases the lock on its own whenever the document stops being
+ * visible (tab switch, screen lock) and a released sentinel cannot be reused,
+ * so a fresh one is requested on every return to visibility. A lock the browser
+ * drops for another reason (power saving, low battery) is only replaced on the
+ * next return to visibility, because re-requesting straight from the `release`
+ * event fights the browser's own decision. The same goes for a visibility round
+ * trip that happens entirely while a request is pending: the request in flight
+ * wins, and if it fails there is no event left to retry on until the next one.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API
+ */
+export function useScreenWakeLock(isActive: boolean) {
+  useEffect(() => {
+    if (!isActive || !("wakeLock" in navigator)) return;
+
+    let sentinel: WakeLockSentinel | null = null;
+    let isEffectActive = true;
+    let isRequestInFlight = false;
+
+    const acquireWakeLock = async () => {
+      if (
+        sentinel ||
+        isRequestInFlight ||
+        document.visibilityState !== "visible"
+      ) {
+        return;
+      }
+
+      isRequestInFlight = true;
+
+      try {
+        const requestedSentinel = await navigator.wakeLock.request("screen");
+
+        if (!isEffectActive) {
+          await requestedSentinel.release();
+          return;
+        }
+
+        if (requestedSentinel.released) return;
+
+        sentinel = requestedSentinel;
+        requestedSentinel.addEventListener("release", () => {
+          if (sentinel === requestedSentinel) sentinel = null;
+        });
+        addLogEntry("Screen wake lock acquired");
+      } catch (error) {
+        addLogEntry(`Screen wake lock unavailable: ${describeError(error)}`);
+      } finally {
+        isRequestInFlight = false;
+      }
+    };
+
+    acquireWakeLock();
+    document.addEventListener("visibilitychange", acquireWakeLock);
+
+    return () => {
+      isEffectActive = false;
+      document.removeEventListener("visibilitychange", acquireWakeLock);
+      sentinel
+        ?.release()
+        .then(() => addLogEntry("Screen wake lock released"))
+        .catch((error: unknown) => {
+          addLogEntry(
+            `Failed to release screen wake lock: ${describeError(error)}`,
+          );
+        });
+    };
+  }, [isActive]);
+}

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -403,6 +403,19 @@ const { isDrawerOpen, openDrawer, closeDrawer } = useDrawerState(
 );
 ```
 
+### useScreenWakeLock
+
+Holds the [Screen Wake Lock](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API)
+while the flag is true, so a phone left untouched during a long answer does not
+lock while the text streams in:
+```typescript
+useScreenWakeLock(statesKeepingTheScreenAwake.includes(textGenerationState));
+```
+
+The lock is requested by `AiResponseSection` for the initial answer and by
+`ChatInterface` for follow-up turns, and dropped as soon as generation ends.
+Browsers without the API get no lock and no error.
+
 ## Styling
 
 **Framework:** Mantine UI v9


### PR DESCRIPTION
## Description

Adds `useScreenWakeLock`, so the screen stays on while the AI response is being generated. Currently, on mobile, the phone locks after its usual timeout while the user is reading the text streaming in, because nothing counts as user activity during generation.

This uses the native [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) instead of a library like NoSleep.js (which plays a hidden looping video to get the same effect). The API has been [Baseline since March 2025](https://developer.mozilla.org/en-US/docs/Web/API/WakeLock) and covers Chrome/Edge 84+, Firefox 126+, Safari 16.4+ and iOS Safari 18.4+ ([caniuse](https://caniuse.com/mdn-api_wakelock)). Browsers without it get no lock and no error.

`AiResponseSection` holds the lock for the initial answer (states `loadingModel`, `awaitingSearchResults`, `preparingToGenerate` and `generating`), and `ChatInterface` holds it while a follow-up turn is being answered. Both release it as soon as generation ends. The two never overlap: `ChatInterface` only renders while `textGenerationState` is `completed`, which is not one of the states above.

The non-obvious part, documented in the hook: the platform releases the lock on its own whenever the document stops being visible, and a released `WakeLockSentinel` can't be reused, so the hook requests a new one on every return to visibility.

## Where to start

Most of the diff is the new hook (78 lines) and its tests (250). The wiring is 3 lines in `ChatInterface.tsx` and 11 in `AiResponseSection.tsx`, and the rest is docs (14).

Every guard and every log line in the hook has a test that fails when it is removed. I checked each by breaking it on purpose and running the file: the API-support guard, the hidden-document guard, the already-held guard, the in-flight request guard, the already-released guard, the release of a lock that arrives after the hook stopped needing it, the listener cleanup, the four log lines, the non-`Error` fallback in the message, and clearing the in-flight flag in the `finally` rather than only on the success path.

Three things left out on purpose:

- The lock drops when generation ends, so it doesn't cover reading a finished answer. Happy to add a grace period if you'd prefer that.
- No setting for it, since it only engages during active generation and only while the page is visible.
- `ChatInterface` watches `isGeneratingResponse` only, not `isGeneratingFollowUpQuestion`, because that flag can get stuck at `true` (#2581) and would then hold the screen on for the rest of the reading session. Once #2581 is fixed, adding it here is a one-line change.

## How to test

1. Run `docker compose exec development-server npm test` (11 new tests in `client/hooks/useScreenWakeLock.test.ts`). Without a running dev server, `docker compose run --rm --no-deps development-server npm test` does the same.
2. Start the dev server with `BASIC_SSL=true` and open it on a phone (the API needs a secure context).
3. Run a search with a slow model, don't touch the screen, and check that the screen stays on while the answer streams in.
4. Open the Logs modal and check for `Screen wake lock acquired`, then `Screen wake lock released` when the answer finishes.

Note: I only ran step 1 (751 tests pass, plus `npm run lint`). Steps 2 to 4 need a real device, so the screen actually staying on is still unverified.
