### PR TITLE
fix: give each chat generation flag a single owner

### DIFF
--- a/client/components/AiResponse/ChatInterface.test.tsx
+++ b/client/components/AiResponse/ChatInterface.test.tsx
@@ -1,0 +1,400 @@
+import { MantineProvider } from "@mantine/core";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  chatGenerationStatePubSub,
+  chatInputPubSub,
+  followUpQuestionPubSub,
+  suppressNextFollowUpPubSub,
+} from "@/modules/pubSub";
+import type { ChatMessage } from "@/modules/types";
+import ChatInterface from "./ChatInterface";
+
+const [updateChatGenerationState, , getChatGenerationState] =
+  chatGenerationStatePubSub;
+const [updateChatInput] = chatInputPubSub;
+const [updateFollowUpQuestion] = followUpQuestionPubSub;
+const [updateSuppressNextFollowUp] = suppressNextFollowUpPubSub;
+
+vi.mock("@/modules/textGeneration", () => ({
+  generateChatResponse: vi.fn(),
+}));
+
+vi.mock("@/modules/followUpQuestions", () => ({
+  generateFollowUpQuestion: vi.fn(),
+}));
+
+vi.mock("@/modules/chatHelpers", () => ({
+  persistChatMessages: vi.fn(() => Promise.resolve()),
+  runFollowUpSearch: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/modules/notifications", () => ({
+  showAiCompleteNotification: vi.fn(),
+}));
+
+vi.mock("@/modules/logEntries", () => ({ addLogEntry: vi.fn() }));
+
+vi.mock("./ChatHeader", () => ({ default: () => null }));
+
+let sendMessage: (textToSend?: string) => Promise<void>;
+let regenerateResponse: () => Promise<void>;
+let messageListMessages: ChatMessage[] = [];
+let messageListIsGenerating = false;
+
+vi.mock("./ChatInputArea", () => ({
+  default: (props: { handleSend: (textToSend?: string) => Promise<void> }) => {
+    sendMessage = props.handleSend;
+    return null;
+  },
+}));
+
+vi.mock("./MessageList", () => ({
+  default: (props: {
+    messages: ChatMessage[];
+    isGenerating: boolean;
+    onRegenerate: () => Promise<void>;
+  }) => {
+    regenerateResponse = props.onRegenerate;
+    messageListMessages = props.messages;
+    messageListIsGenerating = props.isGenerating;
+    return null;
+  },
+}));
+
+const { generateChatResponse } = await import("@/modules/textGeneration");
+const { generateFollowUpQuestion } = await import(
+  "@/modules/followUpQuestions"
+);
+
+/** A promise plus the handle to settle it, so a test can hold a call open. */
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason: Error) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const initialQuery = "What is a wake lock?";
+const initialResponse = "An API that keeps the screen on.";
+
+function renderChatInterface({ suppressInitialFollowUp = true } = {}) {
+  return render(
+    <MantineProvider>
+      <ChatInterface
+        initialQuery={initialQuery}
+        initialResponse={initialResponse}
+        suppressInitialFollowUp={suppressInitialFollowUp}
+      />
+    </MantineProvider>,
+  );
+}
+
+function stubWakeLockApi() {
+  const release = vi.fn(() => Promise.resolve());
+  const request = vi.fn(() =>
+    Promise.resolve({ released: false, release, addEventListener: vi.fn() }),
+  );
+
+  Object.defineProperty(navigator, "wakeLock", {
+    value: { request },
+    configurable: true,
+  });
+
+  return { request, release };
+}
+
+beforeEach(() => {
+  updateChatGenerationState({
+    isGeneratingResponse: false,
+    isGeneratingFollowUpQuestion: false,
+  });
+  updateChatInput("");
+  updateFollowUpQuestion("");
+  updateSuppressNextFollowUp(false);
+  messageListMessages = [];
+  messageListIsGenerating = false;
+  vi.mocked(generateChatResponse).mockResolvedValue("An answer.");
+  vi.mocked(generateFollowUpQuestion).mockResolvedValue("A question?");
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, "wakeLock");
+  vi.resetAllMocks();
+});
+
+describe("ChatInterface generation state", () => {
+  it("leaves the follow-up question flag off after sending during its generation", async () => {
+    const earlierQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      earlierQuestion.promise,
+    );
+
+    renderChatInterface({ suppressInitialFollowUp: false });
+
+    await act(async () => {});
+
+    expect(getChatGenerationState().isGeneratingFollowUpQuestion).toBe(true);
+
+    await act(async () => {
+      await sendMessage("And how do I use it?");
+    });
+
+    expect(getChatGenerationState().isGeneratingFollowUpQuestion).toBe(false);
+
+    await act(async () => {
+      earlierQuestion.resolve("An earlier question?");
+    });
+  });
+
+  it("keeps the response flag on when an earlier follow-up question completes mid-response", async () => {
+    const followUpQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      followUpQuestion.promise,
+    );
+    const chatResponse = deferred<string>();
+    vi.mocked(generateChatResponse).mockReturnValueOnce(chatResponse.promise);
+
+    renderChatInterface({ suppressInitialFollowUp: false });
+
+    await act(async () => {});
+
+    expect(getChatGenerationState().isGeneratingFollowUpQuestion).toBe(true);
+
+    let send: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      send = sendMessage("And how do I use it?");
+    });
+
+    expect(getChatGenerationState().isGeneratingResponse).toBe(true);
+
+    await act(async () => {
+      followUpQuestion.resolve("An earlier question?");
+    });
+
+    expect(getChatGenerationState().isGeneratingResponse).toBe(true);
+
+    await act(async () => {
+      chatResponse.resolve("An answer.");
+      await send;
+    });
+  });
+
+  it("leaves a concurrent follow-up question flag alone when the response fails", async () => {
+    const followUpQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      followUpQuestion.promise,
+    );
+    vi.mocked(generateChatResponse).mockRejectedValueOnce(
+      new Error("no model"),
+    );
+
+    renderChatInterface({ suppressInitialFollowUp: false });
+
+    await act(async () => {});
+
+    await act(async () => {
+      await sendMessage("And how do I use it?");
+    });
+
+    expect(getChatGenerationState()).toEqual({
+      isGeneratingResponse: false,
+      isGeneratingFollowUpQuestion: true,
+    });
+
+    await act(async () => {
+      followUpQuestion.resolve("An earlier question?");
+    });
+  });
+
+  it("starts one generation when two sends land in the same task", async () => {
+    renderChatInterface();
+
+    await act(async () => {
+      await Promise.all([
+        sendMessage("And how do I use it?"),
+        sendMessage("Does it work offline?"),
+      ]);
+    });
+
+    expect(generateChatResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a send while the follow-up question is still being generated", async () => {
+    const followUpQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      followUpQuestion.promise,
+    );
+    // Streams the answer, so the placeholder row holds it the way it does in
+    // the app and a leftover copy would be visible.
+    vi.mocked(generateChatResponse).mockImplementationOnce(
+      async (_messages, onUpdate) => {
+        onUpdate("An answer.");
+        return "An answer.";
+      },
+    );
+
+    renderChatInterface();
+
+    let send: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      send = sendMessage("And how do I use it?");
+    });
+
+    expect(getChatGenerationState()).toEqual({
+      isGeneratingResponse: false,
+      isGeneratingFollowUpQuestion: true,
+    });
+
+    // The input stays enabled through this window, so the guard has to accept
+    // the send rather than refuse it silently, and the streamed placeholder
+    // must not leave a second copy of the answer in the list.
+    expect(messageListIsGenerating).toBe(false);
+    expect(
+      messageListMessages.filter((message) => message.content === "An answer."),
+    ).toHaveLength(1);
+
+    await act(async () => {
+      await sendMessage("Does it work offline?");
+    });
+
+    expect(generateChatResponse).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      followUpQuestion.resolve("An earlier question?");
+      await send;
+    });
+  });
+
+  it("regenerates without clobbering a follow-up question in flight", async () => {
+    const followUpQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      followUpQuestion.promise,
+    );
+    const regeneratedQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      regeneratedQuestion.promise,
+    );
+    const chatResponse = deferred<string>();
+    vi.mocked(generateChatResponse)
+      .mockResolvedValueOnce("An answer.")
+      .mockReturnValueOnce(chatResponse.promise);
+
+    renderChatInterface();
+
+    let send: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      send = sendMessage("And how do I use it?");
+    });
+
+    let regenerate: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      regenerate = regenerateResponse();
+    });
+
+    expect(getChatGenerationState().isGeneratingResponse).toBe(true);
+    expect(getChatGenerationState().isGeneratingFollowUpQuestion).toBe(true);
+
+    await act(async () => {
+      followUpQuestion.resolve("An earlier question?");
+    });
+
+    expect(getChatGenerationState().isGeneratingResponse).toBe(true);
+
+    await act(async () => {
+      chatResponse.resolve("A regenerated answer.");
+    });
+
+    // The regenerate hands the lock over the way the send does: it must not
+    // stay in the response phase while its own question is still coming.
+    expect(getChatGenerationState()).toEqual({
+      isGeneratingResponse: false,
+      isGeneratingFollowUpQuestion: true,
+    });
+
+    await act(async () => {
+      regeneratedQuestion.resolve("A later question?");
+      await Promise.all([send, regenerate]);
+    });
+  });
+
+  it("starts one re-generation when two regenerates land in the same task", async () => {
+    renderChatInterface();
+
+    await act(async () => {
+      await sendMessage("And how do I use it?");
+    });
+
+    await act(async () => {
+      await Promise.all([regenerateResponse(), regenerateResponse()]);
+    });
+
+    expect(generateChatResponse).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the response flag on when a follow-up question fails mid-response", async () => {
+    const earlierQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      earlierQuestion.promise,
+    );
+    const chatResponse = deferred<string>();
+    vi.mocked(generateChatResponse).mockReturnValueOnce(chatResponse.promise);
+
+    renderChatInterface({ suppressInitialFollowUp: false });
+
+    await act(async () => {});
+
+    let send: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      send = sendMessage("And how do I use it?");
+    });
+
+    await act(async () => {
+      earlierQuestion.reject(new Error("no model"));
+    });
+
+    expect(getChatGenerationState()).toEqual({
+      isGeneratingResponse: true,
+      isGeneratingFollowUpQuestion: false,
+    });
+
+    await act(async () => {
+      chatResponse.resolve("An answer.");
+      await send;
+    });
+  });
+
+  it("holds the screen wake lock from the response through the follow-up question", async () => {
+    const { request, release } = stubWakeLockApi();
+    const followUpQuestion = deferred<string>();
+    vi.mocked(generateFollowUpQuestion).mockReturnValueOnce(
+      followUpQuestion.promise,
+    );
+
+    renderChatInterface();
+
+    let send: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      send = sendMessage("And how do I use it?");
+    });
+
+    expect(request).toHaveBeenCalledExactlyOnceWith("screen");
+    expect(release).not.toHaveBeenCalled();
+
+    await act(async () => {
+      followUpQuestion.resolve("An earlier question?");
+      await send;
+    });
+
+    expect(release).toHaveBeenCalled();
+  });
+});

--- a/client/components/AiResponse/ChatInterface.tsx
+++ b/client/components/AiResponse/ChatInterface.tsx
@@ -18,6 +18,7 @@ import {
   chatGenerationStatePubSub,
   chatInputPubSub,
   followUpQuestionPubSub,
+  getChatGenerationState,
   imageSearchResultsPubSub,
   queryPubSub,
   settingsPubSub,
@@ -79,7 +80,10 @@ export default function ChatInterface({
     [],
   );
 
-  useScreenWakeLock(generationState.isGeneratingResponse);
+  useScreenWakeLock(
+    generationState.isGeneratingResponse ||
+      generationState.isGeneratingFollowUpQuestion,
+  );
 
   const regenerateFollowUpQuestion = useCallback(
     async (currentQuery: string, currentResponse: string) => {
@@ -88,7 +92,7 @@ export default function ChatInterface({
 
       try {
         setGenerationState({
-          isGeneratingResponse: false,
+          ...getChatGenerationState(),
           isGeneratingFollowUpQuestion: true,
         });
 
@@ -103,13 +107,13 @@ export default function ChatInterface({
         );
         setFollowUpQuestion(newQuestion);
         setGenerationState({
-          isGeneratingResponse: false,
+          ...getChatGenerationState(),
           isGeneratingFollowUpQuestion: false,
         });
       } catch (_) {
         setFollowUpQuestion("");
         setGenerationState({
-          isGeneratingResponse: false,
+          ...getChatGenerationState(),
           isGeneratingFollowUpQuestion: false,
         });
       }
@@ -205,7 +209,7 @@ export default function ChatInterface({
 
   const handleRegenerateResponse = useCallback(async () => {
     if (
-      generationState.isGeneratingResponse ||
+      getChatGenerationState().isGeneratingResponse ||
       messages.length < 3 ||
       messages[messages.length - 1].role !== "assistant"
     )
@@ -215,7 +219,10 @@ export default function ChatInterface({
     const lastUser = history[history.length - 1];
 
     setMessages(history);
-    setGenerationState({ ...generationState, isGeneratingResponse: true });
+    setGenerationState({
+      ...getChatGenerationState(),
+      isGeneratingResponse: true,
+    });
     setFollowUpQuestion("");
     setStreamedResponse("");
 
@@ -236,15 +243,20 @@ export default function ChatInterface({
         if (settings.enableNotificationOnAiComplete) {
           showAiCompleteNotification(lastUser.content);
         }
-        await regenerateFollowUpQuestion(lastUser.content, finalResponse);
+        // Not awaited: the follow-up question raises its own flag
+        // synchronously, so the `finally` below can hand the wake lock over
+        // and release the response flag while that question is still coming.
+        regenerateFollowUpQuestion(lastUser.content, finalResponse);
       }
     } catch (error) {
       addLogEntry(`Error re-generating response: ${error}`);
     } finally {
-      setGenerationState({ ...generationState, isGeneratingResponse: false });
+      setGenerationState({
+        ...getChatGenerationState(),
+        isGeneratingResponse: false,
+      });
     }
   }, [
-    generationState,
     messages,
     regenerateFollowUpQuestion,
     settings,
@@ -256,8 +268,12 @@ export default function ChatInterface({
   const handleSend = useCallback(
     async (textToSend?: string) => {
       const currentInput = textToSend ?? input;
-      if (currentInput.trim() === "" || generationState.isGeneratingResponse)
+      if (
+        currentInput.trim() === "" ||
+        getChatGenerationState().isGeneratingResponse
+      ) {
         return;
+      }
 
       const userMessage: ChatMessage = { role: "user", content: currentInput };
       const newMessages: ChatMessage[] = [...messages, userMessage];
@@ -265,7 +281,7 @@ export default function ChatInterface({
       setMessages(newMessages);
       if (!textToSend) setInput("");
       setGenerationState({
-        ...generationState,
+        ...getChatGenerationState(),
         isGeneratingResponse: true,
       });
       setFollowUpQuestion("");
@@ -302,7 +318,7 @@ export default function ChatInterface({
 
         await persistChatMessages(currentQuery, currentInput, finalResponse);
 
-        await regenerateFollowUpQuestion(currentInput, finalResponse);
+        regenerateFollowUpQuestion(currentInput, finalResponse);
       } catch (error) {
         addLogEntry(`Error in chat response: ${error}`);
         setMessages((prevMessages) => [
@@ -315,13 +331,12 @@ export default function ChatInterface({
         ]);
       } finally {
         setGenerationState({
-          ...generationState,
+          ...getChatGenerationState(),
           isGeneratingResponse: false,
         });
       }
     },
     [
-      generationState,
       messages,
       settings,
       input,

--- a/client/modules/pubSub.ts
+++ b/client/modules/pubSub.ts
@@ -183,6 +183,8 @@ export const chatGenerationStatePubSub = createPubSub({
   isGeneratingFollowUpQuestion: false,
 });
 
+export const [, , getChatGenerationState] = chatGenerationStatePubSub;
+
 export const followUpQuestionPubSub = createPubSub("");
 
 export const [updateFollowUpQuestion] = followUpQuestionPubSub;

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -83,7 +83,7 @@ All state channels are defined in `client/modules/pubSub.ts`:
 | `modelSizeInMegabytesPubSub` | `number` | Model size in MB for progress calc | AiResponseSection |
 | `chatMessagesPubSub` | `ChatMessage[]` | Chat conversation | ChatInterface |
 | `chatInputPubSub` | `string` | Current chat input content | ChatInputArea |
-| `chatGenerationStatePubSub` | `{isGeneratingResponse, isGeneratingFollowUpQuestion}` | Chat generation states | ChatInterface |
+| `chatGenerationStatePubSub` | `{isGeneratingResponse, isGeneratingFollowUpQuestion}` | Chat generation states. Each flag has one owner: the send and regenerate handlers write `isGeneratingResponse`, `regenerateFollowUpQuestion` writes `isGeneratingFollowUpQuestion`, and every writer merges `getChatGenerationState()` so a concurrent flow is not clobbered | ChatInterface |
 | `conversationSummaryPubSub` | `{id, summary}` | Rolling conversation summary | TextGeneration module |
 | `followUpQuestionPubSub` | `string` | Generated follow-up question | AiResponseSection |
 | `suppressNextFollowUpPubSub` | `boolean` | Flag to skip next follow-up | FollowUpQuestions module |
@@ -413,8 +413,9 @@ useScreenWakeLock(statesKeepingTheScreenAwake.includes(textGenerationState));
 ```
 
 The lock is requested by `AiResponseSection` for the initial answer and by
-`ChatInterface` for follow-up turns, and dropped as soon as generation ends.
-Browsers without the API get no lock and no error.
+`ChatInterface` for follow-up turns and for the follow-up question that follows
+them, and dropped as soon as generation ends. Browsers without the API get no
+lock and no error.
 
 ## Styling
 


### PR DESCRIPTION
## Description

Fixes #2581. Currently, `handleSend` and `handleRegenerateResponse` spread a `generationState` captured at click time, so the value they write in their `finally` can resurrect a flag that the awaited work already cleared. Send a message while the suggested follow-up question is still being generated and `isGeneratingFollowUpQuestion` stays `true` for the rest of the session.

The same stale value drove the re-entry guard at the head of both handlers, so two sends landing in the same task both saw `isGeneratingResponse: false` and started two generations. And `regenerateFollowUpQuestion` wrote the whole object, so an initial follow-up question finishing during a response cleared `isGeneratingResponse` mid-stream.

Every writer now merges `getChatGenerationState()` and sets only the flag it owns: the two handlers own `isGeneratingResponse`, `regenerateFollowUpQuestion` owns `isGeneratingFollowUpQuestion`. `create-pubsub` publishes synchronously, so the getter always returns the value the previous write just stored.

Both handlers also stop awaiting `regenerateFollowUpQuestion`. It raises its own flag synchronously, so the `finally` can hand the wake lock over and drop `isGeneratingResponse` while the question is still coming. Keeping the `await` would have stretched the response flag across the follow-up window, which enables the input while the send guard still refuses (a silent no-op) and leaves the streamed placeholder duplicating the answer in `MessageList` under a colliding React key.

With no writer clobbering the other, the screen wake lock can watch the follow-up question again, which is the one-liner #2580 deferred:

```ts
useScreenWakeLock(
  generationState.isGeneratingResponse ||
    generationState.isGeneratingFollowUpQuestion,
);
```

## Where to start

`ChatInterface.tsx` carries the behavior: 7 writes, 2 guards and the 2 dropped `await`s, none of which touch what the component renders. The 2 lines in `pubSub.ts` export the getter, following the `getConversationSummary` precedent right below it, and `docs/ui-components.md` is where the ownership rule is written down.

Most of the diff is `ChatInterface.test.tsx` (400 lines), the first test harness for this component. It mocks five modules plus the three child components, and drives the flow through the `handleSend` and `onRegenerate` those children receive. Deferred promises hold a generation open so the interleavings are reproducible rather than timing-dependent.

I checked the tests against `main` and against five ways of getting this change half-right, because "it fails on `main`" alone would not have caught the regressions above:

| Version under test | Tests that fail |
| --- | --- |
| `main` | 5 of 9 |
| Awaiting the follow-up question again, send path | 2 |
| Awaiting it again, regenerate path | 1 |
| Send's `finally` owning both flags | 4 |
| Follow-up question's `catch` owning both flags | 1 |
| Regenerate guard reading the captured value | 2 |

Deferred to #2583: `regenerateFollowUpQuestion` has no re-entry guard of its own, so two overlapping invocations still race on the flag and on the question text. It needs a slow follow-up call to reach, and an invocation token fixes both at once.

## How to test

1. Run `docker compose exec development-server npm test` (9 new tests in `client/components/AiResponse/ChatInterface.test.tsx`). Without a running dev server, `docker compose run --rm --no-deps development-server npm test` does the same.
2. Ask something, and while the suggested follow-up question is still loading, send another message. It should be accepted. On `main` the stuck flag means the textarea never disables and the send button never shows its loading state again for the rest of the session, so a send during generation looks available and is silently ignored.
3. On a phone, check the Logs modal shows the wake lock held across the answer and the follow-up question. Follow-up turns log one acquire and one release each; the first turn logs two pairs, because the answer and its question are held by different components.

Note: I ran step 1 (760 tests pass, plus `npm run lint`). Steps 2 and 3 are the manual checks I could not run here, and step 3 needs a real device.
