### PR TITLE
Update create-pubsub to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@wllama/wllama": "^3.6.0",
         "ai": "^7.0.0",
         "country-flag-icons": "^1.5.13",
-        "create-pubsub": "^1.6.3",
+        "create-pubsub": "^1.7.0",
         "debug": "^4.4.0",
         "dexie": "^4.0.11",
         "dotenv": "^17.0.0",
@@ -3257,10 +3257,22 @@
       "license": "MIT"
     },
     "node_modules/create-pubsub": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/create-pubsub/-/create-pubsub-1.6.3.tgz",
-      "integrity": "sha512-Usd90HBbaYY5Jrfv90WVnIJcQrBcbxGtGIW6PsFPfsk743jqsLHAzBn3ggSrtjzRt0+RRkOeA02DqSb67iytUw==",
-      "license": "MIT"
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/create-pubsub/-/create-pubsub-1.7.0.tgz",
+      "integrity": "sha512-+nEjTl7J03J7RTGWwQZ/0bAJBdCXn/8f5aFHp+ibBSB+LMdhQ1yq7Qt8TRGopw++6w9yts6yDyZT2aLfsieQBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "immer": ">=9",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@wllama/wllama": "^3.6.0",
     "ai": "^7.0.0",
     "country-flag-icons": "^1.5.13",
-    "create-pubsub": "^1.6.3",
+    "create-pubsub": "^1.7.0",
     "debug": "^4.4.0",
     "dexie": "^4.0.11",
     "dotenv": "^17.0.0",


### PR DESCRIPTION
## Description

Updates `create-pubsub` from 1.6.3 to 1.7.0.

The fix that matters for us is in `unsubscribe`. In 1.6.3 each subscription kept a reference to the node that preceded it at subscribe time, so unsubscribing a subscriber and then one that was registered after it left the second one still receiving events. 1.7.0 walks the list to find the real predecessor, so the removal is correct in any order. Every `usePubSub` in the app unsubscribes on unmount, so any tree where components unmount in registration order (the drawers, the results sections) could keep stale subscribers alive.

The rest of the release is packaging: the types are now emitted by `tsc` instead of bundled by hand, and `react` and `immer` became optional peer dependencies (we're on React 19, and `immer` is not installed, which is fine because it's optional).

### Note on the release age

Our `.npmrc` sets `min-release-age = 3`, and 1.7.0 was published today, so `npm install` refuses to resolve it. The install was run with `--min-release-age=0`. `npm ci` and `docker compose up` both install 1.7.0 from the lockfile without complaining, so CI is not affected.

## How to test

1. `docker compose exec development-server npm run lint`
2. `docker compose exec development-server npm run test`
3. `docker compose up`, open http://localhost:7860, run a search and check that both the text results and the image carousel render.
4. Open and close the Menu and History drawers a few times, then run a second search, to confirm the state still reaches the components after subscribers have been mounted and unmounted.

The unsubscribe fix itself is easier to see outside the app:

```js
const [publish, subscribe] = createPubSub(0);
const calls = [];
const unsubA = subscribe(() => calls.push("A"));
const unsubB = subscribe(() => calls.push("B"));
subscribe(() => calls.push("C"));
unsubA();
unsubB();
publish(1);
// 1.6.3 => ["B", "C"]
// 1.7.0 => ["C"]
```
