### PR TITLE
Update create-pubsub to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@wllama/wllama": "^3.6.0",
         "ai": "^7.0.0",
         "country-flag-icons": "^1.5.13",
-        "create-pubsub": "^1.7.0",
+        "create-pubsub": "^2.0.0",
         "debug": "^4.4.0",
         "dexie": "^4.0.11",
         "dotenv": "^17.0.0",
@@ -82,7 +82,7 @@
         "zod": "^4.3.6"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3257,13 +3257,16 @@
       "license": "MIT"
     },
     "node_modules/create-pubsub": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/create-pubsub/-/create-pubsub-1.7.0.tgz",
-      "integrity": "sha512-+nEjTl7J03J7RTGWwQZ/0bAJBdCXn/8f5aFHp+ibBSB+LMdhQ1yq7Qt8TRGopw++6w9yts6yDyZT2aLfsieQBQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/create-pubsub/-/create-pubsub-2.0.0.tgz",
+      "integrity": "sha512-O8n2Sjjrpx4E10HODiMHilJhKs1QE/7pFRbwnBi7GbW6ra2/nLQNB5cqhJ3LowuPAvjpppXEw4FrHkbehI8meA==",
       "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
       "peerDependencies": {
         "immer": ">=9",
-        "react": ">=16.8"
+        "react": ">=18"
       },
       "peerDependenciesMeta": {
         "immer": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://felladrin-minisearch.hf.space",
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12"
   },
   "scripts": {
     "start": "vite preview",
@@ -46,7 +46,7 @@
     "@wllama/wllama": "^3.6.0",
     "ai": "^7.0.0",
     "country-flag-icons": "^1.5.13",
-    "create-pubsub": "^1.7.0",
+    "create-pubsub": "^2.0.0",
     "debug": "^4.4.0",
     "dexie": "^4.0.11",
     "dotenv": "^17.0.0",


### PR DESCRIPTION
## Description

Updates `create-pubsub` from 1.7.0 to 2.0.0, and raises our Node floor from `>=22` to `>=22.12` to match what the new version requires.

Two breaking changes in 2.0.0, and neither one reaches us:

- `usePubSub` is now built on `useSyncExternalStore`, so it needs React 18 or newer. We're on React 19. The old hook subscribed inside `useEffect`, which left a window between the first render and the effect where a published value was missed, and could tear under concurrent rendering.
- The package is ESM-only now, with no CommonJS or UMD build. All three of our tsconfigs use `moduleResolution: "bundler"`, the app is `"type": "module"`, and `create-pubsub` is imported only from client code, never from `server/`, `shared/` or `eval/`.

### Why the engines change belongs here

2.0.0 declares `engines: { node: "^20.19.0 || >=22.12.0" }`. Our `>=22` was looser than that, so Node 22.0 through 22.11 satisfied us but not our dependency. Nobody hits it today (the container runs Node 24, CI runs `lts/*` and `current`, and `.nvmrc` is `lts/*`), and npm only warns because we don't set `engine-strict`. Still, the floor should not be looser than the dependency's, and this is the version bump that introduced the gap.

### Note on the release age

Our `.npmrc` sets `min-release-age = 3` and 2.0.0 was published today, so the install was run with `--min-release-age=0`. `npm ci` and `docker compose up` both install it from the lockfile without complaining, so CI is not affected.

## How to test

1. `docker compose exec development-server npm run lint`
2. `docker compose exec development-server npm run test`
3. `docker compose exec development-server npm run build`
4. `docker compose up`, open http://localhost:7860, run a search and check that the text results and the image carousel both render.
5. Open and close the Menu and History drawers a few times, run a second search, then restore the first search from the History drawer.

Step 5 is the one worth doing. Every `usePubSub` subscribes on mount and unsubscribes on unmount, so the hook rewrite shows up when components come and go, not on a first page load. The other thing to watch is the browser console: `useSyncExternalStore` logs a "The result of getSnapshot should be cached" warning if the getter returns a fresh value on every call, and `getStoredData` returns the stored reference, so it stays quiet.

I also ran step 4 against the production bundle (`npm run build` then `npm run start`), because the dev server serves the dependency through Vite's dependency optimizer while the build inlines it, and a module-format change can pass one and fail the other. Both are clean.
